### PR TITLE
Adding vehicle reequipping and reworked equipping script

### DIFF
--- a/objects/obj_controller/Mouse_50.gml
+++ b/objects/obj_controller/Mouse_50.gml
@@ -13,15 +13,15 @@ if (menu=11) and (cooldown<=0){
     if (gene_seed>0) and (obj_ini.zygote=0) and (mouse_x>=xx+407) and (mouse_y>=yy+788) and (mouse_x<xx+529) and (mouse_y<yy+811){
         var i,g;i=0;g=0;repeat(120){i+=1;if (g=0){if (obj_ini.slave_batch_eta[i]=120) then g=i;}}
         if (g=0){i=0;repeat(120){i+=1;if (g=0){if (obj_ini.slave_batch_num[i]=0) then g=i;}}}
-        
+
         var carpal;carpal=1;
         if (obj_ini.slave_batch_num[g]>=10) and (obj_ini.slave_batch_num[g]<50) then carpal=2;
         if (obj_ini.slave_batch_num[g]>=50) then carpal=5;if (obj_ini.slave_batch_num[g]>=150) then carpal=10;
         if (obj_controller.gene_seed<carpal) then carpal=obj_controller.gene_seed;
-        
+
         obj_controller.gene_seed-=carpal;obj_ini.slave_batch_num[g]+=carpal;obj_ini.slave_batch_eta[g]=120;
-        
-        
+
+
         // cooldown=8000;
         cooldown=10;
     }
@@ -50,7 +50,7 @@ if (menu=12) and (cooldown<=0) and (penitorium>0){
                     if (obj_ini.age[c,e]<=((obj_controller.millenium*1000)+obj_controller.year)-10) and (obj_ini.zygote=0) and (string_count("Doom",obj_ini.strin2)=0) then obj_controller.gene_seed+=1;
                     if (obj_ini.age[c,e]<=((obj_controller.millenium*1000)+obj_controller.year)-5) and (string_count("Doom",obj_ini.strin2)=0) then obj_controller.gene_seed+=1;
                 }
-                
+
                 var tek;tek="";
                 if (obj_ini.race[c,e]=1){
                     tek=obj_ini.wep1[c,e];if (tek!="") then scr_add_item(tek,1);
@@ -59,7 +59,7 @@ if (menu=12) and (cooldown<=0) and (penitorium>0){
                     tek=obj_ini.mobi[c,e];if (tek!="") then scr_add_item(tek,1);
                     tek=obj_ini.gear[c,e];if (tek!="") then scr_add_item(tek,1);
                 }
-                
+
                 tek="";
                 if (obj_ini.race[c,e]=1) then tek="m";
                 if (obj_ini.role[c,e]="Captain") then tek="c";
@@ -76,11 +76,11 @@ if (menu=12) and (cooldown<=0) and (penitorium>0){
                 if (obj_ini.role[c,e]="Master of the Apothecarion") then tek="c";
                 if (obj_ini.role[c,e]="Forge Master") then tek="c";
                 if (obj_ini.role[c,e]="Chapter Master"){tek="c";obj_controller.alarm[7]=5;global.defeat=3;}
-                
+
                 // Needs to be based on role
                 if (tek="m") then obj_controller.marines-=1;
                 if (tek="c") then obj_controller.command-=1;
-                
+
                 obj_ini.race[c,e]=0;obj_ini.loc[c,e]="";obj_ini.name[c,e]="";obj_ini.role[c,e]="";obj_ini.wep1[c,e]="";obj_ini.lid[c,e]=0;
                 obj_ini.wep2[c,e]="";obj_ini.armor[c,e]="";obj_ini.gear[c,e]="";obj_ini.hp[c,e]=100;obj_ini.chaos[c,e]=0;obj_ini.experience[c,e]=0;
                 obj_ini.mobi[c,e]="";obj_ini.age[c,e]=0;obj_ini.spe[c,e]="";obj_ini.god[c,e]=0;
@@ -97,7 +97,7 @@ if (menu=12) and (cooldown<=0) and (penitorium>0){
         repeat(100){g+=1;
             penit_co[g]=0;penit_id[g]=0;
         }
-        
+
         penitorium=0;
         var c,e,p;c=-1;e=0;p=0;
         repeat(11){
@@ -139,8 +139,8 @@ if (menu=13) and (cooldown<=0) and (artifacts>0){
             audio_sound_gain(snd_identify,master_volume*effect_volume,0);
         }
     }
-    
-    
+
+
     if (obj_ini.artifact_identified[menu_artifact]=0){
         if (mouse_x>=xx+354) and (mouse_y>=yy+789) and (mouse_x<xx+448) and (mouse_y<yy+804) and (cooldown<=0){// Equip
             var hue;hue=1;
@@ -168,13 +168,13 @@ if (menu=13) and (cooldown<=0) and (artifacts>0){
             var fun;fun=floor(random(100))+1;
             // Below here cleans up the artifacts
             var i;i=menu_artifact;
-            
+
             if (menu_artifact=fest_display) then fest_display=0;
-            
+
             if (string_count("Daemon",obj_ini.artifact_tags[i])>0){
                 if (obj_ini.artifact_sid[i]>=500){
                     var oops;oops=floor(random(100))+1;
-                    
+
                     if (oops<=60) and (obj_ini.ship_carrying[obj_ini.artifact_sid[i]-500]>0){
                         instance_create(0,0,obj_ncombat);
                         obj_ncombat.battle_special="ship_demon";obj_ncombat.formation_set=1;
@@ -183,8 +183,8 @@ if (menu=13) and (cooldown<=0) and (artifacts>0){
                     }
                 }
             }
-            
-            
+
+
             var e;e=0;
             repeat(500){e+=1;
                 if (obj_ini.artifact_tags[i]=obj_controller.recent_keyword[e]){
@@ -194,13 +194,13 @@ if (menu=13) and (cooldown<=0) and (artifacts>0){
                     scr_recent("","",0);
                 }
             }
-            
+
             obj_ini.artifact[i]="";obj_ini.artifact_tags[i]="";
             obj_ini.artifact_identified[i]=0;obj_ini.artifact_condition[i]=100;
             obj_ini.artifact_loc[i]="";obj_ini.artifact_sid[i]=0;
             artifacts-=1;cooldown=12;
             if (menu_artifact>artifacts) then menu_artifact=artifacts;
-            
+
             repeat(20){
                 obj_ini.artifact[i]=obj_ini.artifact[i+1];obj_ini.artifact_tags[i]=obj_ini.artifact_tags[i+1];
                 obj_ini.artifact_identified[i]=obj_ini.artifact_identified[i+1];
@@ -210,8 +210,8 @@ if (menu=13) and (cooldown<=0) and (artifacts>0){
             }
         }
     }
-    
-    
+
+
 }
 
 if (menu=14) and (cooldown<=0){
@@ -223,7 +223,7 @@ if (menu=14) and (cooldown<=0){
     }draw_set_alpha(1);
     if (stc_wargear_un+stc_vehicles_un+stc_ships_un=0) then draw_set_alpha(0.5);
     draw_text(xx+670,yy+467,"Identify");draw_set_alpha(1);
-    
+
     draw_set_alpha(1);draw_rectangle(xx+733,yy+466,xx+790,yy+486,1);
     draw_set_alpha(0.5);draw_rectangle(xx+734,yy+467,xx+789,yy+485,1);
     if (mouse_x>xx+733) and (mouse_y>yy+466) and (mouse_x<xx+790) and (mouse_y<yy+486){
@@ -232,8 +232,8 @@ if (menu=14) and (cooldown<=0){
     if (stc_wargear_un+stc_vehicles_un+stc_ships_un=0) then draw_set_alpha(0.5);
     draw_text(xx+761,yy+467,"Gift");draw_set_alpha(1);
     */
-    
-    
+
+
     if (mouse_x>=xx+733) and (mouse_y>=yy+466) and (mouse_x<xx+790) and (mouse_y<yy+486) and (cooldown<=0){// Gift STC Fragment
         if (stc_wargear_un+stc_vehicles_un+stc_ships_un>0){
             var pop,chick;chick=0;
@@ -246,23 +246,23 @@ if (menu=14) and (cooldown<=0){
             }
         }
     }
-    
-    
+
+
     if (mouse_x>xx+621) and (mouse_y>yy+466) and (mouse_x<xx+720) and (mouse_y<yy+486){// Identify STC
         if (stc_wargear_un+stc_vehicles_un+stc_ships_un>0){
             var r1,r2;r2=0;cooldown=8000;
             audio_play_sound(snd_stc,-500,0)
             audio_sound_gain(snd_stc,master_volume*effect_volume,0);
             r1=floor(random(stc_wargear_un+stc_vehicles_un+stc_ships_un))+1;
-            
+
             if (r1<stc_wargear_un) and (stc_wargear_un>0) then r2=1;
             if (r1>stc_wargear_un) and (r1<=stc_wargear_un+stc_vehicles_un) and (stc_vehicles_un>0) then r2=2;
             if (r1>stc_wargear_un+stc_vehicles_un) and (r2<=stc_wargear_un+stc_vehicles_un+stc_ships_un) and (stc_ships_un>0) then r2=3;
-            
+
             if (stc_wargear_un>0) and (stc_vehicles_un+stc_ships_un=0) then r2=1;
             if (stc_vehicles_un>0) and (stc_wargear_un+stc_ships_un=0) then r2=2;
             if (stc_ships_un>0) and (stc_vehicles_un+stc_wargear_un=0) then r2=3;
-            
+
             if (r2=1){
                 stc_wargear_un-=1;stc_wargear+=1;
                 if (stc_wargear=2) then stc_bonus[1]=choose(1,2,3,4,5);
@@ -282,8 +282,8 @@ if (menu=14) and (cooldown<=0){
         }
         exit;
     }
-    
-    
+
+
 
     /*
     if (mouse_x>=xx+223) and (mouse_y>=yy+301) and (mouse_x<xx+333) and (mouse_y<yy+347){menu=55;cooldown=8;with(obj_shop){instance_destroy();}instance_create(0,0,obj_shop);}
@@ -297,7 +297,7 @@ if (menu=14) and (cooldown<=0){
 if (menu=15) and (cooldown<=0){
     if (mouse_x>=xx+748) and (mouse_x<xx+772){
         if (mouse_y>=yy+355) and (mouse_y<yy+373) and (recruiting<5) and (obj_controller.gene_seed>0) and (obj_ini.doomed=0) and (string_count("|",obj_controller.recruiting_worlds)>0) and (obj_controller.penitent=0){cooldown=8000;recruiting+=1;income_recruiting-=2*(string_count("|",obj_controller.recruiting_worlds));scr_income();}
-        
+
         if (mouse_y>=yy+395) and (mouse_y<yy+413) and (training_apothecary<6){cooldown=8000;training_apothecary+=1;scr_income();}
         if (mouse_y>=yy+415) and (mouse_y<yy+433) and (training_chaplain<6) and (global.chapter_name!="Space Wolves") and (global.chapter_name!="Iron Hands"){cooldown=8000;training_chaplain+=1;scr_income();}
         if (mouse_y>=yy+435) and (mouse_y<yy+452) and (training_psyker<6) and (string_count("Intolerant",obj_ini.strin2)=0){cooldown=8000;training_psyker+=1;scr_income();}
@@ -368,9 +368,9 @@ if (menu=16) and (cooldown<=0){
 
 if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (cooldown<=0){// Diplomacy
     if (trading=0) and (diplo_option[1]="") and (diplo_option[2]="") and (diplo_option[3]="") and (diplo_option[4]=""){
-    
+
         // xx+=208;yy+=83;yy+=50;
-    
+
         if (force_goodbye<=0){
             if (audience=0){
                 if (mouse_x>=xx+442) and (mouse_y>=yy+718) and (mouse_x<xx+547) and (mouse_y<yy+737) and (audience=0) and (force_goodbye=0){// Trade
@@ -380,7 +380,7 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
                     cooldown=8;click2=1;trading_demand=diplomacy;scr_dialogue("trading_demand");
                 }
                 if (mouse_x>=xx+682) and (mouse_y>=yy+718) and (mouse_x<xx+787) and (mouse_y<yy+737) and (force_goodbye=0){// Discuss
-                    // 
+                    //
                 }
             }
             if (mouse_x>=xx+442) and (mouse_y>=yy+752) and (mouse_x<xx+547) and (mouse_y<yy+771) and (force_goodbye=0){// Denounce
@@ -389,7 +389,7 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
             if (mouse_x>=xx+561) and (mouse_y>=yy+752) and (mouse_x<xx+667) and (mouse_y<yy+771) and (force_goodbye=0){// Praise
                 if (diplo_last!="praised"){scr_dialogue("praised");cooldown=8;click2=1;}
             }
-            
+
             if (audience=0){
                 if (mouse_x>=xx+682) and (mouse_y>=yy+752) and (mouse_x<xx+787) and (mouse_y<yy+771) and (force_goodbye=0){// Propose Alliance
                     if (diplo_last!="propose_alliance"){cooldown=8;click2=1;scr_dialogue("propose_alliance");}
@@ -397,19 +397,19 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
                 // Declare war here
             }
         }
-        
+
         /*
         Propose Alliance    same as Discuss but 752-771
         Declare War         551,784,677,803
         */
-           
+
         if (mouse_x>=xx+818) and (mouse_y>=yy+795) and (mouse_x<xx+897) and (mouse_y<yy+814){// Exit
             click=1;
-            
+
             if (audio_is_playing(snd_blood)=true) then scr_music("royal",2000);
-            
-            
-            
+
+
+
             if (complex_event=true) and (instance_exists(obj_temp_meeting)){
                 complex_event=false;diplomacy=0;menu=0;
                 force_goodbye=0;cooldown=80;
@@ -417,9 +417,9 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
                 if (instance_exists(obj_turn_end)){obj_turn_end.alarm[1]=1;exit;}
                 exit;
             }
-            
-            
-            
+
+
+
             if (trading_artifact!=0){
                 var h;h=0;repeat(4){h+=1;obj_controller.diplo_option[h]="";obj_controller.diplo_goto[h]="";}
                 diplomacy=0;menu=0;force_goodbye=0;cooldown=8;
@@ -427,12 +427,12 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
                 trading_artifact=0;
                 with(obj_popup){obj_temp4.alarm[1]=1;instance_destroy();}exit;
             }
-            
+
             if (force_goodbye=5){
                 var h;h=0;repeat(4){h+=1;obj_controller.diplo_option[h]="";obj_controller.diplo_goto[h]="";}
                 diplomacy=0;menu=0;force_goodbye=0;cooldown=8;exit;
             }
-            
+
             if (liscensing=2) and (repair_ships=0){
                 cooldown=8;
                 var cru;
@@ -443,40 +443,40 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
                 if (zoomed=0) then scr_zoom();
                 exit;
             }
-            
+
             if (exit_all!=0){cooldown=8;diplomacy=0;force_goodbye=0;menu=0;exit_all=0;}
-            
+
             if (diplo_last="artifact_thanks") and (force_goodbye!=0){
                 diplomacy=0;menu=13;force_goodbye=0;cooldown=8;exit;
             }
-            
+
             // Trading artifact was here
-            
+
             if (audience=0){cooldown=8;diplomacy=0;force_goodbye=0;}// Exits back to diplomacy thing
-            
+
             if (audience>0) and (!instance_exists(obj_turn_end)){cooldown=8;diplomacy=0;menu=0;audience=0;force_goodbye=0;exit;}// No need to check for next audience
             if (audience>0) and (instance_exists(obj_turn_end)){
                 if (obj_controller.complex_event=false){
                     cooldown=8;diplomacy=0;menu=0;obj_turn_end.alarm[1]=1;audience=0;force_goodbye=0;exit;
                 }
                 if (obj_controller.complex_event=true){
-                    
+
                 }
             }// Have this check for the next audience, if any
         }
-        
+
         // xx=view_xview[0]+0;yy=view_yview[0]+0;
-        
-        
-        
+
+
+
         if (trading=1) or (trading=2){// Trade goods go here
             trade_theirs[1]="";trade_theirs[2]="";trade_theirs[3]="";trade_theirs[4]="";trade_theirs[5]="";trade_theirs[6]="";
             trade_disp[0]=-100;trade_disp[1]=-100;trade_disp[2]=-100;trade_disp[3]=-100;trade_disp[4]=-100;trade_disp[5]=-100;trade_disp[6]=-100;
-            
+
             trade_req=requisition;trade_gene=gene_seed;
             trade_chip=stc_wargear_un+stc_vehicles_un+stc_ships_un;
             trade_info=info_chips;
-            
+
             if (diplomacy=2){cooldown=8;// Imperium trade goods
                 trade_theirs[1]="Requisition";
                 // trade_theirs[2]="Storm Trooper";
@@ -497,7 +497,7 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
                 trade_theirs[1]="Eviscerator";trade_theirs[2]="Heavy Flamer";trade_theirs[3]="Inferno Bolts";trade_theirs[4]="Sister of Battle";trade_theirs[5]="Sister Hospitaler";
                 trade_disp[1]=20;trade_disp[2]=30;trade_disp[3]=30;trade_disp[4]=50;trade_disp[5]=50;
             }
-            
+
             if (diplomacy=6){cooldown=8;// Elfdar trade goods
                 trade_theirs[1]="Master Crafted Power Sword";trade_theirs[2]="Archeotech Laspistol";trade_theirs[3]="Ranger";trade_theirs[4]="Useful Information";
                 trade_disp[1]=-10;trade_disp[2]=-10;trade_disp[3]=10;trade_disp[4]=-15;
@@ -506,31 +506,31 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
             if (diplomacy=7){cooldown=8;// Ork trade goods
                 trade_theirs[1]="Power Klaw";trade_theirs[2]="Ork Sniper";trade_theirs[3]="Flash Git";
             }
-            
+
             if (diplomacy=8) then trade_theirs[1]="Test";
-            
+
         }
     }
-    // 
-    
-    
-    
-    
-    
-    
-    
+    //
+
+
+
+
+
+
+
     if (trading=0) and ((diplo_option[1]!="") or (diplo_option[2]!="") or (diplo_option[3]!="") or (diplo_option[4]!="")){
         if (force_goodbye=0) and (cooldown<=0){
-            
+
             var diplo_pressed;diplo_pressed=0;
             yy=__view_get( e__VW.YView, 0 )+0;
-            
+
             var opts,slot,dp;opts=0;slot=0;dp=0;
             repeat(4){dp+=1;if (diplo_option[dp]!="") then opts+=1;}
             if (opts=4) then yy-=30;
             if (opts=2) then yy+=30;
             if (opts=1) then yy+=60;
-            
+
             repeat(4){slot+=1;
                 if (diplo_option[slot]!=""){
                     if (mouse_x>=xx+354) and (mouse_y>=yy+694) and (mouse_x<xx+887) and (mouse_y<yy+717) and (cooldown<=0){
@@ -540,17 +540,17 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
                 yy+=30;
             }
             yy=__view_get( e__VW.YView, 0 );
-            
-            
+
+
             if (diplo_pressed>0) and (diplo_goto[diplo_pressed]!="") and (cooldown<=0){
                 click2=1;scr_dialogue(diplo_goto[diplo_pressed]);cooldown=4000;exit;
             }
-            
+
             if (diplo_pressed=1){click2=1;
                 if (questing=0) and (trading_artifact=0) and (trading_demand=0){
                     if (diplomacy=4) and (diplo_option[1]="It will not happen again"){// It will not happen again mang
                         scr_dialogue("you_better");diplo_option[1]="";diplo_option[2]="";diplo_option[3]="";force_goodbye=1;
-                        
+
                         var tb,tc,pp;
                         explode_script(obj_controller.temp[1008],"|");
                         tb=string(explode[0]);tc=real(explode[1]);
@@ -559,7 +559,7 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
                         exit;
                     }
                 }
-                
+
                 if (questing!=0){cooldown=8;
                     if (questing=1) and (diplomacy=6){
                         if (requisition>=500){scr_loyalty("Xeno Trade","+");
@@ -569,22 +569,22 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
                         }
                     }
                 }
-                
+
                 if ((diplomacy=3) or (diplomacy=5)) and (trading_artifact!=0){trading=1;scr_dialogue("open_trade");trade_take[1]="Artifact";trade_tnum[1]=1;trade_req=requisition;trade_gene=gene_seed;trade_chip=info_chips;trade_info=stc_wargear_un+stc_vehicles_un+stc_ships_un;}
-                
+
                 if (trading_demand>0) and (diplo_option[1]!="Cancel") and (diplo_option[1]!="") then scr_demand(1);
             }
-            
-            
-            
+
+
+
             if (diplo_pressed=2){
                 // show_message("special diplomacy option 2");
                 click2=1;
-                
+
                 if (questing=0) and (trading_artifact=0) and (trading_demand=0){// Don't want no trabble
                     if (diplomacy=4) and (diplo_option[2]="Very well"){
                         diplo_option[1]="";diplo_option[2]="";diplo_option[3]="";force_goodbye=1;
-                        
+
                         var tb,tc,pp;
                         explode_script(obj_controller.temp[1008],"|");
                         tb=string(explode[0]);tc=real(explode[1]);
@@ -594,38 +594,38 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
                         exit;
                     }
                 }
-                
-                
-                
+
+
+
                 if (questing!=0){cooldown=8;
                     if (questing=1) and (diplomacy=6){
                         scr_dialogue("quest_maybe");questing=0;
                         diplo_option[1]="";diplo_option[2]="";diplo_option[3]="";exit;
                     }
                 }
-                
+
                 if (trading_demand>0) and (diplo_option[2]!="Cancel") and (diplo_option[2]!="") then scr_demand(2);
                 if (trading_demand>0) and (diplo_option[2]="Cancel"){cooldown=8000;trading_demand=0;diplo_option[1]="";diplo_option[2]="";diplo_option[3]="";diplo_text="...";diplo_txt="...";}
-            
-                
+
+
                 if (diplomacy>0) and (trading_artifact>0) and (menu=20){cooldown=8;
                     obj_temp4.alarm[1]=2;trading_artifact=0;menu=0;diplomacy=0;diplo_option[1]="";diplo_option[2]="";diplo_option[3]="";
                 }
             }
-            
-            
-            
+
+
+
             if (diplo_pressed=3){
                 // show_message("special diplomacy option 3");
                 click2=1;
-                
+
                 if (questing=0) and (trading_artifact=0) and (trading_demand=0){
                     if (diplomacy=4) and (string_count("You will not",diplo_option[3])>0){// MIIIIINE!!!1
                         scr_dialogue("die_heretic");diplo_option[1]="";diplo_option[2]="";diplo_option[3]="";force_goodbye=1;
                         exit;
                     }
                 }
-                
+
                 if (questing!=0){cooldown=8;
                     if (questing=1) and (diplomacy=6){// That +2 counteracts the WAITED TOO LONG penalty
                         scr_dialogue("mission1_refused");
@@ -633,7 +633,7 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
                         diplo_option[1]="";diplo_option[2]="";diplo_option[3]="";exit;
                     }
                 }
-                
+
                 if (trading_demand>0) and (diplo_option[3]!="Cancel") and (diplo_option[3]!="") then scr_demand(3);
                 if (trading_demand>0) and (diplo_option[3]="Cancel"){cooldown=8;trading_demand=0;diplo_option[1]="";diplo_option[2]="";diplo_option[3]="";diplo_text="...";diplo_txt="...";}
             }
@@ -649,14 +649,14 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
             }
         }
     }
-    
-    
-    
-    
-    
-    
-    
-    // 
+
+
+
+
+
+
+
+    //
     if (trading=1) or (trading=2){
         if (scr_hit(xx+818,yy+796,xx+897,yy+815)=true){// Exit
             cooldown=8;trading=0;scr_dialogue("trade_close");click2=1;
@@ -667,7 +667,7 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
         if (scr_hit(xx+510,yy+649,xx+615,yy+668)=true){// Clear Terms
             cooldown=8;click2=1;trade_likely="";
             trade_req=requisition;trade_gene=gene_seed;trade_chip=stc_wargear_un+stc_vehicles_un+stc_ships_un;trade_info=info_chips;
-            
+
             if (trading_artifact=0){
                 trade_take[0]="";trade_take[1]="";trade_take[2]="";trade_take[3]="";trade_take[4]="";trade_take[5]="";trade_tnum[0]=0;trade_tnum[1]=0;trade_tnum[2]=0;trade_tnum[3]=0;trade_tnum[4]=0;trade_tnum[5]=0;
             }
@@ -676,12 +676,12 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
         if (scr_hit(xx+630,yy+649,xx+735,yy+668)=true){// Trade Here?
             cooldown=8;click2=1;if (diplo_last!="offer") then scr_trade(true);
         }
-        
-        
-        
+
+
+
         var minz,;minz=0;
-        if (trade_give[4]="") then minz=4;if (trade_give[3]="") then minz=3;if (trade_give[2]="") then minz=2;if (trade_give[1]="") then minz=1; 
-        
+        if (trade_give[4]="") then minz=4;if (trade_give[3]="") then minz=3;if (trade_give[2]="") then minz=2;if (trade_give[1]="") then minz=1;
+
         // Opponent things to offer
         if (trading_artifact=0){
             if (scr_hit(xx+342,yy+371,xx+485,yy+422)=true) and (cooldown<=0) and (disposition[diplomacy]>=trade_disp[1]){
@@ -700,7 +700,7 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
                 cooldown=8;click2=1;scr_trade_add(string(trade_theirs[5]));
             }
         }
-        
+
         xx+=419;
         // Player Things to Offer
         if (scr_hit(xx+342,yy+371,xx+485,yy+422)=true) and (minz!=0) and (cooldown<=0) and (trade_req>0){// Requisition
@@ -724,10 +724,10 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
             scr_trade(false);
         }
         xx-=419;
-        
-        
-        
-        
+
+
+
+
         // Remove items buttons
         if (trading_artifact=0){
             if (scr_hit(xx+507,yy+399,xx+527,yy+418)=true) and (trade_tnum[2]=0) and (trade_tnum[1]!=0) and (cooldown<=0){
@@ -743,7 +743,7 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
                 trade_tnum[4]=0;trade_take[4]="";cooldown=8000;click2=1;scr_trade(false);
             }
         }
-        
+
         if (scr_hit(xx+507,yy+547,xx+527,yy+566)=true) and (trade_mnum[2]=0) and (trade_mnum[1]!=0) and (cooldown<=0){
             if (trade_give[1]="Requisition") then trade_req+=trade_mnum[1];if (trade_give[1]="Gene-Seed") then trade_gene+=trade_mnum[1];
             if (trade_give[1]="STC Fragment") then trade_chip+=trade_mnum[1];if (trade_give[1]="Info Chip") then trade_info+=trade_mnum[1];
@@ -765,7 +765,7 @@ if (menu=20) and ((diplomacy>0) or ((diplomacy<-5) and (diplomacy>-6))) and (coo
             trade_mnum[4]=0;trade_give[4]="";cooldown=8000;click2=1;scr_trade(false);
         }
     }
-    
+
 }
 
 
@@ -826,9 +826,9 @@ if (zoomed=0) and (cooldown<=0) and (menu=20) and (diplomacy=0){
             if (ignore[5]=1) and (onceh=0){onceh=1;ignore[5]=0;}
         }
     }
-    
-    
-    
+
+
+
     // speak with Eldar
     if (mouse_y>=yy+355) and (mouse_y<yy+369){
         if (mouse_x>=xx+1203) and (mouse_x<xx+1300) and (cooldown<=0) and (faction_defeated[6]=0){
@@ -873,18 +873,18 @@ if (zoomed=0) and (cooldown<=0) and (menu=20) and (diplomacy=0){
             if (ignore[10]=1) and (onceh=0){onceh=1;ignore[10]=0;}
         }
     }
-    
-    
-    
+
+
+
     if (diplomacy>0) and (cooldown=8000){var onceh;onceh=0;
         if (known[diplomacy]=1) and (diplomacy!=4) and (onceh=0){scr_dialogue("intro");onceh=1;known[diplomacy]=2;faction_justmet=1;}
         if (known[diplomacy]>=2) and (diplomacy!=4) and (onceh=0){scr_dialogue("hello");onceh=1;}
-        
+
         if (known[4]=1) and (diplomacy=4) and (onceh=0){scr_dialogue("intro");onceh=1;known[diplomacy]=2;faction_justmet=1;obj_controller.last_mission=turn+1;}
         if (known[4]=3) and (diplomacy=4) and (onceh=0){scr_dialogue("intro");onceh=1;known[diplomacy]=4;faction_justmet=1;obj_controller.last_mission=turn+1;}
         if (known[diplomacy]>=4) and (diplomacy=4) and (onceh=0){scr_dialogue("hello");onceh=1;}
     }
-    
+
 
 }
 
@@ -927,7 +927,7 @@ if (zoomed=0) and (cooldown<=0) and (menu>=500) and (menu<=510){
             show_message("Exit");cooldown=8000;click=1;
         }
     }*/
-    
+
     if (mouse_y>=__view_get( e__VW.YView, 0 )+27){
         cooldown=8000;
         if (menu>=500) and (temp[menu-434]=""){menu=0;exit;}
@@ -946,7 +946,7 @@ xx=__view_get( e__VW.XView, 0 );yy=__view_get( e__VW.YView, 0 );
 zoomeh=zoomed;
 
 
-if (menu=0) then hide_banner=0;// 136 ; 
+if (menu=0) then hide_banner=0;// 136 ;
 
 
 
@@ -960,7 +960,7 @@ if (zoomed=0) and (!instance_exists(obj_ingame_menu)) and (!instance_exists(obj_
         igm.settings=1;with(obj_new_button){x-=2000;y-=2000;}
         butt=instance_create(xx+653,yy+664,obj_new_button);butt.sprite_index=spr_ui_but_1;
         butt.depth=-20010;butt.button_text="Exit";butt.button_id=1;butt.scaling=1.5;butt.target=26;*/
-        
+
         if (menu!=17.5) and (onceh=0){menu=17.5;onceh=1;cooldown=8000;click=1;hide_banner=0;instance_activate_object(obj_event_log);obj_event_log.top=1;obj_event_log.help=1;}
         if (menu=17.5) and (onceh=0){menu=0;onceh=1;cooldown=8000;click=1;hide_banner=0;}
         managing=0;
@@ -1021,15 +1021,15 @@ if (zoomed=0) and (cooldown<=0) and (diplomacy=0){
             if (settings>0) and (onceh=0){menu=21;onceh=1;cooldown=8000;click=1;settings=0;}
         }
     }
-    
-    
+
+
     if (mouse_x>=xx+358) and (mouse_y>=yy+838) and (mouse_x<xx+471) and (mouse_y<yy+879){// Apothecarium
         menu_adept=0;hide_banner=1;if (scr_role_count("Master of the Apothecarion","0")=0) then menu_adept=1;
         if (menu!=11) and (onceh=0){menu=11;onceh=1;cooldown=8000;click=1;temp[36]=scr_role_count(obj_ini.role[100,15],"");}
         if (menu=11) and (onceh=0){menu=0;onceh=1;cooldown=8000;click=1;}
         managing=0;
     }
-    
+
     if (mouse_x>=xx+474) and (mouse_y>=yy+838) and (mouse_x<xx+587) and (mouse_y<yy+879){// Reclusium
         menu_adept=0;hide_banner=1;if (scr_role_count("Master of Sanctity","0")=0) then menu_adept=1;
         if (menu!=12) and (onceh=0){
@@ -1038,7 +1038,7 @@ if (zoomed=0) and (cooldown<=0) and (diplomacy=0){
             click=1;
             temp[36]=string(scr_role_count(obj_ini.role[100,14],"field"));temp[37]=string(scr_role_count(obj_ini.role[100,14],"home"));
             penitorium=0;
-            
+
             var c,e,p;c=-1;e=0;p=0;// Get lis of penitent dudes?
             repeat(11){
                 c+=1;e=0;
@@ -1052,7 +1052,7 @@ if (zoomed=0) and (cooldown<=0) and (diplomacy=0){
         if (menu=12) and (onceh=0){menu=0;onceh=1;cooldown=8000;click=1;}
         managing=0;
     }
-    
+
     if (mouse_x>=xx+591) and (mouse_y>=yy+838) and (mouse_x<xx+704) and (mouse_y<yy+879){// Librarium
         menu_adept=0;hide_banner=1;if (scr_role_count("Chief "+string(obj_ini.role[100,17]),"0")=0) then menu_adept=1;
         if (menu!=13) and (onceh=0){menu=13;onceh=1;cooldown=8000;click=1;
@@ -1064,7 +1064,7 @@ if (zoomed=0) and (cooldown<=0) and (diplomacy=0){
         if (menu=13) and (onceh=0){menu=0;onceh=1;cooldown=8000;click=1;}
         managing=0;
     }
-    
+
     if (mouse_x>=xx+707) and (mouse_y>=yy+838) and (mouse_x<xx+820) and (mouse_y<yy+879){// Armamentarium
         menu_adept=0;hide_banner=1;if (scr_role_count("Forge Master","0")=0) then menu_adept=1;
         if (menu!=14) and (onceh=0){menu=14;onceh=1;cooldown=8000;click=1;temp[36]=scr_role_count(obj_ini.role[100,16],"");
@@ -1072,24 +1072,24 @@ if (zoomed=0) and (cooldown<=0) and (diplomacy=0){
         if (menu=14) and (onceh=0){menu=0;onceh=1;cooldown=8000;click=1;}
         managing=0;
     }
-    
+
     if (mouse_x>=xx+805) and (mouse_y>=yy+838) and (mouse_x<xx+918) and (mouse_y<yy+879){// Recruiting
         var geh,good;good=0;geh=0;
         repeat(50){geh+=1;if (good=0){if (obj_ini.role[10,geh]=obj_ini.role[100,5]) and (obj_ini.name[10,geh]=obj_ini.recruiter_name) then good=geh;}}
         if (geh=0) then menu_adept=1;
-        
+
         menu_adept=0;hide_banner=1;
         if (menu!=15) and (onceh=0){menu=15;onceh=1;cooldown=8000;click=1;}
         if (menu=15) and (onceh=0){menu=0;onceh=1;cooldown=8000;click=1;}
         managing=0;
     }
-    
+
     if (mouse_x>=xx+939) and (mouse_y>=yy+838) and (mouse_x<xx+1052) and (mouse_y<yy+879){// Master of the Fleet
         menu_adept=0;hide_banner=1;
         var geh,good;good=0;geh=0;
         repeat(50){geh+=1;if (good=0){if (obj_ini.role[4,geh]=obj_ini.role[100,5]) and (obj_ini.name[10,geh]=obj_ini.lord_admiral_name) then good=geh;}}
         if (geh=0) then menu_adept=1;
-        
+
         if (menu!=16) and (onceh=0){
             menu=16;onceh=1;cooldown=8000;click=1;
             temp[37]="";temp[38]="";temp[39]="";temp[40]="";temp[41]="";
@@ -1097,7 +1097,7 @@ if (zoomed=0) and (cooldown<=0) and (diplomacy=0){
             temp[105]="";temp[106]="";temp[107]="";temp[108]="";
             temp[109]="";temp[110]="";temp[112]="";temp[114]="";
             temp[116]="";temp[118]="";temp[119]="";
-            
+
             var i,g,u,m,d;i=0;g=0;u=0;m=0;d=0;
             i=0;g=0;repeat(60){i+=1;if (obj_ini.ship[i]!="") and (obj_ini.ship_size[i]=3) then g+=1;}temp[37]=string(g);
             i=0;g=0;repeat(60){i+=1;if (obj_ini.ship[i]!="") and (obj_ini.ship_size[i]=2) then g+=1;}temp[38]=string(g);
@@ -1116,44 +1116,44 @@ if (zoomed=0) and (cooldown<=0) and (diplomacy=0){
         if (menu=16) and (onceh=0){menu=0;onceh=1;cooldown=8000;click=1;}
         managing=0;
     }
-    
-    
-    
+
+
+
     /*diyst=point_distance(mouse_x,mouse_y,xx+608,yy+453);
     if (diyst<=-5) and (!instance_exists(obj_turn_end)){// End turn
-        
+
     }*/
-    
-    
-    
-    
+
+
+
+
     if (mouse_x>=xx+1131) and (mouse_y>=yy+838) and (mouse_x<xx+1273) and (mouse_y<yy+879){// Diplomacy
         if (menu!=20) and (onceh=0){menu=20;onceh=1;cooldown=8000;click=1;hide_banner=1;}
         if (menu=20) and (onceh=0){menu=0;onceh=1;cooldown=8000;click=1;hide_banner=0;}
         managing=0;
     }
-    
+
     if (scr_hit(xx+1275,yy+838,xx+1417,yy+879)=true){// Event Log
         if (menu!=17) and (onceh=0){menu=17;onceh=1;cooldown=8000;click=1;hide_banner=1;instance_activate_object(obj_event_log);obj_event_log.top=1;}
         if (menu=17) and (onceh=0){menu=0;onceh=1;cooldown=8000;click=1;hide_banner=0;}
         managing=0;
     }
-    
+
     if (mouse_x>=xx+1420) and (mouse_y>=yy+837) and (mouse_x<xx+1562) and (mouse_y<yy+877){// End Turn
         if (menu=0) and (cooldown<=0){
             cooldown=8;menu=0;
-            
+
             if (!instance_exists(obj_turn_end)) then ok=1;
             if (instance_exists(obj_turn_end)){if (obj_turn_end.popups_end=1) then ok=1;}
-            
+
             if (ok=1){
                 with(obj_turn_end){instance_destroy();}
                 with(obj_star_event){instance_destroy();}
                 cooldown=8;audio_play_sound(snd_end_turn,-50,0);
                 audio_sound_gain(snd_end_turn,master_volume*effect_volume,0);
-                
+
                 turn+=1;
-                
+
                 with(obj_star){
                     present_fleet[1]=0;present_fleet[2]=0;present_fleet[3]=0;present_fleet[4]=0;present_fleet[5]=0;
                     present_fleet[6]=0;present_fleet[7]=0;present_fleet[8]=0;present_fleet[9]=0;present_fleet[10]=0;
@@ -1175,15 +1175,15 @@ if (zoomed=0) and (cooldown<=0) and (diplomacy=0){
                         }
                     }
                 }
-                
+
                 if (instance_exists(obj_p_fleet)){obj_p_fleet.alarm[1]=1;}
                 if (instance_exists(obj_en_fleet)){obj_en_fleet.alarm[1]=1;}
                 if (instance_exists(obj_crusade)){obj_crusade.alarm[0]=2;}
-                
+
                 requisition+=income;scr_income();gene_tithe-=1;
-                
+
                 // Do that after the combats and all of that crap
-                
+
                 with(obj_star){
                     ai_a=2;ai_b=3;ai_c=4;ai_d=5;ai_e=5;
                     if (p_type[1]="Craftworld"){
@@ -1195,17 +1195,17 @@ if (zoomed=0) and (cooldown<=0) and (diplomacy=0){
                 alarm[5]=6;instance_create(0,0,obj_turn_end);scr_turn_first();
             }
         }
-        
+
         if (menu=1) and (onceh=0){menu=0;onceh=1;cooldown=8000;click=1;hide_banner=0;}
         managing=0;
     }
-    
-    
-    
-    
-    
+
+
+
+
+
     // if (mouse_x>=xx+512) and (mouse_y>=yy+449) and (mouse_x<xx+575) and (mouse_y<yy+472){show_message("Log");cooldown=8000;click=1;}
-       
+
 }
 
 
@@ -1226,8 +1226,8 @@ if (zoomed=0) and (menu=40) and (cooldown<=0){
 
 if (zoomed=0) and (menu=1) and (managing=0) and (cooldown<=0) and (diplomacy=0){// Main management screen
     var xx, yy;managing=0;
-    
-    
+
+
     xx=xx+0;yy=yy+0;
     if (mouse_x>=xx+248) and (mouse_y>=yy+64) and (mouse_x<xx+392) and (mouse_y<yy+80+64){managing=11;cooldown=8000;}// HQ
     if (mouse_x>=xx+136) and (mouse_y>=yy+64) and (mouse_x<xx+248) and (mouse_y<yy+80+64){managing=12;cooldown=8000;}// Apoth
@@ -1245,20 +1245,20 @@ if (zoomed=0) and (menu=1) and (managing=0) and (cooldown<=0) and (diplomacy=0){
     if (mouse_x>=xx+248) and (mouse_y>=yy+320) and (mouse_x<xx+360) and (mouse_y<yy+352+64){managing=8;cooldown=8000;}
     if (mouse_x>=xx+360) and (mouse_y>=yy+320) and (mouse_x<xx+472) and (mouse_y<yy+352+64){managing=9;cooldown=8000;}
     if (mouse_x>=xx+472) and (mouse_y>=yy+320) and (mouse_x<xx+584) and (mouse_y<yy+352+64){managing=10;cooldown=8000;}
-    
-    
-    
+
+
+
     if (mouse_x>=xx+426) and (mouse_y>=yy+421) and (mouse_x<xx+556) and (mouse_y<yy+443){
         managing=0;cooldown=8000;menu=40;
     }
-    
+
     /*
     draw_rectangle(xx+426,yy+421,xx+556,yy+443,0);
     */
-    
-    
-    
-    
+
+
+
+
     if (managing!=0) and (managing<=15){
         var i;i=-1;man_size=0;selecting_location="";selecting_types="";selecting_ship=0;sel_uid=0;
         repeat(501){i+=1;
@@ -1278,7 +1278,7 @@ if (zoomed=0) and (menu=1) and (managing=0) and (cooldown<=0) and (diplomacy=0){
 
 if (zoomed=0) and (menu=1) and (managing>0) and (cooldown<=0){
     var xx,yy;xx=xx+0;yy=yy+0;
-    
+
     if (mouse_x>=xx+23) and (mouse_y>=yy+80) and (mouse_x<xx+95) and (mouse_y<yy+128){// Back out from company
         managing=0;cooldown=8000;scr_ui_refres();scr_management(1);cooldown=8000;click=1;popup=0;selected=0;hide_banner=1;
     }
@@ -1300,7 +1300,7 @@ if (zoomed=0) and (menu=1) and (managing>0) and (cooldown<=0){
 
 if (zoomed=0) and (menu=30) and (managing>0) and (cooldown<=0){// This is the back button at LOADING TO SHIPS
     var xx, yy;xx=xx+0;yy=yy+0;
-    
+
     if (mouse_x>=xx+22) and (mouse_y>=yy+84) and (mouse_x<xx+98) and (mouse_y<yy+126){menu=1;cooldown=8000;}
 }
 
@@ -1312,14 +1312,14 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
     xx=__view_get( e__VW.XView, 0 )+0;yy=__view_get( e__VW.YView, 0 )+0;
     var top,sel,temp1,temp2,temp3,temp4,temp5;temp1="";temp2="";temp3="";temp4="";temp5="";
     top=man_current;var stop;stop=0;sel=top;eventing=false;
-    
+
     if (man_size=0) then alll=0;
-    
+
     // selecting all
     if (mouse_x>=xx+1281) and (mouse_y>=yy+607) and (mouse_x<xx+1409) and (mouse_y<yy+636) and (cooldown<=0) and (alll=0){cooldown=8;scr_load_all(true);selecting_types="%!@";}
     if (mouse_x>=xx+1281) and (mouse_y>=yy+607) and (mouse_x<xx+1409) and (mouse_y<yy+636) and (cooldown<=0) and (alll=1){cooldown=8;scr_load_all(false);selecting_types="";}
-    
-    
+
+
     // This clicks on the squad_sel button
     yy+=77;x1=xx;y1=yy;
     var squad_sel;squad_sel=0;
@@ -1330,7 +1330,7 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
         }
         yy+=21;sel+=1;
     }
-    
+
     // This is the 'select all of type' buttons
     sel=1;yy=__view_get( e__VW.YView, 0 )+77;
     if (sel_all!=""){
@@ -1340,16 +1340,16 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
         if (sel_all="man") then scr_load_decide_loc("man","man",false);
         if (sel_all="vehicle") then scr_load_decide_loc("vehicle","vehicle",true);
         if (sel_all="Command") then scr_load_decide_loc("command","command",false);
-        
+
         repeat(man_max){eventing=false;
-        
+
             // Prevent selecting marines that are in an event
             if (fest_repeats>0){
                 if (fest_planet=0) and (fest_sid>0) and (ma_lid[sel]=fest_sid){eventing=true;}
                 if (fest_planet=1) and (fest_wid>0) and (ma_wid[sel]=fest_wid) and (ma_loc[sel]=fest_star){eventing=true;}
             }
-            
-            
+
+
             if (sel_all!="Command") and (sel_all!="man") and (sel_all!="vehicle"){// Selects all men of type
                 if (man[sel]="man") and (ma_role[sel]=sel_all) and (ma_loc[sel]!="Terra") and (ma_loc[sel]!="Mechanicus Vessel") and (ma_loc[sel]!="Lost") and (ma_god[sel]<10) and ((ma_loc[sel]=selecting_location) or (selecting_location="")) and ((ma_wid[sel]=selecting_planet) or (selecting_planet=0)) and ((ma_lid[sel]=selecting_ship) or (selecting_ship=0)) and (eventing=false){var onceh;onceh=0;
                     if (man_sel[sel]=0) and (onceh=0){man_sel[sel]=1;man_size+=scr_unit_size(ma_armor[sel],ma_role[sel],true);onceh=1;if (selecting_location="") and (ma_lid[sel]>0){selecting_location=obj_ini.ship_location[ma_lid[sel]];selecting_ship=ma_lid[sel];sel_loading=1;}}
@@ -1388,10 +1388,10 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
                 if (yep=1){var onceh;onceh=0;
                     if (man_sel[sel]=0) and (onceh=0){man_sel[sel]=1;man_size+=scr_unit_size(ma_armor[sel],ma_role[sel],true);onceh=1;if (selecting_location="") and (ma_lid[sel]>0){selecting_location=obj_ini.ship_location[ma_lid[sel]];selecting_ship=ma_lid[sel];sel_loading=1;}}
                     if (man_sel[sel]=1) and (onceh=0){man_sel[sel]=0;man_size-=scr_unit_size(ma_armor[sel],ma_role[sel],true);onceh=1;}
-                
-                
-                
-                
+
+
+
+
                 /*
                 if (ma_role[sel]=obj_ini.role[100,5]) or (ma_role[sel]=obj_ini.role[100,14]) then yep=1;
                 if (ma_role[sel]=obj_ini.role[100,15]) or (ma_role[sel]=obj_ini.role[100,17]) then yep=1;
@@ -1406,37 +1406,37 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
         }
         sel_all="";
     }
-    
-    
+
+
     sel=top;yy=__view_get( e__VW.YView, 0 )+77;
     repeat(min(man_max,man_see)){
         repeat(500){if (man[sel]="hide") then sel+=1;}
         eventing=false;
-        
+
         if ((mouse_x>=xx+25+8) and (mouse_y>=yy+64) and (mouse_x<xx+974) and (mouse_y<yy+85) and (cooldown<=0)) or ((squad[sel]=squad_sel) and (squad_sel!=0)){
-            
+
             /*if (mouse_x<=xx+37) and (man[sel]="man") and (ma_role[sel]="Chapter Master"){
                 cooldown=30;menu=50;click2=1;
                 exit;
             }*/
-            
+
             var onceh,dib;onceh=0;stop=0;dib=0;                   // This is the actual individual click right here
-            
+
             eventing=false;
-        
-            
+
+
             // Prevent selecting marines that are in an event
             if (fest_repeats>0){
                 if (fest_planet=0) and (fest_sid>0) and (ma_lid[sel]=fest_sid){eventing=true;}
                 if (fest_planet=1) and (fest_wid>0) and (ma_wid[sel]=fest_wid) and (ma_loc[sel]=fest_star){eventing=true;}
             }
-            
-            
+
+
             // Register double click
             if (ma_god[sel]<10) and (ma_loc[sel]!="Terra") and (ma_loc[sel]!="Mechanicus Vessel") and (ma_loc[sel]!="Lost") and (eventing=false){
                 if (double_click>5) and (sel=double_was) then dib=1;
             }
-            
+
             if ((man_sel[sel]=0) and (onceh=0) and (ma_god[sel]<10) and (ma_loc[sel]!="Terra") and (ma_loc[sel]!="Mechanicus Vessel") and (ma_loc[sel]!="Lost") and (eventing=false)) or (dib=1){
                 if (selecting_location="") and (man[sel]="man"){
                     selecting_location=ma_loc[sel];selecting_ship=ma_lid[sel];selecting_planet=ma_wid[sel];// sel_uid=ma_uid[sel];
@@ -1444,54 +1444,54 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
                 if (selecting_location="") and (man[sel]="vehicle"){
                     selecting_location=ma_loc[sel];selecting_ship=ma_lid[sel];selecting_planet=ma_wid[sel];// sel_uid=ma_uid[sel];
                 }
-                
+
                 if (selecting_location!="") and (man[sel]="man") and (ma_loc[sel]!=selecting_location) then stop=1;
                 if (selecting_location!="") and (man[sel]="vehicle") and (ma_loc[sel]!=selecting_location) then stop=1;
-                
+
                 if (man[sel]="man") and (ma_lid[sel]!=sel_loading) and (sel_loading!=0) then stop=1;
                 if (man[sel]="vehicle") and (ma_lid[sel]!=sel_loading) and (sel_loading!=0) then stop=1;
-                
+
                 // Continue with double click
                 if (dib=1) and (stop!=1){
                     // show_message("selecting all "+string(ma_role[sel])+" at "+string(selecting_location));
-                    
+
                     var bi;bi=0;
                     repeat(300){bi+=1;
                         if (man_sel[bi]=0) and (ma_god[bi]<10) and (ma_loc[bi]!="Terra") and (ma_loc[bi]!="Mechanicus Vessel") and (ma_loc[bi]!="Lost"){
                             if (ma_loc[bi]=selecting_location) and (ma_role[bi]=ma_role[double_was]) and (bi!=double_was){
                                 man_sel[bi]=1;
-                                
+
                                 if (man[bi]="man") then man_size+=scr_unit_size(ma_armor[bi],ma_role[bi],true);
                                 if (man[bi]="vehicle") then man_size+=scr_unit_size("",ma_role[bi],true);
                             }
                         }
                     }
-                    
+
                     double_was=0;
                     cooldown=8;
                     click2=1;
                     stop=1;
-                    
+
                     exit;
                 }
-                
+
                 cooldown=8;click2=1;double_click+=12;double_was=sel;
-                
+
                 if (stop!=1){
                     onceh=1;man_sel[sel]=1;
                     if (string_count("%!@",selecting_types)=0){
                         if (man[sel]="man") then selecting_types+=string(ma_role[sel]);
                         if (man[sel]="vehicle") then selecting_types+=string(ma_role[sel]);
                     }
-                    
+
                     // check for location here
                     if (man[sel]="man") and (ma_lid[sel]>0) then sel_loading=ma_lid[sel];
                     if (man[sel]="vehicle") and (ma_lid[sel]>0) then sel_loading=ma_lid[sel];
-                    
+
                     if (man[sel]="man") then man_size+=scr_unit_size(ma_armor[sel],ma_role[sel],true);
                     if (man[sel]="vehicle") then man_size+=scr_unit_size("",ma_role[sel],true);
                 }
-                
+
             }
             if (man_sel[sel]=1) and (onceh=0){
                 onceh=1;man_sel[sel]=0;cooldown=8;click2=1;
@@ -1499,10 +1499,10 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
                     if (man[sel]="man") and (string_count(ma_role[sel],selecting_types)>0) then selecting_types=string_replace(selecting_types,ma_role[sel],"");
                     if (man[sel]="vehicle") and (string_count(ma_role[sel],selecting_types)>0) then selecting_types=string_replace(selecting_types,ma_role[sel],"");
                 }
-                
+
                 if (man[sel]="man") then man_size-=scr_unit_size(ma_armor[sel],ma_role[sel],true);
                 if (man[sel]="vehicle") then man_size-=scr_unit_size("",ma_role[sel],true);
-                
+
                 if (man_size=0) then sel_loading=0;
             }
         }
@@ -1511,24 +1511,24 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
     }
     if (sel_all!="") then sel_all="";
     // End selecting
-    
+
     xx=xx+0;yy=__view_get( e__VW.YView, 0 )+0;
-    
+
     if (mouse_x>=xx+1018) and (mouse_y>yy+805) and (mouse_x<xx+1018+141) and (mouse_y<yy+831){
         if (man_size>0) and (sel_loading=0) and (selecting_location!="Terra") and (selecting_location!="Mechanicus Vessel"){// Load to ship
             scr_company_load(selecting_location);
             menu=30;cooldown=8000;top=1;exit;
         }
-        
+
         if (man_size>0) and (sel_loading>=1) and (!instance_exists(obj_star_select)) and (selecting_location!="Terra") and (selecting_location!="Mechanicus Vessel") and (selecting_location!="Warp"){// Unload - ask for planet confirmation
             cooldown=8000;
             var boba;boba=0;
-            
+
             with(obj_temp3){instance_destroy();}
             with(obj_star){if (name=obj_ini.ship_location[obj_controller.selecting_ship]) then instance_create(x,y,obj_temp3);}
-            
+
             if (instance_exists(obj_temp3)){boba=instance_nearest(x,y,obj_star);if (boba.space_hulk=1) and (boba.name=obj_ini.ship_location[obj_controller.selecting_ship]) then with(obj_temp3){instance_destroy();}}
-            
+
             if (instance_exists(obj_temp3)){boba=instance_create(obj_temp3.x,obj_temp3.y,obj_star_select);
                 boba.loading=1;
                 boba.loading_name=obj_ini.ship_location[selecting_ship];// selecting location is the ship right now; get it's orbit location
@@ -1537,14 +1537,14 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
                 scr_company_load(obj_ini.ship_location[selecting_ship]);
             }
             with(obj_temp3){instance_destroy();}
-        
-            
-            
+
+
+
         }
     }
     // Other buttons go here
-    
-    
+
+
     // Change equipment
     if (mouse_x>=xx+1018+141) and (mouse_y>yy+805) and (mouse_x<xx+1297) and (mouse_y<yy+831) and (selecting_location!="Terra") and (selecting_location!="Mechanicus Vessel") and (otha=0){// Change Equipment
         if (man_size>0) and (instance_number(obj_popup)=0){
@@ -1554,27 +1554,41 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
             var vih;vih=0;
             o_wep1="";o_wep2="";o_armor="";o_gear="";o_mobi="";
             b_wep1=0;b_wep2=0;b_armor=0;b_gear=0;b_mobi=0;
-            
-            repeat(man_max){// Need to make sure that no vehicles are selected
+
+            repeat(man_max){// Need to make sure that group selected is all the same type
                 f+=1;
-                
-                if (man[f]="man") and (man_sel[f]=1) and (vih=0) then vih=1;// If come across a man, set vih to 1
-                if (man[f]="vehicle") and (man_sel[f]=1) and (vih=0) then vih=2;// If come across a vehicle, set vih to 2
-                
-                if (man[f]="man") and (man_sel[f]=1) and (vih=2) then vih=-1;// If there is a selected man, and vih=2, then stop
-                if (man[f]="vehicle") and (man_sel[f]=1) and (vih=1) then vih=-1;// If there is a selected vehicle, and vih=1, then stop
-                
+
+                // Set different vih depending on unit type
+                if (man[f]="man") and (man_sel[f]=1) and (ma_role[f]!=obj_ini.role[100,6]) and (ma_role[f]!="Venerable "+string(obj_ini.role[100,6])) and (vih=0) then vih=1;
+                if (ma_role[f]=obj_ini.role[100,6]) and (man_sel[f]=1) and (vih=0) then vih=6;
+                if (ma_role[f]="Venerable "+string(obj_ini.role[100,6])) and (man_sel[f]=1) and (vih=0) then vih=6;
+                if (ma_role[f]="Land Raider") and (man_sel[f]=1) and (vih=0) then vih=50;
+                if (ma_role[f]="Rhino") and (man_sel[f]=1) and (vih=0) then vih=51;
+                if (ma_role[f]="Predator") and (man_sel[f]=1) and (vih=0) then vih=52;
+                if (ma_role[f]="Land Speeder") and (man_sel[f]=1) and (vih=0) then vih=53;
+                if (ma_role[f]="Whirlwind") and (man_sel[f]=1) and (vih=0) then vih=54;
+
+                // Make output invalid if newly selected unit has a different vih than previous ones by setting vih to -1
+                if (man[f]="man") and (man_sel[f]=1) and (ma_role[f]!=obj_ini.role[100,6]) and (ma_role[f]!="Venerable "+string(obj_ini.role[100,6])) and (man_sel[f]=1) and (vih!=1) and (vih!=0) then vih=-1;
+                if (ma_role[f]=obj_ini.role[100,6]) and (man_sel[f]=1) and (vih!=6) and (vih!=0) then vih=-1;
+                if (ma_role[f]="Venerable "+string(obj_ini.role[100,6])) and (man_sel[f]=1) and (vih!=6) and (vih!=0) then vih=-1;
+                if (ma_role[f]="Land Raider") and (man_sel[f]=1) and (vih!=50) and (vih!=0) then vih=-1;
+                if (ma_role[f]="Rhino") and (man_sel[f]=1) and (vih!=51) and (vih!=0) then vih=-1;
+                if (ma_role[f]="Predator") and (man_sel[f]=1) and (vih!=52) and (vih!=0) then vih=-1;
+                if (ma_role[f]="Land Speeder") and (man_sel[f]=1) and (vih!=53) and (vih!=0) then vih=-1;
+                if (ma_role[f]="Whirlwind") and (man_sel[f]=1) and (vih!=54) and (vih!=0) then vih=-1;
+
                 if (man_sel[f]=1) and (vih!=-1){nuuum+=1;
                     if (o_wep1="") and (ma_wep1[f]!="") then o_wep1=ma_wep1[f];
                     if (o_wep2="") and (ma_wep2[f]!="") then o_wep2=ma_wep2[f];
                     if (o_armor="") and (ma_armor[f]!="") then o_armor=ma_armor[f];
                     if (o_gear="") and (ma_gear[f]!="") then o_gear=ma_gear[f];
                     if (o_mobi="") and (ma_mobi[f]!="") then o_mobi=ma_mobi[f];
-                    
+
                     if (ma_wep1[f]="") then b_wep1+=1;if (ma_wep2[f]="") then b_wep2+=1;
                     if (ma_armor[f]="") then b_armor+=1;if (ma_gear[f]="") then b_gear+=1;
                     if (ma_mobi[f]="") then b_mobi+=1;
-                    
+
                     if ((o_wep1!="") and (ma_wep1[f]!=o_wep1)) or (b_wep1=1) then o_wep1="Assortment";
                     if ((o_wep2!="") and (ma_wep2[f]!=o_wep2)) or (b_wep2=1) then o_wep2="Assortment";
                     if ((o_armor!="") and (ma_armor[f]!=o_armor)) or (b_armor=1) then o_armor="Assortment";
@@ -1582,28 +1596,30 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
                     if ((o_mobi!="") and (ma_mobi[f]!=o_mobi)) or (b_mobi=1) then o_mobi="Assortment";
                 }
             }// End repeat
-            
+
             /*if (o_wep1!="") and (string_count("&",o_wep1)>0) then o_wep1=clean_tags(o_wep1);
             if (o_wep2!="") and (string_count("&",o_wep2)>0) then o_wep2=clean_tags(o_wep2);
             if (o_armor!="") and (string_count("&",o_armor)>0) then o_armor=clean_tags(o_armor);
             if (o_gear!="") and (string_count("&",o_gear)>0) then o_gear=clean_tags(o_gear);
             if (o_mobi!="") and (string_count("&",o_mobi)>0) then o_mobi=clean_tags(o_mobi);*/
-            
+
             if (b_wep1=nuuum) then o_wep1="";
             if (b_wep2=nuuum) then o_wep2="";
             if (b_armor=nuuum) then o_armor="";
             if (b_gear=nuuum) then o_gear="";
             if (b_mobi=nuuum) then o_mobi="";
-            
-            // show_message(string(vih));
-            
+
+            //show_message(string(vih));
+
             if (vih>0) and (man_size>0){
                 var pip;pip=instance_create(0,0,obj_popup);pip.type=6;
                 pip.o_wep1=o_wep1;pip.o_wep2=o_wep2;pip.o_armor=o_armor;pip.o_gear=o_gear;
                 pip.n_wep1=o_wep1;pip.n_wep2=o_wep2;pip.n_armor=o_armor;pip.n_gear=o_gear;
                 pip.o_mobi=o_mobi;pip.n_mobi=o_mobi;
-                pip.company=managing;pip.units=nuuum;if (vih=2) then pip.vehicle_equipment=1;
-                
+                pip.company=managing;pip.units=nuuum;
+
+                pip.vehicle_equipment=vih; //Forwards vih selection to the vehicle_equipment variable used in mouse_50 obj_popup and weapons_equip script
+
                 if (o_wep1!="") and (string_count("&",o_wep1)>0) then pip.a_wep1=clean_tags(o_wep1);
                 if (o_wep2!="") and (string_count("&",o_wep2)>0) then pip.a_wep2=clean_tags(o_wep2);
                 if (o_armor!="") and (string_count("&",o_armor)>0) then pip.a_armor=clean_tags(o_armor);
@@ -1612,29 +1628,29 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
             }
         }
     }
-    
+
     // Reset equipment
     if (mouse_x>=xx+1018+141) and (mouse_y>yy+805-26) and (mouse_x<xx+1297) and (mouse_y<yy+831-26) and (selecting_location!="Terra") and (selecting_location!="Mechanicus Vessel") and (man_size>0){// Reset Equipment
         var f,god,nuuum;f=0;god=0;nuuum=0;
         o_wep1="";o_wep2="";o_armor="";o_gear="";o_mobi="";
         b_wep1=0;b_wep2=0;b_armor=0;b_gear=0;b_mobi=0;
-        
+
         repeat(man_max){f+=1;
             if (man[f]="man") and (man_sel[f]=1) then nuuum+=1;// If come across a man, set vih to 1
         }
-    
+
         var pip;pip=instance_create(0,0,obj_popup);pip.type=6;
         pip.o_wep1="Assortment";pip.o_wep2="Assortment";pip.o_armor="Assortment";pip.o_gear="Assortment";pip.o_mobi="Assortment";
         pip.n_wep1="Assortment";pip.n_wep2="Assortment";pip.n_armor="Assortment";pip.n_gear="Assortment";pip.n_mobi="Assortment";
         pip.company=managing;pip.units=nuuum;pip.alarm[1]=1;
     }
-    
+
     // Promote
     if (mouse_x>=xx+1297) and (mouse_y>yy+805) and (mouse_x<xx+1436) and (mouse_y<yy+831) and (selecting_location!="Terra") and (selecting_location!="Mechanicus Vessel") and (man_size>0){// Promote
         if (sel_promoting=1) and (instance_number(obj_popup)=0){// and (managing>=0) and (managing<11){
             var pip;pip=instance_create(0,0,obj_popup);
             pip.type=5;pip.company=managing;
-            
+
             var f,god,nuuum;f=0;god=0;nuuum=0;
             repeat(man_max){
                 f+=1;
@@ -1648,8 +1664,8 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
             pip.units=nuuum;
         }
     }
-    
-    
+
+
     if (mouse_x>=xx+1438) and (mouse_y>=yy+803) and (mouse_x<xx+1578) and (mouse_y<yy+831) and (man_size>0){var f;f=0;// Jail
         repeat(man_max){f+=1;
             if (man[f]="man") and (man_sel[f]=1) and (ma_loc[f]!="Terra") and (ma_loc[f]!="Mechanicus Vessel"){
@@ -1672,8 +1688,8 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
             cooldown=8000;sel_loading=0;unload=0;alarm[6]=7;
         }
     }
-    
-    
+
+
     // Add bionics to marine(s)
     if (scr_hit(xx+1300+141,yy+779,xx+1436+141,yy+801)=true) and (man_size>0) and (cooldown<=0){
         var bionics_before,bionics_after,p,cah;
@@ -1690,11 +1706,11 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
                 }
             }
         }
-        
+
         if (bionics_before!=bionics_after){click=1;scr_add_item("Bionics",bionics_after-bionics_before);}
     }
-    
-    
+
+
     // Set boarders; simple as that
     if (scr_hit(xx+1018,yy+779,xx+1018+141,yy+801)=true) and (man_size>0) and (cooldown<=0){
         var p,cah;p=0;cooldown=8000;cah=managing;if (cah>10) then cah=0;temp[114]="refresh";
@@ -1709,16 +1725,16 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
             }
         }
     }
-    
-    
-    
-    
-    
+
+
+
+
+
     if (mouse_x>=xx+1297) and (mouse_y>yy+777) and (mouse_x<xx+1436) and (mouse_y<yy+804) and (selecting_location!="Terra") and (selecting_location!="Mechanicus Vessel") and (man_size>0){// Transfer
         if (instance_number(obj_popup)=0){// and (managing>=0) and (managing<11){
             var pip;pip=instance_create(0,0,obj_popup);
             pip.type=5.1;pip.company=managing;
-            
+
             var f,god,nuuum,nuuum2,checky,check_number;f=0;god=0;nuuum=0;nuuum2=0;checky=0;check_number=0;
             repeat(man_max){f+=1;
                 if (god=0) and (man_sel[f]=1) and (man[f]="man"){god=1;pip.unit_role=ma_role[f];}
@@ -1743,12 +1759,12 @@ if (menu=1) and (managing>0){                       // Selecting individual mari
             if (nuuum>0) and (check_number>0){if (obj_controller.command_set[1]=0){cooldown=8000;with(pip){instance_destroy();}}}
         }
     }
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
 }
 
 
@@ -1760,30 +1776,30 @@ if (menu=30) and (managing>0){// Selecting the ship
     yy=yy+0;
     var top,sel,temp1,temp2,temp3,temp4,temp5;temp1="";temp2="";temp3="";temp4="";temp5="";
     top=ship_current;var stop;stop=0;sel=top;
-    
+
     var wombat;wombat=0;
     sel_uid=sh_uid[sel];
-    
+
     yy=yy+77;
-    
+
     if (cooldown<=0) then repeat(min(ship_max,ship_see)){
-        
+
         if (mouse_x>=xx+25+8) and (mouse_y>=yy+64) and (mouse_x<xx+974) and (mouse_y<yy+85) and (cooldown<=0) and (((sh_cargo[sel]+man_size)<=sh_cargo_max[sel])){
             var onceh, q;onceh=0;stop=0;q=0;
-            
+
             repeat(500){q+=1;
                 if (man[q]="man") and (ma_loc[q]=selecting_location) and (sh_loc[sel]=selecting_location){// load man to ship
                     if ((sh_cargo[sel]+man_size)<=sh_cargo_max[sel]) and (man_sel[q]!=0){
-                    
-                        
+
+
                         wombat=sel;
-                        
+
                         ma_loc[q]=sh_name[sel];
                         ma_lid[q]=sh_ide[sel];
                         ma_wid[q]=0;
                         ma_uid[q]=sh_uid[sel];
-                        
-                        
+
+
                         if (managing<=10){
                             loc[managing,q]=sh_name[sel];obj_ini.lid[managing,ide[q]]=sh_ide[sel];obj_ini.wid[managing,ide[q]]=0;
                             obj_ini.uid[managing,ide[q]]=sel_uid;
@@ -1792,25 +1808,25 @@ if (menu=30) and (managing>0){// Selecting the ship
                             loc[0,q]=sh_name[sel];obj_ini.lid[0,ide[q]]=sh_ide[sel];obj_ini.wid[0,ide[q]]=0;
                             obj_ini.uid[0,ide[q]]=sel_uid;
                         }
-                        
-                        
+
+
                     }
                 }
                 if (man[q]="vehicle") and (ma_loc[q]=selecting_location) and (sh_loc[sel]=selecting_location){// load vehicle to ship
                     if ((sh_cargo[sel]+man_size)<=sh_cargo_max[sel]) and (man_sel[q]!=0){
-                    
+
                         wombat=sel;
-                        
+
                         ma_loc[q]=sh_name[sel];
                         ma_lid[q]=sh_ide[sel];
                         ma_wid[q]=0;
                         ma_uid[q]=sh_uid[sel];
                         veh_loc[managing,q]=sh_name[sel];
-                        
-                        
+
+
                         // if (managing<=10){obj_ini.veh_lid[managing,ide[q]]=sel;obj_ini.veh_wid[managing,ide[q]]=0;}
                         // if (managing>10){obj_ini.veh_lid[0,ide[q]]=sel;obj_ini.veh_wid[0,ide[q]]=0;}
-                        
+
                         if (managing<=10){
                             obj_ini.veh_lid[managing,ide[q]]=sh_ide[sel];obj_ini.veh_wid[managing,ide[q]]=0;
                             obj_ini.veh_uid[managing,ide[q]]=sel_uid;
@@ -1819,69 +1835,69 @@ if (menu=30) and (managing>0){// Selecting the ship
                             obj_ini.veh_lid[0,ide[q]]=sh_ide[sel];obj_ini.veh_wid[0,ide[q]]=0;
                             obj_ini.veh_uid[0,ide[q]]=sel_uid;
                         }
-                        
+
                     }
                 }
             }
-            
+
             // Right here decrease the size of stuff on that planet
             // Need to find the obj_star that the controller is loading from
-            
+
             var xb, yb, god, tiber;
             xb=0;yb=0;god=0;tiber=0;
-            
+
             repeat(200){
                 if (god=0){
                     xb=random(room_width);
                     yb=random(room_height);
                     tiber=instance_nearest(xb,yb,obj_star);
-                    
+
                     if (tiber.name=selecting_location) then god=1;
                     if (tiber.name!=selecting_location) then instance_deactivate_object(tiber);
                 }
             }
-            
+
             if (god=1){
                 tiber.p_player[selecting_planet]-=man_size;
                 // 135;
                 // also need the wid here
             }
-            
+
             instance_activate_object(obj_star);
-            
-            
-            
-            
-            
+
+
+
+
+
             /*
             with(obj_star_select){// This marks that there are forces upon this planet
                 if (p_player[obj_controller.unload]=0) then p_player[obj_controller.unload]+=obj_controller.man_size;
             }
             */
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
             obj_ini.ship_carrying[sh_ide[sel]]+=man_size;
-            
+
             man_size=0;man_current=1;
             menu=1;cooldown=8;
-            
+
             var k;k=0;repeat(500){k+=1;man_sel[k]=0;}
-            
+
         }
         yy+=20;
         sel+=1;
-        
+
     }
     // End selecting
-    
-    
-    
-    
-    
+
+
+
+
+
     xx=xx+0;
     yy=yy+0;
 }

--- a/objects/obj_popup/Mouse_50.gml
+++ b/objects/obj_popup/Mouse_50.gml
@@ -38,7 +38,7 @@ if (option1="") and (type<5){
 
 if (type>4) and (type!=9) and (cooldown<=0){
     var xx,yy;xx=__view_get( e__VW.XView, 0 );yy=__view_get( e__VW.YView, 0 );
-    
+
     if (mouse_x>=xx+1006) and (mouse_y>=yy+499) and (mouse_x<=xx+1116) and (mouse_y<yy+519){
         obj_controller.cooldown=10;
         instance_destroy();exit;
@@ -52,10 +52,10 @@ if (type=5.1) and (cooldown<=0){
     xx=__view_get( e__VW.XView, 0 );yy=__view_get( e__VW.YView, 0 );
     before=target_comp;
     before2=target_role;
-    
+
     if (mouse_y>=yy+210) and (mouse_y<yy+230){
         if (mouse_x>=xx+1468) and (mouse_x<=xx+1515){target_comp=0;cooldown=8000;}
-    }    
+    }
     if (mouse_y>=yy+230) and (mouse_y<yy+250){
         if (mouse_x>=xx+1030) and (mouse_x<=xx+1120){target_comp=1;cooldown=8000;}
         if (mouse_x>=xx+1140) and (mouse_x<=xx+1230){target_comp=2;cooldown=8000;}
@@ -71,17 +71,17 @@ if (type=5.1) and (cooldown<=0){
         if (mouse_x>=xx+1470) and (mouse_x<=xx+1560){target_comp=10;cooldown=8000;}
     }
 }
-   
+
 if (type=5) and (cooldown<=0){
     var xx,yy,before,before2;
     xx=__view_get( e__VW.XView, 0 );yy=__view_get( e__VW.YView, 0 );
     before=target_comp;
     before2=target_role;
-    
+
     /*if (unit_role=obj_ini.role[100,17]) and (obj_controller.command_set[1]!=0){
         if (mouse_y>=yy+210) and (mouse_y<yy+230){
             if (mouse_x>=xx+1468) and (mouse_x<=xx+1515) and (min_exp>=0){target_comp=0;cooldown=8000;}
-        }    
+        }
         if (mouse_y>=yy+230) and (mouse_y<yy+250) and (unit_role!="Lexicanum") and (unit_role!="Codiciery"){
             if (mouse_x>=xx+1030) and (mouse_x<=xx+1120) and (min_exp>=0){target_comp=1;cooldown=8000;}
             if (mouse_x>=xx+1140) and (mouse_x<=xx+1230) and (min_exp>=0){target_comp=2;cooldown=8000;}
@@ -97,11 +97,11 @@ if (type=5) and (cooldown<=0){
             if (mouse_x>=xx+1470) and (mouse_x<=xx+1560) and (min_exp>=0){target_comp=10;cooldown=8000;}
         }
     }*/
-    
+
     if (unit_role!=obj_ini.role[100,17]) or (obj_controller.command_set[1]!=0){
         if (mouse_y>=yy+210) and (mouse_y<yy+230){
             if (mouse_x>=xx+1468) and (mouse_x<=xx+1515) and (min_exp>=0){target_comp=0;cooldown=8000;}
-        }    
+        }
         if (mouse_y>=yy+230) and (mouse_y<yy+250) and (unit_role!="Lexicanum") and (unit_role!="Codiciery"){
             if (mouse_x>=xx+1030) and (mouse_x<=xx+1120) and (min_exp>=80){target_comp=1;cooldown=8000;}
             if (mouse_x>=xx+1140) and (mouse_x<=xx+1230) and (min_exp>=70){target_comp=2;cooldown=8000;}
@@ -117,7 +117,7 @@ if (type=5) and (cooldown<=0){
             if (mouse_x>=xx+1470) and (mouse_x<=xx+1560) and (min_exp>=0){target_comp=10;cooldown=8000;}
         }
     }
-    
+
     if (mouse_y>=yy+310) and (mouse_y<yy+330) and (type=5){
         if (mouse_x>=xx+1030) and (mouse_x<xx+1180) and (min_exp>=role_exp[1]) and (role_name[1]!=""){target_role=1;cooldown=8;}
         if (mouse_x>=xx+1200) and (mouse_x<xx+1350) and (min_exp>=role_exp[2]) and (role_name[2]!=""){target_role=2;cooldown=8;}
@@ -129,10 +129,10 @@ if (type=5) and (cooldown<=0){
         if (mouse_x>=xx+1370) and (mouse_x<xx+1520) and (min_exp>=role_exp[6]) and (role_name[6]!=""){target_role=6;cooldown=8;}
     }
 
-    
+
     if (before!=target_comp) and (type=5){
         var i,cap,bear,spec,champ;i=0;cap=0;bear=0;spec=0;champ=0;
-    
+
         var i;i=-1;
         repeat(10){i+=1;role_name[i]="";role_exp[i]=0;}
         req_armor="";req_armor_num=0;
@@ -140,12 +140,12 @@ if (type=5) and (cooldown<=0){
         req_mobi="";req_mobi_num=0;
         req_wep1="";req_wep1_num=0;
         req_wep2="";req_wep2_num=0;
-        
+
         if (unit_role=obj_ini.role[100,16]){role_name[1]=obj_ini.role[100,16];role_exp[1]=5;spec=1;}
         if (unit_role=obj_ini.role[100,15]){role_name[1]=obj_ini.role[100,15];role_exp[1]=5;spec=1;}
         if (unit_role=obj_ini.role[100,6]){role_name[1]="Venerable "+string(obj_ini.role[100,6]);role_exp[1]=400;spec=0;}
-        
-        
+
+
         if (unit_role=obj_ini.role[100,14]) and (global.chapter_name!="Space Wolves") and (global.chapter_name!="Iron Hands"){role_name[1]=obj_ini.role[100,14];role_exp[1]=5;spec=1;}
         if (unit_role="Lexicanum") and (target_comp=0){
             role_name[1]=obj_ini.role[100,17];role_exp[1]=125;spec=1;
@@ -154,13 +154,13 @@ if (type=5) and (cooldown<=0){
         if (unit_role="Codiciery") and (target_comp=0){
             role_name[1]=obj_ini.role[100,17];role_exp[1]=125;spec=1;
         }
-        
-        
+
+
         if ((target_comp=0) or (target_comp>10)) and (spec=0){
             i=0;cap=0;bear=0;champ=0;
             i+=1;role_name[i]=obj_ini.role[100,2];role_exp[i]=90;// 136;
         }
-        
+
         if (target_comp=1) and (spec=0){
             i=0;cap=0;bear=0;champ=0;
             if (units=1){cap=scr_role_count(obj_ini.role[100,5],"1");if (cap=0){i+=1;role_name[i]=obj_ini.role[100,5];role_exp[i]=100;}}
@@ -171,7 +171,7 @@ if (type=5) and (cooldown<=0){
             i+=1;role_name[i]=obj_ini.role[100,3];role_exp[i]=80;
             if (units=1){i+=1;role_name[i]=obj_ini.role[100,6];role_exp[i]=80;}
         }
-        
+
         if (target_comp=2) and (spec=0){
             i=0;cap=0;bear=0;champ=0;
             if (units=1){cap=scr_role_count(obj_ini.role[100,5],"2");if (cap=0){i+=1;role_name[i]=obj_ini.role[100,5];role_exp[i]=80;}}
@@ -182,7 +182,7 @@ if (type=5) and (cooldown<=0){
             i+=1;role_name[i]=obj_ini.role[100,9];role_exp[i]=70;
             if (units=1){i+=1;role_name[i]=obj_ini.role[100,6];role_exp[i]=75;}
         }
-        
+
         if (target_comp=3) and (spec=0){
             i=0;cap=0;bear=0;champ=0;
             if (units=1){cap=scr_role_count(obj_ini.role[100,5],"3");if (cap=0){i+=1;role_name[i]=obj_ini.role[100,5];role_exp[i]=70;}}
@@ -193,7 +193,7 @@ if (type=5) and (cooldown<=0){
             i+=1;role_name[i]=obj_ini.role[100,9];role_exp[i]=60;
             if (units=1){i+=1;role_name[i]=obj_ini.role[100,6];role_exp[i]=60;}
         }
-        
+
         if (target_comp=4) and (spec=0){
             i=0;cap=0;bear=0;champ=0;
             if (units=1){cap=scr_role_count(obj_ini.role[100,5],"4");if (cap=0){i+=1;role_name[i]=obj_ini.role[100,5];role_exp[i]=60;}}
@@ -204,7 +204,7 @@ if (type=5) and (cooldown<=0){
             i+=1;role_name[i]=obj_ini.role[100,9];role_exp[i]=50;
             if (units=1){i+=1;role_name[i]=obj_ini.role[100,6];role_exp[i]=50;}
         }
-        
+
         if (target_comp=5) and (spec=0){
             i=0;cap=0;bear=0;champ=0;
             if (units=1){cap=scr_role_count(obj_ini.role[100,5],"5");if (cap=0){i+=1;role_name[i]=obj_ini.role[100,5];role_exp[i]=50;}}
@@ -215,7 +215,7 @@ if (type=5) and (cooldown<=0){
             i+=1;role_name[i]=obj_ini.role[100,9];role_exp[i]=40;
             if (units=1){i+=1;role_name[i]=obj_ini.role[100,6];role_exp[i]=40;}
         }
-        
+
         if (target_comp=6) and (spec=0){
             i=0;cap=0;bear=0;champ=0;
             if (units=1){cap=scr_role_count(obj_ini.role[100,5],"6");if (cap=0){i+=1;role_name[i]=obj_ini.role[100,5];role_exp[i]=45;}}
@@ -224,7 +224,7 @@ if (type=5) and (cooldown<=0){
             i+=1;role_name[i]=obj_ini.role[100,8];role_exp[i]=35;
             if (units=1){i+=1;role_name[i]=obj_ini.role[100,6];role_exp[i]=35;}
         }
-        
+
         if (target_comp=7) and (spec=0){
             i=0;cap=0;bear=0;champ=0;
             if (units=1){cap=scr_role_count(obj_ini.role[100,5],"7");if (cap=0){i+=1;role_name[i]=obj_ini.role[100,5];role_exp[i]=40;}}
@@ -233,7 +233,7 @@ if (type=5) and (cooldown<=0){
             i+=1;role_name[i]=obj_ini.role[100,8];role_exp[i]=30;
             if (units=1){i+=1;role_name[i]=obj_ini.role[100,6];role_exp[i]=30;}
         }
-        
+
         if (target_comp=8) and (spec=0){
             i=0;cap=0;bear=0;champ=0;
             if (units=1){cap=scr_role_count(obj_ini.role[100,5],"8");if (cap=0){i+=1;role_name[i]=obj_ini.role[100,5];role_exp[i]=40;}}
@@ -242,7 +242,7 @@ if (type=5) and (cooldown<=0){
             i+=1;role_name[i]=obj_ini.role[100,10];role_exp[i]=25;
             if (units=1){i+=1;role_name[i]=obj_ini.role[100,6];role_exp[i]=25;}
         }
-        
+
         if (target_comp=9) and (spec=0){
             i=0;cap=0;bear=0;champ=0;
             if (units=1){cap=scr_role_count(obj_ini.role[100,5],"9");if (cap=0){i+=1;role_name[i]=obj_ini.role[100,5];role_exp[i]=40;}}
@@ -251,7 +251,7 @@ if (type=5) and (cooldown<=0){
             i+=1;role_name[i]=obj_ini.role[100,9];role_exp[i]=20;
             if (units=1){i+=1;role_name[i]=obj_ini.role[100,6];role_exp[i]=20;}
         }
-        
+
         if (target_comp=10) and (spec=0){
             i=0;cap=0;bear=0;champ=0;
             if (units=1){cap=scr_role_count(obj_ini.role[100,5],"10");if (cap=0){i+=1;role_name[i]=obj_ini.role[100,5];role_exp[i]=40;}}
@@ -259,48 +259,48 @@ if (type=5) and (cooldown<=0){
             if (units=1){champ=scr_role_count(obj_ini.role[100,7],"10");if (champ=0){i+=1;role_name[i]=obj_ini.role[100,7];role_exp[i]=120;}}
             i+=1;role_name[i]=obj_ini.role[100,12];role_exp[i]=0;
         }
-        
-        
-        
+
+
+
         var huj;huj=1;
         if (unit_role=obj_ini.role[100,5]){
             huj-=scr_role_count(obj_ini.role[100,5],string(target_comp));
             huj-=scr_role_count("Company Champion",string(target_comp));
         }
         if (huj=1) and (target_comp!=0){i+=1;role_name[i]="DoNotChange";}
-        
+
         target_role=0;all_good=0;
-        
-        
+
+
         if (obj_controller.command_set[2]=1){var w;w=0;
             repeat(10){w+=1;if (role_name[w]!="") and (role_exp[w]>5) then role_exp[w]=5;}
         }
-        
+
         /* More elaborate checking here; the EXP should be the minimum for that company.
         If any of the units are captain, dread, special, etc. then it should be greyed out.*/
-        
+
     }
-    
-    
-    
+
+
+
     if (before2!=target_role) and (type=5){
         var i,rall;i=0;rall="";all_good=0;
-        
+
         req_armor="";req_armor_num=0;have_armor_num=0;
         req_gear="";req_gear_num=0;have_gear_num=0;
         req_mobi="";req_mobi_num=0;have_mobi_num=0;
         req_wep1="";req_wep1_num=0;have_wep1_num=0;
         req_wep2="";req_wep2_num=0;have_wep2_num=0;
-        
+
         rall=role_name[target_role];
-        
+
         if (rall=obj_ini.role[100,14]) and (global.chapter_name!="Space Wolves") and (global.chapter_name!="Iron Hands"){req_armor="";req_armor_num=0;req_wep1="";req_wep1_num=0;req_wep2="";req_wep2_num=0;req_mobi="";req_mobi_num=0;}
         if (rall=obj_ini.role[100,15]){req_armor="";req_armor_num=0;req_wep1="";req_wep1_num=0;req_wep2="";req_wep2_num=0;req_mobi="";req_mobi_num=0;}
-        
+
         if (rall=obj_ini.role[100,17]){req_armor="";req_armor_num=0;req_wep1=obj_ini.wep1[100,17];req_wep1_num=units;req_wep2=obj_ini.wep2[100,17];req_wep2_num=units;req_gear=obj_ini.gear[100,17];req_gear_num=units;}
         if (rall="Codiciery"){req_armor="";req_armor_num=0;req_wep1="";req_wep1_num=0;req_wep2="";req_wep2_num=0;req_mobi="";req_mobi_num=0;req_gear=obj_ini.gear[100,17];req_gear_num=units;}
         if (rall="Lexicanum"){req_armor="";req_armor_num=0;req_wep1="";req_wep1_num=0;req_wep2="";req_wep2_num=0;req_mobi="";req_mobi_num=0;}
-                
+
         if (rall=obj_ini.role[100,5]){req_armor=obj_ini.armor[100,5];req_armor_num=units;req_wep1="Chainsword";req_wep1_num=units;req_wep2="Bolt Pistol";req_wep2_num=units;}
         if (rall="Standard Bearer"){req_armor="Power Armor";req_armor_num=units;req_wep2="Company Standard";req_wep2_num=units;}
         if (rall=obj_ini.role[100,3]){req_armor=obj_ini.armor[100,3];req_armor_num=units;req_wep1=obj_ini.wep1[100,3];req_wep1_num=units;req_wep2=obj_ini.wep2[100,3];req_wep2_num=units;}
@@ -308,40 +308,40 @@ if (type=5) and (cooldown<=0){
         if (rall=obj_ini.role[100,8]){req_armor=obj_ini.armor[100,8];req_armor_num=units;req_wep1=obj_ini.wep1[100,8];req_wep1_num=units;req_wep2=obj_ini.wep2[100,8];req_wep2_num=units;}
         if (rall=obj_ini.role[100,9]){req_armor=obj_ini.armor[100,9];req_armor_num=units;req_wep1=obj_ini.wep1[100,9];req_wep1_num=units;req_wep2=obj_ini.wep2[100,9];req_wep2_num=units;}
         if (rall=obj_ini.role[100,10]){req_armor=obj_ini.armor[100,10];req_armor_num=units;req_wep1=obj_ini.wep1[100,10];req_wep1_num=units;req_wep2=obj_ini.wep2[100,10];req_wep2_num=units;req_mobi="Jump Pack";req_mobi_num=units;}
-        
+
         if (rall=obj_ini.role[100,2]){req_wep1=obj_ini.wep1[100,2];req_wep1_num=units;req_wep2=obj_ini.wep2[100,2];req_wep2_num=units;req_mobi=obj_ini.mobi[100,2];req_mobi_num=units;}
-        
+
         if (rall=obj_ini.role[100,6]){req_armor="Dreadnought";req_armor_num=units;req_wep1=obj_ini.wep1[100,6];req_wep1_num=units;req_wep2=obj_ini.wep2[100,6];req_wep2_num=units;}
         if (rall="Venerable "+string(obj_ini.role[100,6])){req_armor="";req_armor_num=0;req_wep1="";req_wep1_num=0;req_wep2="";req_wep2_num=0;}
-        
-        
-        
+
+
+
         repeat(obj_controller.man_max){
             i+=1;
-            
+
             if (obj_controller.man[i]!="") and (obj_controller.man_sel[i]=1) and (obj_controller.ma_promote[i]=1) and (obj_controller.ma_exp[i]>=min_exp){
                 if (req_armor="Power Armor"){
                     if (obj_controller.ma_armor[i]="MK3 Iron Armor") or (obj_controller.ma_armor[i]="MK4 Maximus") or (obj_controller.ma_armor[i]="MK6 Corvus") then have_armor_num+=1;
                     if (obj_controller.ma_armor[i]="MK7 Aquila") or (obj_controller.ma_armor[i]="Power Armor") then have_armor_num+=1;
                 }
                 if (req_armor="Terminator Armor"){if (obj_controller.ma_armor[i]="Terminator Armor") or (obj_controller.ma_armor[i]="Tartaros") then have_armor_num+=1;}
-                
+
                 if (obj_controller.ma_wep1[i]=req_wep1) or (obj_controller.ma_wep2[i]=req_wep1) then have_wep1_num+=1;
                 if (obj_controller.ma_wep2[i]=req_wep2) or (obj_controller.ma_wep1[i]=req_wep2) then have_wep2_num+=1;
-                
-                
+
+
                 if (obj_controller.ma_gear[i]=req_gear) then have_gear_num+=1;
                 if (obj_controller.ma_mobi[i]=req_mobi) then have_mobi_num+=1;
-                
+
                 if (req_wep1="Heavy Ranged"){
                     if (obj_controller.ma_wep1[i]="Heavy Bolter") or (obj_controller.ma_wep1[i]="Lascannon") or (obj_controller.ma_wep1[i]="Missile Launcher") then have_wep1_num+=1;
                 }
             }
-            
+
             // if (n_wep1=n_wep2) and ((o_wep1!=n_wep1) or (o_wep2!=n_wep2)){have_wep1_num-=1;have_wep2_num-=1;}
-            
+
         }// End Repeat
-        
+
         // This checks to see if there is any more in the armory
         if (req_armor="Power Armor"){
             have_armor_num+=scr_item_count("MK3 Iron Armor");
@@ -355,7 +355,7 @@ if (type=5) and (cooldown<=0){
             have_armor_num+=scr_item_count("Tartaros");
         }
         if (req_armor="Dreadnought") then have_armor_num+=scr_item_count("Dreadnought");
-        
+
         if (req_wep1!="Heavy Ranged") then have_wep1_num+=scr_item_count(string(req_wep1));
         if (req_wep2!="Heavy Ranged") then have_wep2_num+=scr_item_count(string(req_wep2));
         if (req_wep1="Heavy Ranged"){
@@ -370,7 +370,7 @@ if (type=5) and (cooldown<=0){
         }
         if (req_gear!="") then have_gear_num+=scr_item_count(string(req_gear));
         if (req_mobi!="") then have_mobi_num+=scr_item_count(string(req_mobi));
-        
+
         if ((have_armor_num>=req_armor_num) or (req_armor="")) and ((have_wep1_num>=req_wep1_num) or (req_wep1="")) and ((have_wep2_num>=req_wep2_num) or (req_wep2="")) then all_good=0.4;
         if (req_gear="") or (req_gear_num<=have_gear_num) then all_good+=0.3;
         if (req_mobi="") or (req_mobi_num<=have_mobi_num) then all_good+=0.3;
@@ -386,7 +386,7 @@ change_tab=0;
 
 
 if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<yy+518){// Transfering right here
-    
+
     if (type=5.1){
         if (target_comp>10) then target_comp=0;
         if (company>10) then company=0;
@@ -395,10 +395,10 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
     }
     if (type=5.1) and (cooldown<=0) and (company!=target_comp) and (target_comp!=-1){
         cooldown=999;obj_controller.cooldown=8000;
-        
+
         var mahreens,w,god,vehi,god2;
         mahreens=0;w=0;god=0;vehi=0;god2=0;
-        
+
         repeat(300){w+=1; // Gets the number of marines in the target company
 			if (god=0) and (obj_ini.name[target_comp,w]=""){god=1;mahreens=w;}
 		}
@@ -406,9 +406,9 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
         repeat(100){w+=1; // Gets the number of vehicles in the target company
 			if (god2=0) and (obj_ini.veh_role[target_comp,w]=""){god2=1;vehi=w;}
 		}
-        
+
         // The MAHREENS and TARGET/FROM seems to check out
-        
+
         w=0;
         repeat(300){w+=1;
             if (obj_controller.man[w]="man") and (obj_controller.man_sel[w]=1){
@@ -432,11 +432,11 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
                 obj_ini.wid[target_comp,mahreens]=obj_ini.wid[company,obj_controller.ide[w]];
                 obj_ini.bio[target_comp,mahreens]=obj_ini.bio[company,obj_controller.ide[w]];
                 obj_ini.spe[target_comp,mahreens]=obj_ini.spe[company,obj_controller.ide[w]];
-                
+
                 // This is pulling the name, correctly, and showing the right target CO/ID
                 // show_message("Marine Number "+string(obj_controller.ide[w])+", Name: "+string(obj_ini.name[company,obj_controller.ide[w]])+", being moved to "+string(target_comp)+"/"+string(mahreens));
                 // show_message("Moved to slot number: "+string(target_comp)+"/"+string(mahreens)+", that slot's Name: "+string(obj_ini.name[target_comp,mahreens]));
-                
+
                 // Clear variables here
                 obj_ini.race[company,obj_controller.ide[w]]=0;
                 obj_ini.loc[company,obj_controller.ide[w]]="";
@@ -460,7 +460,7 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
             }
             if (obj_controller.man[w]="vehicle") and (obj_controller.man_sel[w]=1){// This seems to execute the correct number of times
                 var check;check=0;
-                
+
                 obj_ini.veh_race[target_comp,vehi]=obj_ini.veh_race[company,obj_controller.ide[w]];
                 obj_ini.veh_loc[target_comp,vehi]=obj_ini.veh_loc[company,obj_controller.ide[w]];
                 obj_ini.veh_role[target_comp,vehi]=obj_ini.veh_role[company,obj_controller.ide[w]];
@@ -472,21 +472,21 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
                 obj_ini.veh_pilots[target_comp,vehi]=0;
                 obj_ini.veh_lid[target_comp,vehi]=obj_ini.veh_lid[company,obj_controller.ide[w]];
                 obj_ini.veh_wid[target_comp,vehi]=obj_ini.veh_wid[company,obj_controller.ide[w]];
-                
+
                 obj_ini.veh_race[company,obj_controller.ide[w]]=0;obj_ini.veh_loc[company,obj_controller.ide[w]]="";
                 obj_ini.veh_role[company,obj_controller.ide[w]]="";obj_ini.veh_wep1[company,obj_controller.ide[w]]="";
                 obj_ini.veh_wep2[company,obj_controller.ide[w]]="";obj_ini.veh_upgrade[company,obj_controller.ide[w]]="";
                 obj_ini.veh_hp[company,obj_controller.ide[w]]=0;obj_ini.veh_chaos[company,obj_controller.ide[w]]=0;
                 obj_ini.veh_pilots[company,obj_controller.ide[w]]=0;obj_ini.veh_lid[company,obj_controller.ide[w]]=0;
                 obj_ini.veh_wid[company,obj_controller.ide[w]]=0;
-                
+
                 vehi+=1;
             }
-            
+
         }
-        
+
         // Check this
-        
+
         with(obj_controller){scr_management(1);}
         obj_ini.heh1=company;obj_ini.heh2=target_comp;
         with(obj_ini){
@@ -495,7 +495,7 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
             scr_vehicle_order(heh1);
             scr_vehicle_order(heh2);
         }
-        
+
         with(obj_controller){
             // man_current=0;
             var i;i=-1;man_size=0;selecting_location="";selecting_types="";selecting_ship=0;
@@ -510,9 +510,9 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
             if (managing>10) or (managing=0) then scr_special_view(managing);
             cooldown=10;sel_loading=0;unload=0;alarm[6]=30;
         }
-        
+
         with(obj_managment_panel){instance_destroy();}
-        
+
         obj_controller.cooldown=10;
         instance_destroy();
     }
@@ -536,11 +536,11 @@ if (type=6) and (cooldown<=0){// Actually changing equipment right here
             if (onceh=0) and (master_crafted=1){master_crafted=0;obj_controller.popup_master_crafted=0;onceh=1;scr_weapons_equip();}
         }
     }
-    
-    
+
+
     if ((mouse_x>=xx+1296) and (mouse_x<xx+1578)) or (change_tab=1){
         var befi;befi=target_comp;
-        
+
         if (change_tab=0){
             if (mouse_y>=yy+220) and (mouse_y<yy+240){target_comp=1;cooldown=8000;tab=obj_controller.last_weapons_tab;}
             if (mouse_y>=yy+240) and (mouse_y<yy+260){target_comp=2;cooldown=8000;tab=obj_controller.last_weapons_tab;}
@@ -548,20 +548,20 @@ if (type=6) and (cooldown<=0){// Actually changing equipment right here
             if (mouse_y>=yy+280) and (mouse_y<yy+300){target_comp=4;cooldown=8000;}
             if (mouse_y>=yy+300) and (mouse_y<yy+320){target_comp=5;cooldown=8000;}
         }
-        
-        if ((befi!=target_comp) and (vehicle_equipment=0)) or (change_tab=1){
+
+        if ((befi!=target_comp) and (vehicle_equipment!=-1)) or (change_tab=1){
             var i;i=0;repeat(40){i+=1;item_name[i]="";}
-            
+
             scr_weapons_equip();
-            
+
         }
-        
-        
-        
+
+
+
     }
-    
-    
-    
+
+
+
     var top;top=0;
     if (mouse_x>=xx+1016) and (mouse_x<xx+1160){
         if (mouse_y>=yy+335) and (mouse_y<yy+355) and (item_name[1]!=""){top=1;cooldown=8000;}
@@ -599,9 +599,9 @@ if (type=6) and (cooldown<=0){// Actually changing equipment right here
         if (mouse_y>=yy+435) and (mouse_y<yy+455) and (item_name[27]!=""){top=27;cooldown=8000;}
         if (mouse_y>=yy+455) and (mouse_y<yy+475) and (item_name[28]!=""){top=28;cooldown=8000;}
     }
-    
-    
-    
+
+
+
     if (top!=0){
         warning="";// Add have right here?
         if (target_comp=1){n_wep1=item_name[top];sel1=top;}
@@ -610,37 +610,35 @@ if (type=6) and (cooldown<=0){// Actually changing equipment right here
         if (target_comp=4){n_gear=item_name[top];sel4=top;}
         if (target_comp=5){n_mobi=item_name[top];sel5=top;}
     }
-    
+
     if (target_comp=1) and ((n_wep1="(None)") or (n_wep1="")){n_good1=1;}
     if (target_comp=2) and ((n_wep2="(None)") or (n_wep2="")){n_good2=1;}
     if (target_comp=3) and ((n_armor="(None)") or (n_armor="")){n_good2=1;}
     if (target_comp=4) and ((n_gear="(None)") or (n_gear="")){n_good4=1;}
     if (target_comp=5) and ((n_mobi="(None)") or (n_mobi="")){n_good5=1;}
     // Removed EXIT; from each of these
-    
-    
+
+
     // if (n_wep1=n_wep2){if (o_wep1=n_wep1) and (o_wep2!=n_wep2) then have_wep2_num-=1;if (o_wep2=n_wep2) and (o_wep1!=n_wep1) then have_wep1_num-=1;}
-    
-    
-    
+
+
+
     if (target_comp=1) and (n_wep1!="Assortment") and (n_wep1!="(None)"){// Check numbers
         req_wep1_num=units;have_wep1_num=0;
         var i;i=0;
         repeat(obj_controller.man_max){i+=1;
-            // if (vehicle_equipment=0) and (obj_controller.man[i]="man") and (obj_controller.man_sel[i]=1) and (obj_controller.ma_wep1[i]=n_wep1) then req_wep1_num+=1;
-            // if (vehicle_equipment=0) and (obj_controller.man[i]="man") and (obj_controller.man_sel[i]=1) and (obj_controller.ma_wep2[i]=n_wep1) then req_wep1_num+=1;
-            if (vehicle_equipment=0) and (obj_controller.ma_wep1[i]=n_wep1) then have_wep1_num+=1;
+            if (vehicle_equipment!=-1) and (obj_controller.ma_wep1[i]=n_wep1) then have_wep1_num+=1;
         }
         // req_wep1_num+=scr_item_count(n_wep1);
         have_wep1_num+=scr_item_count(n_wep1);
         // req_wep1_num=units;
-        
+
         if (have_wep1_num>=req_wep1_num) or (n_wep1="(None") then n_good1=1;
         if (have_wep1_num<req_wep1_num){n_good1=0;warning="Not enough "+string(n_wep1)+"; "+string(req_wep1_num-have_wep1_num)+" more are required.";}
         if (n_wep1="Thunder Hammer"){
             var g,exp_check;g=0;exp_check=0;
             repeat(obj_controller.man_max){
-                g+=1;if (obj_controller.man[g]="man") and (obj_controller.man_sel[g]=1) and (obj_controller.ma_exp[g]<70) then exp_check=1;
+                g+=1;if (obj_controller.man_sel[g]=1) and (obj_controller.ma_exp[g]<70) then exp_check=1;
             }
             if (exp_check=1){n_good1=0;warning="A unit must have 70+ EXP to use a Thunder Hammer.";}
         }
@@ -651,20 +649,18 @@ if (type=6) and (cooldown<=0){// Actually changing equipment right here
         req_wep2_num=units;have_wep2_num=0;
         var i;i=0;
         repeat(obj_controller.man_max){i+=1;
-            // if (vehicle_equipment=0) and (obj_controller.man[i]="man") and (obj_controller.man_sel[i]=1) and (obj_controller.ma_wep1[i]=n_wep2) then req_wep2_num+=1;
-            // if (vehicle_equipment=0) and (obj_controller.man[i]="man") and (obj_controller.man_sel[i]=1) and (obj_controller.ma_wep2[i]=n_wep2) then req_wep2_num+=1;
-            if (vehicle_equipment=0) and (obj_controller.ma_wep2[i]=n_wep2) then have_wep2_num+=1;
+            if (vehicle_equipment!=-1) and (obj_controller.ma_wep2[i]=n_wep2) then have_wep2_num+=1;
         }
         // req_wep2_num+=scr_item_count(n_wep2);
         have_wep2_num+=scr_item_count(n_wep2);
         // req_wep2_num=units;
-        
+
         if (have_wep2_num>=req_wep2_num) or (n_wep2="(None") then n_good2=1;
         if (have_wep2_num<req_wep2_num){n_good2=0;warning="Not enough "+string(n_wep2)+"; "+string(req_wep2_num-have_wep2_num)+" more are required.";}
         if (n_wep2="Thunder Hammer"){
             var g,exp_check;g=0;exp_check=0;
             repeat(obj_controller.man_max){
-                g+=1;if (obj_controller.man[g]="man") and (obj_controller.man_sel[g]=1) and (obj_controller.ma_exp[g]<70) then exp_check=1;
+                g+=1;if (obj_controller.man_sel[g]=1) and (obj_controller.ma_exp[g]<70) then exp_check=1;
             }
             if (exp_check=1){n_good2=0;warning="A unit must have 70+ EXP to use a Thunder Hammer.";}
         }
@@ -677,35 +673,35 @@ if (type=6) and (cooldown<=0){// Actually changing equipment right here
         req_armor_num=units;have_armor_num=0;
         var i;i=0;
         repeat(obj_controller.man_max){i+=1;
-            if (vehicle_equipment=0) and (obj_controller.man[i]="man") and (obj_controller.man_sel[i]=1) and (obj_controller.ma_armor[i]=n_armor) then have_armor_num+=1;
+            if (vehicle_equipment!=-1) and (obj_controller.man_sel[i]=1) and (obj_controller.ma_armor[i]=n_armor) then have_armor_num+=1;
         }
         have_armor_num+=scr_item_count(n_armor);
-        
+
         if (have_armor_num>=req_armor_num) or (n_armor="(None") then n_good3=1;
         if (have_armor_num<req_armor_num){n_good3=0;warning="Not enough "+string(n_armor)+"; "+string(units-req_armor_num)+" more are required.";}
-        
+
         var g,exp_check;g=0;exp_check=0;
         if (n_armor="Terminator Armor") or (n_armor="Tartaros") then repeat(obj_controller.man_max){
             g+=1;
-            if (obj_controller.man[g]="man") and (obj_controller.man_sel[g]=1) and (obj_controller.ma_exp[g]<90) then exp_check=1;
+            if (obj_controller.man_sel[g]=1) and (obj_controller.ma_exp[g]<90) then exp_check=1;
         }
         if (exp_check=1){n_good3=0;warning="A unit must have 90+ EXP to use Terminator armor.";}
         if (string_count("Dread",o_armor)>0) and (string_count("Dread",n_armor)=0){
             n_good4=0;warning="Marines may not exit Dreadnoughts.";
         }
-        
+
     }
     if (target_comp=4) and (n_gear!="Assortment") and (n_gear!="(None)"){// Check numbers
         req_gear_num=units;have_gear_num=0;
         var i;i=0;
         repeat(obj_controller.man_max){i+=1;
-            if (vehicle_equipment=0) and (obj_controller.man[i]="man") and (obj_controller.man_sel[i]=1) and (obj_controller.ma_gear[i]=n_gear) then have_gear_num+=1;
+            if (vehicle_equipment!=-1) and (obj_controller.man_sel[i]=1) and (obj_controller.ma_gear[i]=n_gear) then have_gear_num+=1;
         }
         have_gear_num+=scr_item_count(n_gear);
-        
+
         if (have_gear_num>=req_gear_num) or (n_gear="(None") then n_good4=1;
         if (have_gear_num<req_gear_num){n_good4=0;warning="Not enough "+string(n_gear)+"; "+string(units-req_gear_num)+" more are required.";}
-        
+
         if (n_gear!="(None)") and (n_gear!="") and (string_count("Dreadnought",n_armor)>0){
             n_good4=0;warning="Dreadnoughts may not use infantry equipment.";
         }
@@ -714,20 +710,20 @@ if (type=6) and (cooldown<=0){// Actually changing equipment right here
         req_mobi_num=units;have_mobi_num=0;
         var i;i=0;
         repeat(obj_controller.man_max){i+=1;
-            if (vehicle_equipment=0) and (obj_controller.man[i]="man") and (obj_controller.man_sel[i]=1) and (obj_controller.ma_mobi[i]=n_mobi) then have_mobi_num+=1;
+            if (vehicle_equipment!=-1) and (obj_controller.man_sel[i]=1) and (obj_controller.ma_mobi[i]=n_mobi) then have_mobi_num+=1;
         }
         have_mobi_num+=scr_item_count(n_mobi);
-        
+
         if (have_mobi_num>=req_mobi_num) or (n_mobi="(None")  then n_good5=1;
         if (have_mobi_num<req_mobi_num){n_good5=0;warning="Not enough "+string(n_mobi)+"; "+string(units-req_mobi_num)+" more are required.";}
-        
+
         if (n_mobi!="") and ((n_armor="Terminator Armor") or (n_armor="Tartaros")){
             n_good5=0;warning="Terminators cannot use Mobility gear.";
         }
         if (n_mobi!="(None)") and (n_mobi!="") and (n_armor="Dreadnought"){
             n_good5=0;warning=string(obj_ini.role[100,6])+"s may not use mobility gear.";
         }
-        
+
     }
 }
 
@@ -740,24 +736,24 @@ if (type=6) and (cooldown<=0){// Actually changing equipment right here
 if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<yy+518){// Promoting right here
     if (type=5) and (cooldown<=0) and (all_good=1) and (target_comp!=-1) and (role_name[target_role]!=""){
         cooldown=999;obj_controller.cooldown=8000;
-        
+
         var mahreens,i,god;
         mahreens=0;i=0;god=0;
-        
+
         if (target_comp>10) then target_comp=0;
         if (company>10) then company=0;
         manag=obj_controller.managing;
         if (manag>10) then manag=0;
-        
+
         repeat(300){i+=1;if (god=0){if (obj_ini.name[target_comp,i]=""){god=1;mahreens=i;}}}// Gets the number of marines in the target company
         i=0;if (role_name[target_role]="DoNotChange") then dnc=true;
-        
+
         repeat(obj_controller.man_max){
             i+=1;
-            
+
             if (obj_controller.man[i]!="") and (obj_controller.man_sel[i]=1) and (obj_controller.ma_promote[i]>=1) and (obj_controller.ma_exp[i]>=min_exp){
                 var check;check=0;
-                
+
                 if (req_armor="") or (dnc=true) then check=1;
                 if (req_armor="Power Armor"){
                     if (obj_controller.ma_armor[i]="MK3 Iron Armor") or (obj_controller.ma_armor[i]="MK4 Maximus") or (obj_controller.ma_armor[i]="MK6 Corvus") then check=1;
@@ -766,13 +762,13 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
                 if (req_armor="Terminator Armor"){if (obj_controller.ma_armor[i]="Terminator Armor") or (obj_controller.ma_armor[i]="Tartaros") then check=1;}
                 if (req_armor="Scout Armor"){if (obj_controller.ma_armor[i]="Scout Armor") then check=1;}
                 if (req_armor="Dreadnought"){if (obj_controller.ma_armor[i]="Dreadnought") then check=1;}
-                
+
                 if (check=0) and (req_armor="Power Armor"){
                     if (obj_controller.ma_armor[i]!=""){// Move current armor to armory
                         scr_add_item(obj_ini.armor[company,obj_controller.ide[i]],1);
                         obj_controller.ma_armor[i]="";obj_ini.armor[company,obj_controller.ide[i]]="";
                     }
-                    
+
                     if (obj_controller.ma_armor[i]=""){// Check for Aquila
                         var satisfied;satisfied=scr_item_count("MK7 Aquila");
                         if (satisfied>0){scr_add_item("MK7 Aquila",-1);obj_controller.ma_armor[i]="MK7 Aquila";obj_ini.armor[company,obj_controller.ide[i]]="MK7 Aquila";}
@@ -799,7 +795,7 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
                         scr_add_item(obj_ini.armor[company,obj_controller.ide[i]],1);
                         obj_controller.ma_armor[i]="";obj_ini.armor[company,obj_controller.ide[i]]="";
                     }
-                    
+
                     if (obj_controller.ma_armor[i]=""){
                         var satisfied;satisfied=scr_item_count("Terminator Armor");
                         if (satisfied>0){scr_add_item("Terminator Armor",-1);obj_controller.ma_armor[i]="Terminator Armor";obj_ini.armor[company,obj_controller.ide[i]]="Terminator Armor";}
@@ -814,7 +810,7 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
                         scr_add_item(obj_ini.armor[company,obj_controller.ide[i]],1);
                         obj_controller.ma_armor[i]="";obj_ini.armor[company,obj_controller.ide[i]]="";
                     }
-                    
+
                     if (obj_controller.ma_armor[i]=""){
                         var satisfied;satisfied=scr_item_count("Scout Armor");
                         if (satisfied>0){scr_add_item("Scout Armor",-1);obj_controller.ma_armor[i]="Scout Armor";obj_ini.armor[company,obj_controller.ide[i]]="Scout Armor";}
@@ -826,25 +822,25 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
                         obj_controller.ma_armor[i]="";obj_ini.armor[company,obj_controller.ide[i]]="";
                         if (obj_ini.age[company,obj_controller.ide[i]]!=floor(obj_ini.age[company,obj_controller.ide[i]])) then obj_ini.age[company,obj_controller.ide[i]]=floor(obj_ini.age[company,obj_controller.ide[i]]);
                     }
-                    
+
                     if (obj_controller.ma_armor[i]=""){
                         var satisfied;satisfied=scr_item_count("Dreadnought");
                         if (satisfied>0){scr_add_item("Dreadnought",-1);obj_controller.ma_armor[i]="Dreadnought";obj_ini.armor[company,obj_controller.ide[i]]="Dreadnought";}
                     }
                 }
-                
+
                 // End swap armor
-                
-                
+
+
                 if (obj_controller.ma_wep1[i]!=req_wep1) and (req_wep1!="Heavy Ranged") and (req_wep1!="") and (dnc=false){// NOT HEAVY RANGED
                     check=0;var satisfied;satisfied=0;
-                    
+
                     if (obj_controller.ma_wep2[i]=req_wep1)/* and (role_name[target_role]!=obj_ini.role[100,6])*/{
                         var temp;temp="";temp=obj_controller.ma_wep1[i];// Get temp
                         obj_controller.ma_wep1[i]=obj_controller.ma_wep2[i];obj_ini.wep1[company,obj_controller.ide[i]]=obj_ini.wep2[company,obj_controller.ide[i]];// Wep2 -> Wep1
                         obj_controller.ma_wep2[i]=temp;obj_ini.wep2[company,obj_controller.ide[i]]=temp;// Temp -> Wep2
                     }
-                    
+
                     if (obj_controller.ma_wep1[i]!=req_wep1){// If still not it, and has weapon, return to armory
                         if (obj_controller.ma_wep1[i]!=""){
                             scr_add_item(obj_ini.wep1[company,obj_controller.ide[i]],1);
@@ -858,19 +854,19 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
                 }
                 if (obj_controller.ma_wep1[i]!="Heavy Bolter") and (obj_controller.ma_wep1[i]!="Lascannon") and (obj_controller.ma_wep1[i]!="Missile Launcher") and (req_wep1="Heavy Ranged") and (req_wep1!="") and (dnc=false){// HEAVY RANGED
                     check=0;var satisfied;satisfied=0;
-                    
+
                     if (obj_controller.ma_wep2[i]="Heavy Bolter") or (obj_controller.ma_wep2[i]="Lascannon") or (obj_controller.ma_wep2[i]="Missile Launcher"){
                         var temp;temp="";temp=obj_controller.ma_wep1[i];// Get temp
                         obj_controller.ma_wep1[i]=obj_controller.ma_wep2[i];obj_ini.wep1[company,obj_controller.ide[i]]=obj_ini.wep2[company,obj_controller.ide[i]];// Wep2 -> Wep1
                         obj_controller.ma_wep2[i]=temp;obj_ini.wep2[company,obj_controller.ide[i]]=temp;// Temp -> Wep2
                     }
-                    
+
                     if (obj_controller.ma_wep1[i]!="Heavy Bolter") and (obj_controller.ma_wep1[i]!="Lascannon") and (obj_controller.ma_wep1[i]!="Missile Launcher"){// If still not it, and has weapon, return to armory
                         if (obj_controller.ma_wep1[i]!=""){
                             scr_add_item(obj_ini.wep1[company,obj_controller.ide[i]],1);
                             obj_controller.ma_wep1[i]="";obj_ini.wep1[company,obj_controller.ide[i]]="";
                         }
-                        
+
                         if (obj_controller.ma_wep1[i]=""){// Check armory for lascannon
                             satisfied=scr_item_count("Lascannon");
                             if (satisfied>0){scr_add_item("Lascannon",-1);obj_controller.ma_wep1[i]="Lascannon";obj_ini.wep1[company,obj_controller.ide[i]]="Lascannon";}
@@ -886,10 +882,10 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
                     }
                 }
                 // End swap first weapon
-                
+
                 if (obj_controller.ma_wep2[i]!=req_wep1) and (req_wep2!="") and (dnc=false){// SECOND WEAPON
                     check=0;var satisfied;satisfied=0;
-                    
+
                     if (obj_controller.ma_wep2[i]!=req_wep2){// If still not it, and has weapon, return to armory
                         if (obj_controller.ma_wep2[i]!=""){
                             scr_add_item(obj_ini.wep2[company,obj_controller.ide[i]],1);
@@ -902,10 +898,10 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
                     }
                 }
                 // End swap second weapon
-                
+
                 if (obj_controller.ma_gear[i]!=req_gear) and (req_gear!="") and (dnc=false){// GEAR
                     check=0;var satisfied;satisfied=0;
-                    
+
                     if (obj_controller.ma_gear[i]!=req_gear){// If still not it, and have gear, return to armory
                         if (obj_controller.ma_gear[i]!=""){
                             scr_add_item(obj_ini.gear[company,obj_controller.ide[i]],1);
@@ -917,12 +913,12 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
                         }
                     }
                 }
-                
+
                 // End swap gear
-                
+
                 if (obj_controller.ma_mobi[i]!=req_mobi) and (req_mobi!="") and (dnc=false){// mobi
                     check=0;var satisfied;satisfied=0;
-                    
+
                     if (obj_controller.ma_mobi[i]!=req_mobi){// If still not it, and have mobi, return to armory
                         if (obj_controller.ma_mobi[i]!=""){
                             scr_add_item(obj_ini.mobi[company,obj_controller.ide[i]],1);
@@ -934,36 +930,36 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
                         }
                     }
                 }
-                
+
                 // Pass variables here
-                
+
                 // This changes a marine from MARINE to COMMAND if they get put into a dreadnought
                 var bef,aft,wco,wca;
                 bef="";aft="";wco=false;wca=false;
                 bef=obj_controller.ma_role[i];
                 aft=role_name[target_role];
-                
+
                 if (dnc=true) then aft=obj_ini.role[company,obj_controller.ide[i]];
-                
+
                 wco=is_specialist(bef);wca=is_specialist(aft);
                 if (wco=false) and (wca=true){obj_controller.marines-=1;obj_controller.command+=1;}
                 if (wco=true) and (wca=false){obj_controller.marines+=1;obj_controller.command-=1;}
-                
+
                 /*if (bef=obj_ini.role[100,5]) then wco=1;
                 if (bef=obj_ini.role[100,14]) then wco=1;
                 if (bef=obj_ini.role[100,15]) then wco=1;
                 if (bef=obj_ini.role[100,16]) then wco=1;
                 if (bef=obj_ini.role[100,17]) then wco=1;
-                
+
                 if (wco=0) and (role_name[target_role]=obj_ini.role[100,6]) and (dnc=false){obj_controller.marines-=1;obj_controller.command+=1;}
                 */
-                
+
                 if (role_name[target_role]=obj_ini.role[100,5]) and (dnc=false){// Restock recruiter or admiral dude
                     if (target_comp=4) then obj_ini.lord_admiral_name=obj_controller.ma_name[i];
                     if (target_comp=10) then obj_ini.recruiter_name=obj_controller.ma_name[i];
                 }
-                
-                
+
+
                 // obj_ini.race[target_comp,mahreens]=target_comp;
                 obj_ini.race[target_comp,mahreens]=obj_ini.race[company,obj_controller.ide[i]];
                 obj_ini.loc[target_comp,mahreens]=obj_controller.ma_loc[i];
@@ -971,17 +967,17 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
                 // 135 ;
                 // obj_ini.role[target_comp,mahreens]=string_replace(role_name[target_role]," Marine","");
                 obj_ini.role[target_comp,mahreens]=aft;
-                
+
                 obj_ini.name[target_comp,mahreens]=obj_controller.ma_name[i];obj_ini.mobi[target_comp,mahreens]=obj_controller.ma_mobi[i];
                 obj_ini.wep1[target_comp,mahreens]=obj_controller.ma_wep1[i];obj_ini.wep2[target_comp,mahreens]=obj_controller.ma_wep2[i];
                 obj_ini.armor[target_comp,mahreens]=obj_controller.ma_armor[i];obj_ini.gear[target_comp,mahreens]=obj_controller.ma_gear[i];
                 obj_ini.hp[target_comp,mahreens]=obj_controller.ma_health[i];obj_ini.chaos[target_comp,mahreens]=obj_controller.ma_chaos[i];
                 obj_ini.god[target_comp,mahreens]=obj_controller.ma_god[i];
                 obj_ini.spe[target_comp,mahreens]=obj_ini.spe[company,obj_controller.ide[i]]
-                
+
                 if (role_name[target_role]=obj_ini.role[100,6]) and (dnc=false){
                     obj_ini.hp[target_comp,mahreens]=100;
-                    
+
                     // Remove illegal weapons here
                     var dread_good;dread_good=false;
                     if (obj_ini.wep1[target_comp,mahreens]="") then dread_good=true;
@@ -993,7 +989,7 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
                     if (string_count("Missile Launcher",obj_ini.wep1[target_comp,mahreens])>0) then dread_good=true;
                     if (string_count("Heavy Bolter",obj_ini.wep1[target_comp,mahreens])>0) then dread_good=true;
                     if (dread_good=false){scr_add_item(obj_ini.wep1[target_comp,mahreens],1);obj_ini.wep1[target_comp,mahreens]="";}
-                    
+
                     dread_good=false;
                     if (obj_ini.wep2[target_comp,mahreens]="") then dread_good=true;
                     if (string_count("Close Combat Weapon",obj_ini.wep2[target_comp,mahreens])>0) then dread_good=true;
@@ -1004,22 +1000,22 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
                     if (string_count("Missile Launcher",obj_ini.wep2[target_comp,mahreens])>0) then dread_good=true;
                     if (string_count("Heavy Bolter",obj_ini.wep2[target_comp,mahreens])>0) then dread_good=true;
                     if (dread_good=false){scr_add_item(obj_ini.wep2[target_comp,mahreens],1);obj_ini.wep2[target_comp,mahreens]="";}
-                    
+
                     if (obj_ini.mobi[target_comp,mahreens]!=""){scr_add_item(obj_ini.mobi[target_comp,mahreens],1);obj_ini.mobi[target_comp,mahreens]="";}
                     if (obj_ini.gear[target_comp,mahreens]!=""){scr_add_item(obj_ini.gear[target_comp,mahreens],1);obj_ini.gear[target_comp,mahreens]="";}
                 }
-                
+
                 obj_ini.experience[target_comp,mahreens]=obj_controller.ma_exp[i];obj_ini.age[target_comp,mahreens]=obj_ini.age[company,obj_controller.ide[i]];
                 obj_ini.lid[target_comp,mahreens]=obj_controller.ma_lid[i];obj_ini.wid[target_comp,mahreens]=obj_controller.ma_wid[i];
-                
+
                 mahreens+=1;
-                
+
                 if (role_name[target_role]=obj_ini.role[100,5]) then scr_recent("captain_promote",obj_ini.name[target_comp,mahreens],target_comp);
                 if (role_name[target_role]=obj_ini.role[100,4]) then scr_recent("terminator_promote",obj_ini.name[target_comp,mahreens],target_comp);
                 if (role_name[target_role]=obj_ini.role[100,2]) then scr_recent("honor_promote",obj_ini.name[target_comp,mahreens],target_comp);
-                
+
                 // show_message(string(company)+" - "+string(obj_ini.role[company,obj_controller.ide[i]]));
-                
+
                 // Clear variables here
                 obj_ini.race[company,obj_controller.ide[i]]=0;obj_ini.loc[company,obj_controller.ide[i]]="";
                 obj_ini.role[company,obj_controller.ide[i]]="";obj_ini.name[company,obj_controller.ide[i]]="";
@@ -1030,21 +1026,21 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
                 obj_ini.experience[company,obj_controller.ide[i]]=0;obj_ini.age[company,obj_controller.ide[i]]=0;
                 obj_ini.wid[company,obj_controller.ide[i]]=0;obj_ini.lid[company,obj_controller.ide[i]]=0;
                 obj_ini.spe[company,obj_controller.ide[i]]="";
-                
+
                 // show_message(string(company)+" - "+string(obj_ini.role[company,obj_controller.ide[i]]));
-                
+
             }// End that [i]
-            
+
         }// End repeat
-        
-        
+
+
         with(obj_controller){scr_management(1);}
-        
+
         with(obj_ini){
             scr_company_order(obj_popup.manag);
             scr_company_order(obj_popup.target_comp);
         }
-        
+
 
         with(obj_controller){
             // man_current=0;
@@ -1060,9 +1056,9 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
             if (managing>10) or (managing=0) then scr_special_view(managing);
             cooldown=10;sel_loading=0;unload=0;alarm[6]=30;
         }
-        
+
         with(obj_managment_panel){instance_destroy();}
-        
+
         obj_controller.cooldown=10;
         instance_destroy();
     }
@@ -1075,23 +1071,23 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1576) and (mouse_y<y
 if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1577) and (mouse_y<yy+520){// Equipment
     if (type=6) and (cooldown<=0) and (n_good1+n_good2+n_good3+n_good4+n_good5=5){
         cooldown=999;obj_controller.cooldown=8;
-        
+
         if (n_wep1="(None)") then n_wep1="";
         if (n_wep2="(None)") then n_wep2="";
         if (n_armor="(None)") then n_armor="";
         if (n_gear="(None)") then n_gear="";
         if (n_mobi="(None)") then n_mobi="";
-        
-        
+
+
         if (company>10) then company=0;
-        
+
         i=0;
         repeat(obj_controller.man_max){
             i+=1;
-            
-            if (obj_controller.man[i]!="") and (obj_controller.man_sel[i]=1) and (vehicle_equipment=0) and (obj_controller.man[i]="man"){
+
+            if (obj_controller.man[i]!="") and (obj_controller.man_sel[i]=1) and (vehicle_equipment!=-1){
                 var check,scout_check;
-                
+
                 check=0;scout_check=0;
                 if (n_armor=obj_controller.ma_armor[i]) then check=1;
                 if (check=0) and (n_armor!=obj_controller.ma_armor[i]) and (n_armor!="Assortment"){
@@ -1103,11 +1099,11 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1577) and (mouse_y<y
                             if (obj_ini.armor[company,obj_controller.ide[i]]!="") then scr_add_item(obj_ini.armor[company,obj_controller.ide[i]],1);
                             obj_controller.ma_armor[i]="";obj_ini.armor[company,obj_controller.ide[i]]="";
                             scr_add_item(n_armor,-1);obj_controller.ma_armor[i]=n_armor;obj_ini.armor[company,obj_controller.ide[i]]=n_armor;
-                            
+
                             if (n_armor="Dreadnought") and (obj_ini.age[company,obj_controller.ide[i]]!=floor(obj_ini.age[company,obj_controller.ide[i]])) then obj_ini.age[company,obj_controller.ide[i]]=floor(obj_ini.age[company,obj_controller.ide[i]]);
                         }
                     }
-                    
+
                     // NOPE
                     if ((n_armor="Terminator Armor") or (n_armor="Tartaros")) and (obj_ini.mobi[company,obj_controller.ide[i]]!=""){
                         scr_add_item(obj_ini.mobi[company,obj_controller.ide[i]],1);
@@ -1126,15 +1122,15 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1577) and (mouse_y<y
                             }
                         }
                     }
-                    
-                    
+
+
                 }
                 // End swap armor
-                
-                
+
+
                 // if (n_wep1=n_wep2) and (
-                
-                
+
+
                 if (n_wep1=obj_controller.ma_wep2[i]) and (n_wep2!="Assortment") and (n_wep1!="Assortment"){
                     var temp;temp="";
                     temp=obj_controller.ma_wep1[i];// Get temp
@@ -1151,9 +1147,9 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1577) and (mouse_y<y
                     obj_controller.ma_wep1[i]=temp;
                     obj_ini.wep1[company,obj_controller.ide[i]]=temp;
                 }
-                
-                
-                
+
+
+
                 check=0;
                 if (obj_controller.ma_role[i]="Standard Bearer"){
                     if (obj_controller.ma_wep1[i]="Company Standard") and (n_wep1!="Company Standard") and (n_wep2!="Company Standard") then check=1;
@@ -1179,7 +1175,7 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1577) and (mouse_y<y
                     obj_controller.ma_wep2[i]=temp;obj_ini.wep2[company,obj_controller.ide[i]]=temp;check=5;
                 }*/
                 // End swap weapon
-                
+
                 check=0;
                 if (obj_controller.ma_role[i]="Standard Bearer"){
                     if (obj_controller.ma_wep2[i]="Company Standard") and (n_wep1!="Company Standard") and (n_wep2!="Company Standard") then check=1;
@@ -1205,7 +1201,7 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1577) and (mouse_y<y
                     obj_controller.ma_wep1[i]=temp;obj_ini.wep1[company,obj_controller.ide[i]]=temp;
                 }*/
                 // End swap weapon
-                
+
                 check=0;
                 if (n_gear=obj_controller.ma_gear[i]) then check=1;
                 if (check=0) and (n_gear!=obj_controller.ma_gear[i]) and (n_gear!="Assortment"){
@@ -1215,7 +1211,7 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1577) and (mouse_y<y
                     if (n_gear!="") then scr_add_item(n_gear,-1);
                 }
                 // End swap gear
-                
+
                 check=0;
                 if (n_mobi=obj_controller.ma_mobi[i]) then check=1;
                 if (check=0) and (n_mobi!=obj_controller.ma_mobi[i]) and (n_mobi!="Assortment"){
@@ -1227,7 +1223,7 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1577) and (mouse_y<y
                     }
                 }
                 // End mobility
-                
+
                 /*
                 if (obj_controller.ma_wep1[i]="(None)") then obj_controller.ma_wep1[i]="";
                 if (obj_controller.ma_wep2[i]="(None)") then obj_controller.ma_wep2[i]="";
@@ -1240,11 +1236,11 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1577) and (mouse_y<y
                 if (obj_ini.gear[company,obj_controller.ide[i]]="(None)") then obj_ini.gear[company,obj_controller.ide[i]]="";
                 if (obj_ini.mobi[company,obj_controller.ide[i]]="(None)") then obj_ini.mobi[company,obj_controller.ide[i]]="";
                 */
-                
+
             }// End that [i]
-            
+
         }// End repeat
-        
+
         obj_controller.cooldown=10;
         instance_destroy();exit;
     }
@@ -1257,13 +1253,13 @@ if (mouse_x>=xx+1465) and (mouse_y>=yy+499) and (mouse_x<xx+1577) and (mouse_y<y
 if ((type=9) or (type=9.1)) and (mouse_x>=xx+240+420) and (mouse_x<xx+387+420){
     if ((type=9) or (type=9.1)) and (cooldown<=0){
         giveto=0;
-    
+
         if (mouse_y>=yy+325) and (mouse_y<yy+342){
             obj_controller.cooldown=8000;
             instance_destroy();
             exit;
         }
-        
+
         inq_hide=0;
         if (type=9){
             if (string_count("inq",obj_ini.artifact_tags[obj_controller.menu_artifact])>0){
@@ -1275,36 +1271,36 @@ if ((type=9) or (type=9.1)) and (mouse_x>=xx+240+420) and (mouse_x<xx+387+420){
                 }
             }
         }
-        
-        
+
+
         if (mouse_y>=yy+121) and (mouse_y<=yy+149) and (obj_controller.known[2]>1) then giveto=2;
         if (mouse_y>=yy+151) and (mouse_y<=yy+179) and (obj_controller.known[3]>1) then giveto=3;
         if (mouse_y>=yy+181) and (mouse_y<=yy+209) and ((obj_controller.known[4]>1) or (inq_hide=2)) and (inq_hide!=1) then giveto=4;
         if (mouse_y>=yy+211) and (mouse_y<=yy+239) and (obj_controller.known[5]>1) then giveto=5;
         if (mouse_y>=yy+241) and (mouse_y<=yy+269) and (obj_controller.known[6]>1) then giveto=6;
         if (mouse_y>=yy+271) and (mouse_y<=yy+299) and (obj_controller.known[8]>1) then giveto=8;
-        
-        
-        
-        
-        
+
+
+
+
+
         if (giveto>0) and (type=9.1){
             var r1,r2,cn;r2=0;cn=obj_controller;
             r1=floor(random(cn.stc_wargear_un+cn.stc_vehicles_un+cn.stc_ships_un))+1;
-            
+
             if (r1<cn.stc_wargear_un) and (cn.stc_wargear_un>0) then r2=1;
             if (r1>cn.stc_wargear_un) and (r1<=cn.stc_wargear_un+cn.stc_vehicles_un) and (cn.stc_vehicles_un>0) then r2=2;
             if (r1>cn.stc_wargear_un+cn.stc_vehicles_un) and (r2<=cn.stc_wargear_un+cn.stc_vehicles_un+cn.stc_ships_un) and (cn.stc_ships_un>0) then r2=3;
-            
+
             if (cn.stc_wargear_un>0) and (cn.stc_vehicles_un+cn.stc_ships_un=0) then r2=1;
             if (cn.stc_vehicles_un>0) and (cn.stc_wargear_un+cn.stc_ships_un=0) then r2=2;
             if (cn.stc_ships_un>0) and (cn.stc_vehicles_un+cn.stc_wargear_un=0) then r2=3;
-            
+
             cn.stc_un_total-=1;
             if (r2=1) then cn.stc_wargear_un-=1;
             if (r2=2) then cn.stc_vehicles_un-=1;
             if (r2=3) then cn.stc_ships_un-=1;
-            
+
             // Modify disposition here
             if (giveto=2) then obj_controller.disposition[2]+=3;
             if (giveto=3) then obj_controller.disposition[3]+=choose(5,6,7,8);
@@ -1322,18 +1318,18 @@ if ((type=9) or (type=9.1)) and (mouse_x>=xx+240+420) and (mouse_x<xx+387+420){
             obj_controller.force_goodbye=-1;
             var the;the="";if (giveto!=7) and (giveto!=10) then the="the ";
             scr_event_log("","STC Fragment gifted to "+string(the)+string(obj_controller.faction[giveto])+".");
-            
+
             with(obj_controller){scr_dialogue("stc_thanks");}
             instance_destroy();exit;
         }
-        
+
         if (giveto>0) and (type=9){
-        
-        
+
+
             var e;e=0;
             repeat(50){e+=1;
                 if (obj_controller.fest_display=obj_controller.menu_artifact) then obj_controller.fest_display=0;
-                
+
                 /*if (obj_ini.artifact_tags[obj_controller.menu_artifact]=obj_controller.recent_keyword[e]){
                     obj_controller.recent_keyword[e]="";obj_controller.recent_type[e]="";
                     obj_controller.recent_turn[e]=0;obj_controller.recent_number[e]=0;
@@ -1341,16 +1337,16 @@ if ((type=9) or (type=9.1)) and (mouse_x>=xx+240+420) and (mouse_x<xx+387+420){
                     scr_recent("","",0);
                 }*/
             }
-        
-            
-        
-        
+
+
+
+
             old_tags=obj_ini.artifact_tags[obj_controller.menu_artifact];
             obj_ini.artifact[obj_controller.menu_artifact]="";obj_ini.artifact_tags[obj_controller.menu_artifact]="";
             obj_ini.artifact_identified[obj_controller.menu_artifact]=0;obj_ini.artifact_condition[obj_controller.menu_artifact]=100;
             obj_ini.artifact_loc[obj_controller.menu_artifact]="";obj_ini.artifact_sid[obj_controller.menu_artifact]=0;
             obj_controller.artifacts-=1;cooldown=7000;
-            
+
             var g;g=obj_controller.menu_artifact;
             repeat(20){
                 if (obj_ini.artifact[g]="") and (obj_ini.artifact[g+1]!=""){
@@ -1358,7 +1354,7 @@ if ((type=9) or (type=9.1)) and (mouse_x>=xx+240+420) and (mouse_x<xx+387+420){
                     obj_ini.artifact_identified[g]=obj_ini.artifact_identified[g+1];
                     obj_ini.artifact_condition[g]=obj_ini.artifact_condition[g+1];
                     obj_ini.artifact_loc[g]=obj_ini.artifact_loc[g+1];obj_ini.artifact_sid[g]=obj_ini.artifact_sid[g+1];
-                    // 
+                    //
                     obj_ini.artifact[g+1]="";obj_ini.artifact_tags[g+1]="";
                     obj_ini.artifact_identified[g+1]=0;obj_ini.artifact_condition[g+1]=100;
                     obj_ini.artifact_loc[g+1]="";obj_ini.artifact_sid[g+1]=0;
@@ -1367,19 +1363,19 @@ if ((type=9) or (type=9.1)) and (mouse_x>=xx+240+420) and (mouse_x<xx+387+420){
             }
             obj_controller.cooldown=10;
             if (obj_controller.menu_artifact>obj_controller.artifacts) then obj_controller.menu_artifact=obj_controller.artifacts;
-            
+
             obj_controller.menu=20;
             obj_controller.diplomacy=giveto;
             obj_controller.force_goodbye=-1;
             var the;the="";if (giveto!=7) and (giveto!=10) then the="the ";
             scr_event_log("","Artifact gifted to "+string(the)+string(obj_controller.faction[giveto])+".");
-            
+
             if (inq_hide!=2) then with(obj_controller){
                 if (string_count("Daemon",obj_popup.old_tags)=0) or ((diplomacy!=4) and (diplomacy!=5) and (diplomacy!=2)) then scr_dialogue("artifact_thanks");
                 if (string_count("Daemon",obj_popup.old_tags)>0) and ((diplomacy=4) or (diplomacy=5) or (diplomacy=2)) then scr_dialogue("artifact_daemon");
             }
             if (inq_hide=2) and (obj_controller.diplomacy=4) then with(obj_controller){scr_dialogue("artifact_returned");}
-            
+
             if (string_count("mnr",old_tags)=0){
                 if (giveto=2) then obj_controller.disposition[2]+=6;
                 if (giveto=3) then obj_controller.disposition[3]+=4;
@@ -1392,9 +1388,9 @@ if ((type=9) or (type=9.1)) and (mouse_x>=xx+240+420) and (mouse_x<xx+387+420){
                 if (giveto=6) then obj_controller.disposition[6]+=3;
                 if (giveto=8) then obj_controller.disposition[8]+=4;
             }
-            
+
             // Need to modify ^^^^ based on if it is chaos or daemonic
-            
+
             if (giveto=2){
                 if (string_count("Daemon",old_tags)>0){
                     var v,ev;v=0;ev=0;repeat(99){v+=1;if (ev=0) and (obj_controller.event[v]="") then ev=v;}
@@ -1427,7 +1423,7 @@ if ((type=9) or (type=9.1)) and (mouse_x>=xx+240+420) and (mouse_x<xx+387+420){
             }
             instance_destroy();exit;
         }
-    
+
     }
 }
 
@@ -1450,16 +1446,16 @@ if (mouse_x>=xx+121) and (mouse_y>=yy+393) and (mouse_x<xx+231) and (mouse_y<yy+
 if (mouse_x>=xx+408) and (mouse_y>=yy+393) and (mouse_x<xx+518) and (mouse_y<yy+414){
     if (type=8) and (cooldown<=0) and (all_good=1){
         cooldown=100;obj_controller.cooldown=8000;
-        
+
         var i,this,dwarn;i=0;this=0;dwarn=false;
         repeat(obj_controller.man_max){
             i+=1;if (this=0) and (obj_controller.man_sel[i]=1) then this=i;
         }
         i=this;
-        
+
         if (obj_controller.man[i]!="") and (obj_controller.man_sel[i]=1){
             var replace;replace="";
-            
+
             if (target_role=1) then replace="weapon1";
             if (target_role=2) then replace="weapon2";
             if (target_role>3){
@@ -1467,31 +1463,31 @@ if (mouse_x>=xx+408) and (mouse_y>=yy+393) and (mouse_x<xx+518) and (mouse_y<yy+
                 if (obj_ini.artifact[obj_controller.menu_artifact]="Terminator Armor") then replace="armor";
                 if (obj_ini.artifact[obj_controller.menu_artifact]="Artificer Armor") then replace="armor";
                 if (obj_ini.artifact[obj_controller.menu_artifact]="Dreadnought Armor") or (obj_ini.artifact[obj_controller.menu_artifact]="Dreadnought") then replace="armor";
-            
+
                 if (obj_ini.artifact[obj_controller.menu_artifact]="Rosarius") then replace="gear";
                 if (obj_ini.artifact[obj_controller.menu_artifact]="Bionics") then replace="gear";
                 if (obj_ini.artifact[obj_controller.menu_artifact]="Psychic Hood") then replace="gear";
                 if (obj_ini.artifact[obj_controller.menu_artifact]="Servo Arms") then replace="gear";
-                
+
                 if (obj_ini.artifact[obj_controller.menu_artifact]="Jump Pack") then replace="mobility";
                 if (obj_ini.artifact[obj_controller.menu_artifact]="Bike") then replace="mobility";
             }
             if (replace="armor") and (obj_controller.ma_race[i]>5){cooldown=8;obj_controller.cooldown=8;exit;}
-            
+
             if (target_comp>10) then target_comp=0;
-            
+
             if (string_count("aemon",obj_ini.artifact_tags[obj_controller.menu_artifact])>0){
                 obj_ini.chaos[target_comp,obj_controller.ide[i]]+=choose(1,2,3,4,5,6)+choose(1,2,3,4,5,6);
                 if (string_count("dwarn|",obj_controller.useful_info)=0) and (obj_ini.role[target_comp,obj_controller.ide[i]]="Chapter Master"){
                     obj_controller.useful_info+="dwarn|";dwarn=true;
                 }
             }
-                
+
             if (replace="armor"){
                 if (obj_controller.ma_armor[i]!="") and (obj_controller.ma_armor[i]!="None") then scr_add_item(obj_ini.armor[target_comp,obj_controller.ide[i]],1);
-                
+
                 if (obj_controller.menu_artifact=obj_controller.fest_display) then obj_controller.fest_display=0;
-                
+
                 if (obj_ini.artifact[obj_controller.menu_artifact]="Terminator Armor") or (obj_ini.artifact[obj_controller.menu_artifact]="Dreadnought Armor"){
                     if (obj_ini.mobi[target_comp,obj_controller.ide[i]]!=""){// NOPE
                         scr_add_item(obj_ini.mobi[target_comp,obj_controller.ide[i]],1);
@@ -1499,13 +1495,13 @@ if (mouse_x>=xx+408) and (mouse_y>=yy+393) and (mouse_x<xx+518) and (mouse_y<yy+
                         if (obj_ini.artifact[obj_controller.menu_artifact]="Dreadnought Armor"){
                             if (obj_ini.age[target_comp,obj_controller.ide[i]]!=floor(obj_ini.age[target_comp,obj_controller.ide[i]])) then obj_ini.age[target_comp,obj_controller.ide[i]]=floor(obj_ini.age[target_comp,obj_controller.ide[i]]);
                         }
-                        
+
                     }
                 }
                 obj_controller.ma_armor[i]="";obj_ini.armor[target_comp,obj_controller.ide[i]]="";
                 obj_controller.ma_armor[i]=obj_ini.artifact[obj_controller.menu_artifact]+string("&")+obj_ini.artifact_tags[obj_controller.menu_artifact];
                 obj_ini.armor[target_comp,obj_controller.ide[i]]=obj_ini.artifact[obj_controller.menu_artifact]+string("&")+obj_ini.artifact_tags[obj_controller.menu_artifact];
-            
+
                 // NOPE
                 if (obj_ini.wep1[target_comp,obj_controller.ide[i]]="Assault Cannon") or (obj_ini.wep2[target_comp,obj_controller.ide[i]]="Assault Cannon"){
                     var bgn,bed;bed=0;bgn=obj_ini.armor[target_comp,obj_controller.ide[i]];
@@ -1519,8 +1515,8 @@ if (mouse_x>=xx+408) and (mouse_y>=yy+393) and (mouse_x<xx+518) and (mouse_y<yy+
                         }
                     }
                 }
-            
-            
+
+
             }
             if (replace="gear"){
                 if (obj_controller.ma_gear[i]!="") and (obj_controller.ma_gear[i]!="None") then scr_add_item(obj_ini.gear[target_comp,obj_controller.ide[i]],1);
@@ -1546,13 +1542,13 @@ if (mouse_x>=xx+408) and (mouse_y>=yy+393) and (mouse_x<xx+518) and (mouse_y<yy+
                 obj_controller.ma_wep2[i]=obj_ini.artifact[obj_controller.menu_artifact]+string("&")+obj_ini.artifact_tags[obj_controller.menu_artifact];
                 obj_ini.wep2[target_comp,obj_controller.ide[i]]=obj_ini.artifact[obj_controller.menu_artifact]+string("&")+obj_ini.artifact_tags[obj_controller.menu_artifact];
             }
-            
-            
+
+
             obj_ini.artifact[obj_controller.menu_artifact]="";obj_ini.artifact_tags[obj_controller.menu_artifact]="";
             obj_ini.artifact_identified[obj_controller.menu_artifact]=0;obj_ini.artifact_condition[obj_controller.menu_artifact]=100;
             obj_ini.artifact_loc[obj_controller.menu_artifact]="";obj_ini.artifact_sid[obj_controller.menu_artifact]=0;
             obj_controller.artifacts-=1;cooldown=12;
-            
+
             var g;g=obj_controller.menu_artifact;
             repeat(20){
                 if (obj_ini.artifact[g]="") and (obj_ini.artifact[g+1]!=""){
@@ -1560,7 +1556,7 @@ if (mouse_x>=xx+408) and (mouse_y>=yy+393) and (mouse_x<xx+518) and (mouse_y<yy+
                     obj_ini.artifact_identified[g]=obj_ini.artifact_identified[g+1];
                     obj_ini.artifact_condition[g]=obj_ini.artifact_condition[g+1];
                     obj_ini.artifact_loc[g]=obj_ini.artifact_loc[g+1];obj_ini.artifact_sid[g]=obj_ini.artifact_sid[g+1];
-                    // 
+                    //
                     obj_ini.artifact[g+1]="";obj_ini.artifact_tags[g+1]="";
                     obj_ini.artifact_identified[g+1]=0;obj_ini.artifact_condition[g+1]=100;
                     obj_ini.artifact_loc[g+1]="";obj_ini.artifact_sid[g+1]=0;
@@ -1568,17 +1564,17 @@ if (mouse_x>=xx+408) and (mouse_y>=yy+393) and (mouse_x<xx+518) and (mouse_y<yy+
                 g+=1;
             }
             obj_controller.cooldown=10;
-            
+
             if (obj_controller.menu_artifact>obj_controller.artifacts) then obj_controller.menu_artifact=obj_controller.artifacts;
-            
+
             if (dwarn=true){
                 var pip;pip=instance_create(0,0,obj_popup);
                 pip.title="Daemon Artifacts";
                 pip.text="Some artifacts, like the one you now wield, are a blasphemous union of the Materium's matter and the Immaterium's spirit, containing the essence of a bound daemon.  While they may offer great power, and enhanced perception, they are known to whisper poisonous lies to the wielder.  The path to damnation begins with good intentions, and many times artifacts such as these have been the cause.";
                 pip.image="";pip.cooldown=8;obj_controller.cooldown=8;
             }
-            
-            
+
+
             instance_destroy();exit;
         }
     }
@@ -1606,12 +1602,12 @@ if (type=8) and (cooldown<=0){
         if (mouse_x>=xx+386) and (mouse_x<=xx+430){target_comp=9;cooldown=8000;}
         if (mouse_x>=xx+497) and (mouse_x<=xx+545){target_comp=10;cooldown=8000;}
     }
-    
+
     if (mouse_y>=yy+124) and (mouse_y<yy+146) and (target_role<3){
         if (mouse_x>=xx+196) and (mouse_x<xx+291){target_role=1;cooldown=8;}
         if (mouse_x>=xx+424) and (mouse_x<=xx+525){target_role=2;cooldown=8;}
     }
-    
+
     if (before!=target_comp){units=0;
         with(obj_controller){
             if (obj_popup.target_comp>0) then scr_company_view(obj_popup.target_comp);
@@ -1622,13 +1618,13 @@ if (type=8) and (cooldown<=0){
             obj_controller.man_sel[i]=0;
         }i=0;
     }
-    
-    
+
+
     if (cooldown<=0) and (target_comp!=-1){
         var xx,yy,bb;bb="";x2=__view_get( e__VW.XView, 0 )+951;y2=__view_get( e__VW.YView, 0 )+398;
         var top,sel,temp1,temp2,temp3,temp4,temp5;temp1="";temp2="";temp3="";temp4="";temp5="";
         top=obj_controller.man_current;var stop;stop=0;sel=top;
-        
+
         repeat(min(obj_controller.man_max,23)){
             if (mouse_x>=xx+29) and (mouse_y>=yy+150) and (mouse_x<xx+569) and (mouse_y<yy+175.4){
                 var onceh;onceh=0;stop=0;
@@ -1641,13 +1637,13 @@ if (type=8) and (cooldown<=0){
             }
             yy+=25.4;sel+=1;
         }
-        
+
         if (stop!=0){var i;i=0;
             repeat(obj_controller.man_max){i+=1;
                 if (i!=stop) then obj_controller.man_sel[i]=0;
             }
         }
-        
+
     }
 }
 

--- a/scripts/scr_weapons_equip/scr_weapons_equip.gml
+++ b/scripts/scr_weapons_equip/scr_weapons_equip.gml
@@ -12,8 +12,8 @@ function scr_weapons_equip() {
 	if (instance_exists(obj_controller)) and (instance_exists(obj_popup)) and (!instance_exists(obj_mass_equip)){
 	    tc=target_comp;
 	    tb=tab;
-	    dude=0;// This is for equiping the selected marines in management
-    
+	    dude=vehicle_equipment; // This is for equipping the selected marines in management
+
 	}
 	if (instance_exists(obj_creation)){
 	    tc=target_gear;tb=tab;
@@ -25,131 +25,136 @@ function scr_weapons_equip() {
 	    dude=obj_controller.settings;
 	}
 
+	if (dude<50) and (dude!=6) then dude=1
 
+// dude=1 for normal infantry gear
+// dude=6 for dread
+// dude=50 for Land Raider
+// dude=51 for Rhino
+// dude=52 for Predator
+// dude=53 for Land Speeder
+// dude=54 for Whirlwind
 
-
-	if (tc<3) and (tb=1){var i;i=0;
+	if (tc<3) and (tb=1) and (dude=1){var i;i=0; // Infantry Ranged
 	    i+=1;item_name[i]="(None)";
-    
-	    if (dude!=6){
-	        i+=1;item_name[i]="Archeotech Laspistol";
-	        i+=1;item_name[i]="Assault Cannon";
-	        i+=1;item_name[i]="Bolt Pistol";
-	        i+=1;item_name[i]="Bolter";
-	        i+=1;item_name[i]="Combiflamer";
-	        i+=1;item_name[i]="Flamer";
-	    }
-	    i+=1;item_name[i]="Heavy Bolter";
+	    i+=1;item_name[i]="Archeotech Laspistol";
+      i+=1;item_name[i]="Assault Cannon";
+	   	i+=1;item_name[i]="Bolt Pistol";
+	    i+=1;item_name[i]="Bolter";
+	  	i+=1;item_name[i]="Combiflamer";
+	    i+=1;item_name[i]="Flamer";
+			i+=1;item_name[i]="Heavy Bolter";
 	    i+=1;item_name[i]="Heavy Flamer";
-		i+=1;item_name[i]="Twin Linked Heavy Bolters";
-		i+=1;item_name[i]="Twin Linked Heavy Lascannon";
-		i+=1;item_name[i]="Twin Linked Bolters";
-	    if (dude!=6){
-	        i+=1;item_name[i]="Hellrifle";
-	        i+=1;item_name[i]="Incinerator";
-	        i+=1;item_name[i]="Integrated Bolters";
-	    }
-	    i+=1;item_name[i]="Lascannon";
+			i+=1;item_name[i]="Hellrifle";
+	    i+=1;item_name[i]="Incinerator";
+	    i+=1;item_name[i]="Integrated Bolters";
+			i+=1;item_name[i]="Lascannon";
+	    i+=1;item_name[i]="Lascutter";
 	    i+=1;item_name[i]="Meltagun";
 	    i+=1;item_name[i]="Missile Launcher";
 	    i+=1;item_name[i]="Multi-Melta";
-		i+=1;item_name[i]="Inferno Cannon";
-		i+=1;item_name[i]="Autocannon";
-		i+=1;item_name[i]="Flamestorm Cannon";
-		i+=1;item_name[i]="Twin-Linked Assault Cannon";
-	    if (dude!=6){
-	        i+=1;item_name[i]="Plasma Gun";
-	        i+=1;item_name[i]="Plasma Pistol";
-	        i+=1;item_name[i]="Sniper Rifle";
-	        i+=1;item_name[i]="Storm Bolter";
-	        i+=1;item_name[i]="Webber";
-	    }
+			i+=1;item_name[i]="Autocannon";
+			i+=1;item_name[i]="Plasma Gun";
+			i+=1;item_name[i]="Plasma Pistol";
+			i+=1;item_name[i]="Sniper Rifle";
+			i+=1;item_name[i]="Storm Bolter";
+			i+=1;item_name[i]="Webber";
 	}
 
-	if (tc<3) and (tb=2){var i;i=0;
+	if (tc<3) and (tb=2) and (dude=1){var i;i=0; // Infantry Melee
 	    if (!instance_exists(obj_creation)) and (!instance_exists(obj_controller)){i+=1;item_name[i]="(None)";}
-    
-	    if (dude!=6){
-	        i+=1;item_name[i]="Boarding Shield";
-	        i+=1;item_name[i]="Chainaxe";
-	        i+=1;item_name[i]="Chainfist";
-	        i+=1;item_name[i]="Chainsword";
-	    }
-	    i+=1;item_name[i]="Close Combat Weapon";
-	    if (dude!=6){
-	        i+=1;item_name[i]="Combat Knife";
-	        i+=1;item_name[i]="Company Standard";
-	        if (!instance_exists(obj_creation)){i+=1;item_name[i]="Eldar Power Sword";}
-	        i+=1;item_name[i]="Eviscerator";
-	    }
-	    i+=1;item_name[i]="Force Weapon";
-	    if (dude!=6){
-	        i+=1;item_name[i]="Lascutter";
-	        i+=1;item_name[i]="Lightning Claw";
-	        i+=1;item_name[i]="Power Axe";
-	        i+=1;item_name[i]="Power Fist";
-	        i+=1;item_name[i]="Power Sword";
-	        i+=1;item_name[i]="Storm Shield";
-	        i+=1;item_name[i]="Thunder Hammer";
-	    }
+			i+=1;item_name[i]="Combat Knife";
+			i+=1;item_name[i]="Chainsword";
+			i+=1;item_name[i]="Chainaxe";
+			i+=1;item_name[i]="Eviscerator";
+			i+=1;item_name[i]="Power Sword";
+			i+=1;item_name[i]="Power Axe";
+			i+=1;item_name[i]="Power Fist";
+			i+=1;item_name[i]="Chainfist";
+			i+=1;item_name[i]="Force Weapon";
+			i+=1;item_name[i]="Thunder Hammer";
+			i+=1;item_name[i]="Boarding Shield";
+			i+=1;item_name[i]="Storm Shield";
+			i+=1;item_name[i]="Bolt Pistol";
+			i+=1;item_name[i]="Bolter";
+			if (instance_exists(obj_mass_equip)){i+=1;item_name[i]="Company Standard";}
 	}
 
-	/*
-	if (tc<3) and (tb=1){
-	    var i;i=0;
+	if (tc<3) and (tb=1) and (dude=6){var i;i=0; // Dreadnought Ranged
 	    i+=1;item_name[i]="(None)";
-	    if (dude!=6){
-	        i+=1;item_name[i]="Combat Knife";
-	        i+=1;item_name[i]="Chainsword";
-	        i+=1;item_name[i]="Chainaxe";
-	        i+=1;item_name[i]="Eviscerator";
-	        i+=1;item_name[i]="Power Sword";
-	        i+=1;item_name[i]="Power Axe";
-	        i+=1;item_name[i]="Power Fist";
-	        i+=1;item_name[i]="Chainfist";
-	        i+=1;item_name[i]="Force Weapon";
-	        i+=1;item_name[i]="Thunder Hammer";
-	        i+=1;item_name[i]="Boarding Shield";
-	        i+=1;item_name[i]="Storm Shield";
-	        i+=1;item_name[i]="Bolt Pistol";
-	        i+=1;item_name[i]="Bolter";
-	    }
-	    i+=1;item_name[i]="Heavy Bolter";
-	    if (dude!=6){
-	        i+=1;item_name[i]="Storm Bolter";
-	        i+=1;item_name[i]="Flamer";
-	        i+=1;item_name[i]="Combiflamer";
-	        i+=1;item_name[i]="Meltagun";
-	    }
-	    i+=1;item_name[i]="Multi-Melta";
-	    if (dude!=6){
-	        i+=1;item_name[i]="Plasma Pistol";
-	        i+=1;item_name[i]="Plasma Gun";
-	        i+=1;item_name[i]="Sniper Rifle";
-	    }
-	    i+=1;item_name[i]="Assault Cannon";
+      i+=1;item_name[i]="Assault Cannon";
 	    i+=1;item_name[i]="Missile Launcher";
-	    i+=1;item_name[i]="Lascannon";
-	    bad=0;if (instance_exists(obj_creation_popup)){if ((obj_creation_popup.type-100)!=6) then bad=1;}
-	    if (bad=0){i+=1;item_name[i]="Close Combat Weapon";}
-	    if (instance_exists(obj_mass_equip)){i+=1;item_name[i]="Company Standard";}
+	    i+=1;item_name[i]="Multi-Melta";
+			i+=1;item_name[i]="Autocannon";
+			i+=1;item_name[i]="Twin Linked Heavy Bolter";
+			i+=1;item_name[i]="Twin Linked Lascannon";
+			i+=1;item_name[i]="Twin Linked Bolters";
+			i+=1;item_name[i]="Inferno Cannon";
 	}
-	if (tc<3) and (tb=2){var i;i=0;
+
+	if (tc<3) and (tb=2) and (dude=6){var i;i=0; // Dreadnought Melee
+			if (!instance_exists(obj_creation)) and (!instance_exists(obj_controller)){i+=1;item_name[i]="(None)";}
+					i+=1;item_name[i]="Close Combat Weapon";
+	}
+
+	if (tc<3) and (tb=1) and (dude=50){var i;i=0; // Land Raider Weapons - these still need splitting into front and sponson mounts
 	    i+=1;item_name[i]="(None)";
-	    if (dude!=6){
-	        var bad;bad=0;if (instance_exists(obj_creation_popup)) then bad=1;
-	        if (bad=0){i+=1;item_name[i]="Company Standard";}
-	        i+=1;item_name[i]="Webber";
-	        i+=1;item_name[i]="Incinerator";
-	        i+=1;item_name[i]="Heavy Flamer";
-	        i+=1;item_name[i]="Hellrifle";
-	        i+=1;item_name[i]="Lascutter";
-	        i+=1;item_name[i]="Integrated Bolters";
-	        i+=1;item_name[i]="Archeotech Laspistol";
-			i += 1;item_name[i] = "Twin Linked Heavy Bolter"; // Added option for Twin Linked Heavy Bolter
-            i += 1;item_name[i] = "Twin Linked Lascannon"; // Added option for Twin Linked Lascannon
-	    }
-	}*/
+      i+=1;item_name[i]="Assault Cannon";
+	    i+=1;item_name[i]="Multi-Melta";
+			i+=1;item_name[i]="Twin Linked Heavy Bolter";
+			i+=1;item_name[i]="Twin Linked Lascannon";
+			i+=1;item_name[i]="Twin Linked Bolters";
+			i+=1;item_name[i]="Flamestorm Cannon";
+			i+=1;item_name[i]="Twin-Linked Assault Cannon";
+	}
+
+	if (tc<3) and (tb=1) and (dude=51){var i;i=0; // Rhino Weapons
+	    i+=1;item_name[i]="(None)";
+		  i+=1;item_name[i]="Bolter";
+			i+=1;item_name[i]="Combiflamer";
+			i+=1;item_name[i]="Twin Linked Bolters";
+			i+=1;item_name[i]="Storm Bolter";
+	}
+
+	if (tc=1) and (tb=1) and (dude=52){var i;i=0; // Predator Turret
+			i+=1;item_name[i]="(None)";
+			i+=1;item_name[i]="Autocannon";
+			i+=1;item_name[i]="Twin Linked Lascannon";
+			i+=1;item_name[i]="Flamestorm Cannon";
+			i+=1;item_name[i]="Twin-Linked Assault Cannon";
+	}
+
+	if (tc=2) and (tb=1) and (dude=52){var i;i=0; // Predator Sponsons
+			i+=1;item_name[i]="(None)";
+			i+=1;item_name[i]="Lascannons";
+			i+=1;item_name[i]="Heavy Bolters";
+			i+=1;item_name[i]="Heavy Flamer"; // needs proper twin sponson mount creating
+	}
+
+	if (tc=1) and (tb=1) and (dude=53){var i;i=0; // Land Speeder Primary
+			i+=1;item_name[i]="(None)";
+	    i+=1;item_name[i]="Multi-Melta";
+			i+=1;item_name[i]="Heavy Bolter";
+	}
+
+	if (tc=2) and (tb=1) and (dude=53){var i;i=0; // Land Speeder Secondary
+			i+=1;item_name[i]="(None)";
+	    i+=1;item_name[i]="Assault Cannon";
+			i+=1;item_name[i]="Heavy Flamer";
+	}
+
+	if (tc=1) and (tb=1) and (dude=54){var i;i=0; // Whirlwind Missiles
+			i+=1;item_name[i]="(None)";
+	    i+=1;item_name[i]="Whirlwind Missiles";
+	}
+
+	if (tc=2) and (tb=1) and (dude=54){var i;i=0; // Whirlwind Pintle
+		i+=1;item_name[i]="(None)";
+		i+=1;item_name[i]="Bolter";
+		i+=1;item_name[i]="Combiflamer";
+		i+=1;item_name[i]="Twin Linked Bolters";
+		i+=1;item_name[i]="Storm Bolter";
+	}
 
 	if (tc<3){
 	    if (instance_exists(obj_popup)){
@@ -173,9 +178,9 @@ function scr_weapons_equip() {
 	}
 
 
-	if (tc=3){
+	if (tc=3) and (dude=1){ // dude=1 for normal infantry gear
 	    var i;i=0;
-    
+
 	    if (!instance_exists(obj_creation)) and (!instance_exists(obj_mass_equip)){
 	        i+=1;item_name[i]="(None)";
 	        i+=1;item_name[i]="Scout Armor";
@@ -189,50 +194,40 @@ function scr_weapons_equip() {
 	        i+=1;item_name[i]="Terminator Armor";
 	        i+=1;item_name[i]="Tartaros";
 	    }
-    
+
 	    if (instance_exists(obj_creation)) or (instance_exists(obj_mass_equip)){
 	        var bub;bub=0;
 	        i+=1;item_name[i]="Scout Armor";
-        
 	        if (instance_exists(obj_creation)){if (type=112) then bub=1;}
 	        if (instance_exists(obj_mass_equip)){if (obj_controller.settings=12) then bub=1;}
-        
-	        // if (bub=0){
-	            i+=1;item_name[i]="Power Armor";
-	            i+=1;item_name[i]="Terminator Armor";
-            
-	        // }
+	        i+=1;item_name[i]="Power Armor";
+	        i+=1;item_name[i]="Terminator Armor";
 	    }
-    
-	    if (instance_exists(obj_controller))/* and (instance_exists(obj_popup))*/ then i+=2;
+
 	    else i+=1;
-    
+
 	    // var bad;bad=0;if (instance_exists(obj_creation_popup)){if ((obj_creation_popup.type-100)!=6) then bad=1;}
 	    // if (bad=0){item_name[i]="Dreadnought";}
 	}
-	if (tc=4){
+	if (tc=4) and (dude=1){ // dude=1 for normal infantry gear
 	    var i;i=0;
 	    i+=1;item_name[i]="(None)";
-	    if (dude!=6){
-	        // i+=1;item_name[i]="Bionics";
-	        i+=1;item_name[i]="Iron Halo";
-	        i+=1;item_name[i]="Master Servo Arms";
-	        i+=1;item_name[i]="Narthecium";
-	        i+=1;item_name[i]="Psychic Hood";
-	        i+=1;item_name[i]="Rosarius";
-	        i+=1;item_name[i]="Servo Arms";
-	        i+=1;
-	        if (!instance_exists(obj_creation)){i+=1;item_name[i]="Exterminatus";}
-	        if (!instance_exists(obj_creation)){i+=1;item_name[i]="Plasma Bomb";}
-	    }
+	    // i+=1;item_name[i]="Bionics";
+	    i+=1;item_name[i]="Iron Halo";
+	    i+=1;item_name[i]="Master Servo Arms";
+	    i+=1;item_name[i]="Narthecium";
+	    i+=1;item_name[i]="Psychic Hood";
+	    i+=1;item_name[i]="Rosarius";
+	    i+=1;item_name[i]="Servo Arms";
+	    i+=1;
+	    if (!instance_exists(obj_creation)){i+=1;item_name[i]="Exterminatus";}
+	    if (!instance_exists(obj_creation)){i+=1;item_name[i]="Plasma Bomb";}
 	}
-	if (tc=5){
+	if (tc=5) and (dude=1){ // dude=1 for normal infantry gear
 	    var i;i=0;
 	    i+=1;item_name[i]="(None)";
-	    if (dude!=6){
-	        i+=1;item_name[i]="Bike";
-	        i+=1;item_name[i]="Jump Pack";
-	    }
+	    i+=1;item_name[i]="Bike";
+	    i+=1;item_name[i]="Jump Pack";
 	}
 
 


### PR DESCRIPTION
All vehicles can now be reequipped, although the double-weapon bug currently prevents rhinos being modified.

Equip script now checks the unit type for lists of valid equipment under more circumstances. Dreadnoughts should now only ever see dreadnought gear, predators see pred gear etc. Some vehicles have different weapon slots between slot 1 and slot 2 to differentiate between turrets and sponsons.