### PR TITLE
[made by Frost] disposition system changes

### DIFF
--- a/scripts/scr_enemy_ai_a/scr_enemy_ai_a.gml
+++ b/scripts/scr_enemy_ai_a/scr_enemy_ai_a.gml
@@ -616,14 +616,25 @@ function scr_enemy_ai_a() {
 	                    badd=2;
 	                }
                 
-	                if (owner<=5){
-	                    if (badd=1) and (p_tyranids[run]=0) and (p_necrons[run]=0) and (p_sisters[run]=0) then scr_alert("red","owner",string(name)+" "+string(run)+" has been overwhelmed by Orks!",x,y);
-	                    if (badd=2) and (p_tyranids[run]=0) and (p_necrons[run]=0) and (p_sisters[run]=0){
-	                        scr_popup("System Lost","The "+string(name)+" system has been ovewhelmed by Orks!","orks","");
-	                        scr_event_log("red","System "+string(name)+" has been overwhelmed by Orkz.");
-	                        // owner=7;p_owner[1]=7;p_owner[2]=7;p_owner[3]=7;p_owner[4]=7;
-	                    }
-	                }
+					if (owner <= 5) {
+    					if (badd = 1) and(p_tyranids[run] = 0) and(p_necrons[run] = 0) and(p_sisters[run] = 0) {
+        					scr_alert("red", "owner", string(name) + " " + string(run) + " has been overwhelmed by Orks!", x, y);
+        					if (visited == 1) { //visited variable check whether the star has been visisted or not 1 for true 0 for false
+            					if (p_type[run] == "Forge") {
+					                dispo[run] -= 10; // 10 Disposition decrease for the planet govrnor if it's overrun by orks
+					                obj_controller.disposition[3] -= 10; // obj_controller.disposition[3] refer to the disposition of the toaster jocks.
+					            } else if (planet_feature_bool(p_feature[run], P_features.Sororitas_Cathedral) or(p_type[run] == "Shrine")) {
+					                dispo[run] -= 10; // diso[run] is the disposition of the planet. where run refer to the planet that is currently running the code.
+					                obj_controller.disposition[5] -= 5; // obj_controller.disposition[2] refer to the disposition of the sororitas while 3 refer to mechanicus
+					            } else dispo[run] -= 10;
+					        }
+					    } // diso[run] is the disposition of the planet. where run refer to the planet that is currently running the code.
+					    if (badd = 2) and(p_tyranids[run] = 0) and(p_necrons[run] = 0) and(p_sisters[run] = 0) {
+					        scr_popup("System Lost", "The " + string(name) + " system has been ovewhelmed by Orks!", "orks", "");
+					        scr_event_log("red", "System " + string(name) + " has been overwhelmed by Orkz.");
+					        // owner=7;p_owner[1]=7;p_owner[2]=7;p_owner[3]=7;p_owner[4]=7;
+					    }
+					}
 	            }
 	        }
 	        if (ork_attack="sisters"){
@@ -725,58 +736,6 @@ function scr_enemy_ai_a() {
 	            if (rand1>rand2) then temp11-=1;
 	        }
 	    }
-    
-    
-    
-    
-    
-    
-    
-	    // eldar attack
-	    /*if (eldar_score>0) and (eldar_attack!="") and (eldar_attack!="player"){
-	        rand1=choose(1,2,3,4,5,6,7)*eldar_score;
-	        if (eldar_score=6) then rand1=choose(30,36);
-        
-	        if (eldar_attack="tau"){
-	            rand2=(choose(1,2,3,4,5)*tau_score)*choose(1,1.25);
-	            if (rand1>rand2) then temp4-=1;
-	        }
-	        if (eldar_attack="ork"){
-	            rand2=(choose(1,2,3,4,5)*ork_score)*choose(1,1.25);
-	            if (rand1>rand2) then temp3-=1;
-	        }
-	        if (eldar_attack="traitors"){
-	            rand2=(choose(1,2,3,4,5)*traitors_score)*choose(1,1.25);
-	            if (rand1>rand2) then temp10=1;
-	        }
-        
-	        if (eldar_attack="guard"){
-	            rand2=(choose(1,2,3,4,5)*guard_score)*choose(1,1.25);
-	            if (rand1>rand2){
-	                if (eldar_score<=3) then p_guardsmen[run]=floor(p_guardsmen[run]*0.7);
-	                if (eldar_score>=4) then p_guardsmen[run]=floor(p_guardsmen[run]*0.6);
-	                if (eldar_score>=6) then p_guardsmen[run]=floor(p_guardsmen[run]*0.3);
-	                if (eldar_score>=4) and (p_guardsmen[run]<15000) then p_guardsmen[run]=0;
-	                if (eldar_score>=3) and (p_guardsmen[run]<5000) then p_guardsmen[run]=0;
-	                if (eldar_score>=2) and (p_guardsmen[run]<1000) then p_guardsmen[run]=0;
-	                if (eldar_score>=1) and (p_guardsmen[run]<500) then p_guardsmen[run]=0;
-	            }
-	        }
-	        if (eldar_attack="pdf"){
-	            rand2=(choose(1,2,3,4,5)*pdf_score)*choose(1,1.25);
-	            if (rand1>rand2){
-	                if (eldar_score>=6) then p_pdf[run]=0;
-	                if (eldar_score<=3) then p_pdf[run]=floor(p_pdf[run]*0.7);
-	                if (eldar_score>=4) then p_pdf[run]=floor(p_pdf[run]*0.6);
-	                if (eldar_score>=4) and (p_pdf[run]<60000) then p_pdf[run]=0;
-	                if (eldar_score>=3) and (p_pdf[run]<20000) then p_pdf[run]=0;
-	                if (eldar_score>=2) and (p_pdf[run]<3000) then p_pdf[run]=0;
-	                if (eldar_score>=1) and (p_pdf[run]<1000) then p_pdf[run]=0;
-	            }
-	        }
-	    }*/
-    
-    
     
     
 	    // Tyranids attack
@@ -891,7 +850,19 @@ function scr_enemy_ai_a() {
 	                    badd=2;
 	                }
                 
-	                if (badd=1) and (p_tyranids[run]<5) and (p_orks[run]=0) and (p_traitors[run]=0) then scr_alert("red","owner",string(name)+" "+string(run)+" has been overwhelmed by Necrons!",x,y);
+					if (badd = 1) and(p_tyranids[run] < 5) and(p_orks[run] = 0) and(p_traitors[run] = 0) {
+					    scr_alert("red", "owner", string(name) + " " + string(run) + " has been overwhelmed by Necrons!", x, y);
+					    if (visited == 1) {
+					        if (p_type[run] == "Forge") { //visited variable check whether the star has been visisted or not 1 for true 0 for false
+					            dispo[run] -= 10; // 10 Disposition decrease for the planet govrnor if it's overrun by necrons
+					            obj_controller.disposition[3] -= 10; // 10 dis decrease for the faction mechanicus
+					        } else if (planet_feature_bool(p_feature[run], P_features.Sororitas_Cathedral) or(p_type[run] == "Shrine")) {
+					            dispo[run] -= 10; // 10 Disposition decrease for the planet govrnor if it's overrun by necrons
+					            obj_controller.disposition[5] -= 5; // 5 dis decrease for the Nurses
+					        } else dispo[run] -= 10;
+					    }
+					}
+					
 	                if (badd=2) and (p_tyranids[run]<5) and (p_orks[run]=0) and (p_traitors[run]=0){
 	                    scr_popup("System Lost","The "+string(name)+" system has been ovewhelmed by Necrons!","necron_army","");
 	                    scr_event_log("red","System "+string(name)+" has been overwhelmed by Necrons.");
@@ -922,93 +893,216 @@ function scr_enemy_ai_a() {
     
     
 	    // 135;
-    
-	    if (p_owner[run]=7) and (p_player[run]+p_raided[run]>0) and (p_orks[run]=0) and (p_tyranids[run]<4) and (p_chaos[run]=0) and (p_traitors[run]=0) and (p_necrons[run]=0) and (p_tau[run]=0){
-	        scr_event_log("","Orks cleansed from "+string(name)+" "+scr_roman(run));
-	        if (p_first[run]=1){p_owner[run]=1;scr_alert("green","owner","Orks cleansed from "+string(name)+" "+scr_roman(run)+".",x,y);}
-	        if (p_first[run]=2){p_owner[run]=2;scr_alert("green","owner","Orks cleansed from "+string(name)+" "+scr_roman(run)+".  Control returned to the governor.",x,y);}
-	        if (p_first[run]=3){p_owner[run]=3;scr_alert("green","owner","Orks cleansed from "+string(name)+" "+scr_roman(run)+".  Control returned to Mechanicus.",x,y);}
-	        if (dispo[run]=101) then p_owner[run]=1;
+	    p_time_since_saved[run] = 0;
+	    if (p_owner[run] = 7) and(p_player[run] + p_raided[run] > 0) and(p_orks[run] = 0) and(p_tyranids[run] < 4) and(p_chaos[run] = 0) and(p_traitors[run] = 0) and(p_necrons[run] = 0) and(p_tau[run] = 0) {
+	        scr_event_log("", "Orks cleansed from " + string(name) + " " + scr_roman(run));
+	        if (p_first[run] = 1) and((obj_controller.turn - p_time_since_saved[run]) >= 5) {
+	            p_owner[run] = 1;
+	            scr_alert("green", "owner", "Orks cleansed from " + string(name) + " " + scr_roman(run) + ".", x, y);
+	            dispo[run] += 10;
+	            p_time_since_saved[run] = obj_controller.turn;
+	            obj_controller.disposition[5] += 5;
+	        } // 10 Disposition increase for returning control to the governor Planet disposition
+	        if (p_first[run] = 2) and((obj_controller.turn - p_time_since_saved[run]) >= 5) {
+	            p_owner[run] = 2;
+	            scr_alert("green", "owner", "Orks cleansed from " + string(name) + " " + scr_roman(run) + ".  Control returned to the governor.", x, y);
+	            dispo[run] += 10;
+	            p_time_since_saved[run] = obj_controller.turn;
+	        } // 10 Disposition increase for returning control to the governor Planet disposition
+	        if (p_first[run] = 3) and((obj_controller.turn - p_time_since_saved[run]) >= 5) {
+	            p_owner[run] = 3;
+	            scr_alert("green", "owner", "Orks cleansed from " + string(name) + " " + scr_roman(run) + ".  Control returned to Mechanicus.", x, y);
+	            obj_controller.disposition[3] += 10;
+	            dispo[run] += 10;
+	            p_time_since_saved[run] = obj_controller.turn;
+	        } // 10 Disposition increase for returning control to the governor Planet disposition
+	        if (dispo[run] = 101) then p_owner[run] = 1;
 	    }
-	    if (p_owner[run]=8) and (p_player[run]+p_raided[run]>0) and (p_orks[run]=0) and (p_tyranids[run]<4) and (p_chaos[run]=0) and (p_traitors[run]=0) and (p_necrons[run]=0) and (p_tau[run]=0) and (p_pdf[run]=0){
-	        scr_event_log("","Tau cleansed from "+string(name)+" "+scr_roman(run));
-	        if (p_first[run]=1){p_owner[run]=1;scr_alert("green","owner","Tau cleansed from "+string(name)+" "+scr_roman(run)+".",x,y);}
-	        if (p_first[run]=2){p_owner[run]=2;scr_alert("green","owner","Tau cleansed from "+string(name)+" "+scr_roman(run)+".  Control given to new governor.",x,y);}
-	        if (p_first[run]=3){p_owner[run]=3;scr_alert("green","owner","Tau cleansed from "+string(name)+" "+scr_roman(run)+".  Control returned to Mechanicus.",x,y);}
-	        if (dispo[run]=101) then p_owner[run]=1;
+	    if (p_owner[run] = 8) and(p_player[run] + p_raided[run] > 0) and(p_orks[run] = 0) and(p_tyranids[run] < 4) and(p_chaos[run] = 0) and(p_traitors[run] = 0) and(p_necrons[run] = 0) and(p_tau[run] = 0) and(p_pdf[run] = 0) {
+	        scr_event_log("", "Tau cleansed from " + string(name) + " " + scr_roman(run));
+	        if (p_first[run] = 1) and((obj_controller.turn - p_time_since_saved[run]) >= 5) {
+	            p_owner[run] = 1;
+	            scr_alert("green", "owner", "Tau cleansed from " + string(name) + " " + scr_roman(run) + ".", x, y);
+	            dispo[run] += 10;
+	            p_time_since_saved[run] = obj_controller.turn;
+	            obj_controller.disposition[5] += 5;
+	        } // 10 Disposition increase for returning control to the governor Planet disposition
+	        if (p_first[run] = 2) and((obj_controller.turn - p_time_since_saved[run]) >= 5) {
+	            p_owner[run] = 2;
+	            scr_alert("green", "owner", "Tau cleansed from " + string(name) + " " + scr_roman(run) + ".  Control given to new governor.", x, y);
+	            dispo[run] += 10;
+	            p_time_since_saved[run] = obj_controller.turn
+	        } // 10 Disposition increase for returning control to the governor Planet disposition
+	        if (p_first[run] = 3) and((obj_controller.turn - p_time_since_saved[run]) >= 5) {
+	            p_owner[run] = 3;
+	            scr_alert("green", "owner", "Tau cleansed from " + string(name) + " " + scr_roman(run) + ".  Control returned to Mechanicus.", x, y);
+	            obj_controller.disposition[3] += 10;
+	            dispo[run] += 10;
+	            p_time_since_saved[run] = obj_controller.turn
+	        } // 10 Disposition increase for returning control to the governor Planet disposition
+	        if (dispo[run] = 101) then p_owner[run] = 1;
 	    }
-	    if (p_owner[run]=10) and (p_player[run]+p_raided[run]>0) and (p_orks[run]=0) and (p_tyranids[run]<4) and (p_chaos[run]=0) and (p_traitors[run]=0) and (p_necrons[run]=0) and (p_tau[run]=0){
-	        scr_event_log("","Chaos cleansed from "+string(name)+" "+scr_roman(run));
-	        if (p_first[run]=1){p_owner[run]=1;scr_alert("green","owner","Chaos cleansed from "+string(name)+" "+scr_roman(run)+".",x,y);}
-	        if (p_first[run]=2){p_owner[run]=2;scr_alert("green","owner","Chaos cleansed from "+string(name)+" "+scr_roman(run)+".  Control returned to the governor.",x,y);}
-	        if (p_first[run]=3){p_owner[run]=3;scr_alert("green","owner","Chaos cleansed from "+string(name)+" "+scr_roman(run)+".  Control returned to Mechanicus.",x,y);}
-	        if (dispo[run]=101) then p_owner[run]=1;
+	    if (p_owner[run] = 10) and(p_player[run] + p_raided[run] > 0) and(p_orks[run] = 0) and(p_tyranids[run] < 4) and(p_chaos[run] = 0) and(p_traitors[run] = 0) and(p_necrons[run] = 0) and(p_tau[run] = 0) {
+	        scr_event_log("", "Chaos cleansed from " + string(name) + " " + scr_roman(run));
+	        if (p_first[run] = 1) and((obj_controller.turn - p_time_since_saved[run]) >= 5) {
+	            p_owner[run] = 1;
+	            scr_alert("green", "owner", "Chaos cleansed from " + string(name) + " " + scr_roman(run) + ".", x, y);
+	            dispo[run] += 10;
+	            p_time_since_saved[run] = obj_controller.turn;
+	            obj_controller.disposition[5] += 5;
+	        } // 10 Disposition increase for returning control to the governor Planet disposition
+	        if (p_first[run] = 2) and((obj_controller.turn - p_time_since_saved[run]) >= 5) {
+	            p_owner[run] = 2;
+	            scr_alert("green", "owner", "Chaos cleansed from " + string(name) + " " + scr_roman(run) + ".  Control returned to the governor.", x, y);
+	            dispo[run] += 10;
+	            p_time_since_saved[run] = obj_controller.turn
+	        } // 10 Disposition increase for returning control to the governor Planet disposition
+	        if (p_first[run] = 3) and((obj_controller.turn - p_time_since_saved[run]) >= 5) {
+	            p_owner[run] = 3;
+	            scr_alert("green", "owner", "Chaos cleansed from " + string(name) + " " + scr_roman(run) + ".  Control returned to Mechanicus.", x, y);
+	            obj_controller.disposition[3] += 10;
+	            dispo[run] += 10;
+	            p_time_since_saved[run] = obj_controller.turn
+	        } // 10 Disposition increase for returning control to the governor Planet disposition
+	        if (dispo[run] = 101) then p_owner[run] = 1;
 	    }
-	    if (p_owner[run]=13) and (p_player[run]+p_raided[run]>0) and (p_orks[run]=0) and (p_tyranids[run]<4) and (p_chaos[run]=0) and (p_traitors[run]=0) and (p_necrons[run]=0) and (p_tau[run]=0){
-	        if (awake_tomb_world(p_feature[run])!=1){
-	            scr_event_log("","Necrons cleansed from "+string(name)+" "+scr_roman(run));
-	            if (p_first[run]=1){p_owner[run]=1;scr_alert("green","owner","Necrons cleansed from "+string(name)+" "+scr_roman(run)+".",x,y);}
-	            if (p_first[run]=2){p_owner[run]=2;scr_alert("green","owner","Necrons cleansed from "+string(name)+" "+scr_roman(run)+".  Control returned to the governor.",x,y);}
-	            if (p_first[run]=3){p_owner[run]=3;scr_alert("green","owner","Necrons cleansed from "+string(name)+" "+scr_roman(run)+".  Control returned to Mechanicus.",x,y);}
-	            if (dispo[run]=101) then p_owner[run]=1;
+	    if (p_owner[run] = 13) and(p_player[run] + p_raided[run] > 0) and(p_orks[run] = 0) and(p_tyranids[run] < 4) and(p_chaos[run] = 0) and(p_traitors[run] = 0) and(p_necrons[run] = 0) and(p_tau[run] = 0) {
+	        if (awake_tomb_world(p_feature[run]) != 1) {
+	            scr_event_log("", "Necrons cleansed from " + string(name) + " " + scr_roman(run));
+	            if (p_first[run] = 1) and((obj_controller.turn - p_time_since_saved[run]) >= 5) {
+	                p_owner[run] = 1;
+	                scr_alert("green", "owner", "Necrons cleansed from " + string(name) + " " + scr_roman(run) + ".", x, y);
+	                dispo[run] += 10;
+	                p_time_since_save[run] = obj_controller.turn;
+	                obj_controller.disposition[5] += 5;
+	            } // 10 Disposition increase for returning control to the governor Planet disposition
+	            if (p_first[run] = 2) and((obj_controller.turn - p_time_since_saved[run]) >= 5) {
+	                p_owner[run] = 2;
+	                scr_alert("green", "owner", "Necrons cleansed from " + string(name) + " " + scr_roman(run) + ".  Control returned to the governor.", x, y);
+	                dispo[run] += 10;
+	                p_time_since_saved[run] = obj_controller.turn
+	            } // 10 Disposition increase for returning control to the governor Planet disposition
+	            if (p_first[run] = 3) and((obj_controller.turn - p_time_since_saved[run]) >= 5) {
+	                p_owner[run] = 3;
+	                scr_alert("green", "owner", "Necrons cleansed from " + string(name) + " " + scr_roman(run) + ".  Control returned to Mechanicus.", x, y);
+	                obj_controller.disposition[3] += 10;
+	                dispo[run] += 10;
+	                p_time_since_saved[run] = obj_controller.turn
+	            } // 10 Disposition increase for returning control to the governor Planet disposition
+	            if (dispo[run] = 101) then p_owner[run] = 1;
 	        }
 	    }
-	    if (p_raided[run]>0) then p_raided[run]=0;
-	}// end repeat here
+	    if (p_raided[run] > 0) then p_raided[run] = 0;
+	    } // end repeat here
 
 
-	// quene player battles here
+	    // quene player battles here
 
 
-	// End quene player battles
-
-
-
-	scr_star_ownership(true);
+	    // End quene player battles
 
 
 
+	    scr_star_ownership(true);
 
-	// Restock PDF and military
-	var i;i=0;repeat(4){i+=1;
-	    if (p_type[i]="Daemon"){p_heresy[i]=200;p_owner[i]=10;}
-    
-	    if (p_population[i]<=0) and (p_large[i]=0) and (p_chaos[i]=0) and (p_traitors[i]=0) and (p_tau[i]=0) and (p_type[i]!="Daemon") then p_heresy[i]=0;
-	    if (p_population[i]<1) and (p_large[i]=1){p_population[i]=p_population[i]*100000000;p_large[i]=0;}
-    
-	    if (p_owner[i]=2) and (p_type[i]!="Dead") and (planets>=i) and (p_tyranids[i]=0) and (p_chaos[i]=0) and (p_traitors[i]=0) and (p_eldar[i]=0) and (p_tau[i]=0){
-	        var military, pdf,rando,contin;
-	        military=0;pdf=0;contin=0;
-	        rando=floor(random(100))+1;
-        
-	        if (p_population[i]>=10000000){military=(p_population[i]/470);pdf=floor(military*0.75);military=floor(military*0.25);}
-	        if (p_population[i]>=5000000) and (p_population[i]<10000000){military=p_population[i]/200;pdf=floor(military*0.75);military=floor(military*0.25);}
-	        if (p_population[i]>=100000) and (p_population[i]<5000000){military=p_population[i]/50;pdf=floor(military*0.75);military=floor(military*0.25);}
-	        if (p_large[i]=1){military=military*1000000000;pdf=pdf*1000000000;}
-        
-	        if (p_large[i]=0) and (rando<50) and (military!=0) and (pdf!=0){
-	            // if (p_guardsmen[i]<military) and (rando<50){rando=10;contin=max(floor(p_guardsmen[i]*1.05),500);p_population[i]-=contin;p_guardsmen[i]+=contin;}/
-	            if (p_pdf[i]<pdf) and (rando<50){rando=1;rando=10;contin=max(floor(p_pdf[i]*1.02),1000);p_population[i]-=contin;p_pdf[i]+=contin;}
+
+
+
+	    // Restock PDF and military
+	    var i;
+	    i = 0;
+	    repeat(4) {
+	        i += 1;
+	        if (p_type[i] = "Daemon") {
+	            p_heresy[i] = 200;
+	            p_owner[i] = 10;
 	        }
-	        if (p_large[i]=1) and (rando<50) and (military!=0) and (pdf!=0){
-	            // if (p_guardsmen[i]<military) and (rando<50){rando=10;contin=0.01*p_population[i];p_guardsmen[i]+=contin*1250000;}
-	            if (p_pdf[i]<pdf) and (rando<50){rando=1;rando=10;contin=0.01*p_population[i];p_pdf[i]+=contin*1250000;}
+
+	        if (p_population[i] <= 0) and(p_large[i] = 0) and(p_chaos[i] = 0) and(p_traitors[i] = 0) and(p_tau[i] = 0) and(p_type[i] != "Daemon") then p_heresy[i] = 0;
+	        if (p_population[i] < 1) and(p_large[i] = 1) {
+	            p_population[i] = p_population[i] * 100000000;
+	            p_large[i] = 0;
 	        }
-        
-	        if (p_large[i]=1){military=floor(p_population[i]*1250000);pdf=military*3;}
-	        if (p_population[i]<100000) and (p_population[i]>5) and (p_large[i]=0){pdf=floor(p_population[i]/25);military=0;}
-	        if (p_population[i]<2000) and (p_population[i]>5) and (p_large[i]=0){pdf=floor(p_population[i]/10);military=0;}
-        
-	        if (p_large[i]=0) and (rando<3){
-	            // if (p_guardsmen[i]<military) and (rando<3){rando=1;contin=max(floor(p_guardsmen[i]*1.05),500);p_population[i]-=contin;p_guardsmen[i]+=contin;}
-	            if (p_pdf[i]<pdf) and (rando<3){rando=1;rando=1;contin=max(floor(p_pdf[i]*1.02),1000);p_population[i]-=contin;p_pdf[i]+=contin;}
-	        }
-	        if (p_large[i]=1) and (rando<3){
-	            // if (p_guardsmen[i]<military) and (rando<3){rando=1;contin=0.01*p_population[i];p_guardsmen[i]+=floor(contin*1250000);}
-	            if (p_pdf[i]<pdf) and (rando<3){rando=1;rando=1;contin=0.01*p_population[i];p_pdf[i]+=floor(contin*1250000);}
+
+	        if (p_owner[i] = 2) and(p_type[i] != "Dead") and(planets >= i) and(p_tyranids[i] = 0) and(p_chaos[i] = 0) and(p_traitors[i] = 0) and(p_eldar[i] = 0) and(p_tau[i] = 0) {
+	            var military, pdf, rando, contin;
+	            military = 0;
+	            pdf = 0;
+	            contin = 0;
+	            rando = floor(random(100)) + 1;
+
+	            if (p_population[i] >= 10000000) {
+	                military = (p_population[i] / 470);
+	                pdf = floor(military * 0.75);
+	                military = floor(military * 0.25);
+	            }
+	            if (p_population[i] >= 5000000) and(p_population[i] < 10000000) {
+	                military = p_population[i] / 200;
+	                pdf = floor(military * 0.75);
+	                military = floor(military * 0.25);
+	            }
+	            if (p_population[i] >= 100000) and(p_population[i] < 5000000) {
+	                military = p_population[i] / 50;
+	                pdf = floor(military * 0.75);
+	                military = floor(military * 0.25);
+	            }
+	            if (p_large[i] = 1) {
+	                military = military * 1000000000;
+	                pdf = pdf * 1000000000;
+	            }
+
+	            if (p_large[i] = 0) and(rando < 50) and(military != 0) and(pdf != 0) {
+	                // if (p_guardsmen[i]<military) and (rando<50){rando=10;contin=max(floor(p_guardsmen[i]*1.05),500);p_population[i]-=contin;p_guardsmen[i]+=contin;}/
+	                if (p_pdf[i] < pdf) and(rando < 50) {
+	                    rando = 1;
+	                    rando = 10;
+	                    contin = max(floor(p_pdf[i] * 1.02), 1000);
+	                    p_population[i] -= contin;
+	                    p_pdf[i] += contin;
+	                }
+	            }
+	            if (p_large[i] = 1) and(rando < 50) and(military != 0) and(pdf != 0) {
+	                // if (p_guardsmen[i]<military) and (rando<50){rando=10;contin=0.01*p_population[i];p_guardsmen[i]+=contin*1250000;}
+	                if (p_pdf[i] < pdf) and(rando < 50) {
+	                    rando = 1;
+	                    rando = 10;
+	                    contin = 0.01 * p_population[i];
+	                    p_pdf[i] += contin * 1250000;
+	                }
+	            }
+
+	            if (p_large[i] = 1) {
+	                military = floor(p_population[i] * 1250000);
+	                pdf = military * 3;
+	            }
+	            if (p_population[i] < 100000) and(p_population[i] > 5) and(p_large[i] = 0) {
+	                pdf = floor(p_population[i] / 25);
+	                military = 0;
+	            }
+	            if (p_population[i] < 2000) and(p_population[i] > 5) and(p_large[i] = 0) {
+	                pdf = floor(p_population[i] / 10);
+	                military = 0;
+	            }
+
+	            if (p_large[i] = 0) and(rando < 3) {
+	                // if (p_guardsmen[i]<military) and (rando<3){rando=1;contin=max(floor(p_guardsmen[i]*1.05),500);p_population[i]-=contin;p_guardsmen[i]+=contin;}
+	                if (p_pdf[i] < pdf) and(rando < 3) {
+	                    rando = 1;
+	                    rando = 1;
+	                    contin = max(floor(p_pdf[i] * 1.02), 1000);
+	                    p_population[i] -= contin;
+	                    p_pdf[i] += contin;
+	                }
+	            }
+	            if (p_large[i] = 1) and(rando < 3) {
+	                // if (p_guardsmen[i]<military) and (rando<3){rando=1;contin=0.01*p_population[i];p_guardsmen[i]+=floor(contin*1250000);}
+	                if (p_pdf[i] < pdf) and(rando < 3) {
+	                    rando = 1;
+	                    rando = 1;
+	                    contin = 0.01 * p_population[i];
+	                    p_pdf[i] += floor(contin * 1250000);
+	                }
+	            }
 	        }
 	    }
-	}
-
-
 }

--- a/scripts/scr_enemy_ai_b/scr_enemy_ai_b.gml
+++ b/scripts/scr_enemy_ai_b/scr_enemy_ai_b.gml
@@ -148,8 +148,24 @@ function scr_enemy_ai_b() {
 	        if (p_heresy[i]+p_heresy_secret[i]>=70) and (rando<=25) and (p_owner[i]!=7) then contin=1;
 	        if (p_heresy[i]+p_heresy_secret[i]>=90) and (rando<=40) and (p_owner[i]!=7) then contin=1;
         
-	        if (contin>0) and (p_pdf[i]=0) and (p_guardsmen[i]=0) and (p_tau[i]=0) and (p_orks[i]=0){p_owner[i]=10;
+	        if (contin>0) and (p_pdf[i]=0) and (p_guardsmen[i]=0) and (p_tau[i]=0) and (p_orks[i]=0){
+				p_owner[i]=10;
 	            scr_alert("red","owner",string(name)+" "+string(i)+" has fallen to heretics!",x,y);
+				if (visited==1) { //visited variable check whether the star has been visited or not 1 for true 0 for false
+					if(p_type[i]=="Forge") { 
+				  		dispo[i]-=10; // 10 disposition decreases for the respective planet
+				  		obj_controller.disposition[3]-=10;// 10 disposition decrease for the toaster Fetishest since they aren't that numerous
+					} 
+				    else if(planet_feature_bool(p_feature[i], P_features.Sororitas_Cathedral) or (p_type[i]=="Shrine")) {
+                        dispo[i]-=10; // similarly 10 disposition decrease, note those nurses are a bit pissy and
+                                      // and you can't easily gain their favor because you cannot ask them to "step down" from office.
+			            obj_controller.disposition[5]-=5;
+					} // the missus diplomacy 0 is when they cringe when you enter the office and cannot ask them for a date.
+				    else { 
+						dispo[i]-=10;
+					}  // This condition apply when imperium is on control, Because they control so many worlds, you aren't going to gain favor by removing the needle. Also that's your job Astrate take your complaints to your father.
+                }
+
 	        }
         
 	        if (contin>0) and (p_type[i]!="Space Hulk"){
@@ -267,7 +283,20 @@ function scr_enemy_ai_b() {
                 
 	                if (have=targ) then badd=2;
                 
-	                if (badd=1) then scr_alert("red","owner","Planet "+string(name)+" "+string(i)+" has succeeded to the Tau Empire!",x,y);
+	                if (badd=1){ 
+						scr_alert("red","owner","Planet "+string(name)+" "+string(i)+" has succeeded to the Tau Empire!",x,y);
+						if (visited==1) {  //visited variable checks whether the star has been visited by the chapter or not 1 for true 0 for false
+							if(p_type[i]=="Forge") { 
+								dispo[i]-=10; // 10 disposition decreases for the respective planet
+								obj_controller.disposition[3]-=10; // 10 disposition decrease for the toaster Fetishest since they aren't that many toasters in 41 millennia
+							}  
+							else if(planet_feature_bool(p_feature[i], P_features.Sororitas_Cathedral) or (p_type[i]=="Shrine")) { 
+								dispo[i]-=10; // 10 disposition decreases for the respective planet
+								obj_controller.disposition[5]-=5;} 
+							else dispo[i]-=10; // you had only 1 job.
+						} 
+					}
+
 	                if (badd=2){
 	                    scr_popup("System Lost","The "+string(name)+" system has been taken by the Tau Empire!","tau","");owner=8;
 	                    scr_event_log("red","System "+string(name)+" has been taken by the Tau Empire.");
@@ -281,10 +310,7 @@ function scr_enemy_ai_b() {
     
     
 	    }// End repeat
-    
-    
-    
-    
+       
 	}
 
 
@@ -303,14 +329,6 @@ function scr_enemy_ai_b() {
 	        if (spread=1) then p_tyranids[i]+=1;
 	    }
 	}
-
-
-
-
-
-
-
-
 
 	i=0;
 	repeat(4){i+=1;


### PR DESCRIPTION
[Provided by @death0frost] The new disposition system is intricately tied to your influence. As you visit planets, they become integrated into your sphere of control. Within these sectors, factions will request your aid in safeguarding their key locations. For instance, the Adeptus Mechanicus values their Forge Worlds, while the Sisters of Battle prioritize shrines and cathedrals. Allowing these sites to be overwhelmed will harm your reputation and influence as your overall faction standing diminishes due to your perceived negligence.
This can be distilled into the following categories:

1- Imperium: As the commander of the Imperial sector, your efforts to secure planets for them won't be rewarded with disposition points. The scale of planetary management makes it nearly impossible to monitor every world, suddenly the term "needle in a haystack." is relevant. You'll gain 10 disposition points for successfully safeguarding an Imperium-controlled planet, but you'll experience a deduction of 10 points if the planet falls to enemy forces.

Sisters of Battle: The Sisters of Battle have a distinct approach. Their influence surpasses that of the Mechanicus, so allowing numerous sacred sites to be lost will displease their leader. A loss of 5 disposition points will result from such failures. Just like with Imperium planets, securing a planet for the Sisters of Battle will grant you 10 disposition points, while losing the planet will subtract 10 points. Note: You cannot politely ask the sister CEO to resign (you cannot assassinate shrine world governor)

Adeptus Mechanicus: Forge worlds are precious and not numerous, you better have a very good reason if you allow their fall kid. Permitting their overrun will lead to a significant faction-wide reduction of 10 disposition points, as well as 10 points for the specific planet. Carrot in this case is the support of the Mechanicus.