### PR TITLE
fixes for multiple CTDs

### DIFF
--- a/objects/obj_mass_equip/Step_0.gml
+++ b/objects/obj_mass_equip/Step_0.gml
@@ -1,11 +1,10 @@
 
 if (obj_controller.settings=0) or (obj_controller.menu!=23) then instance_destroy();
 
-var romanNumerals;
-romanNumerals= scr_roman_numerals();
+var romanNumerals= scr_roman_numerals();
 
 if (engage=true){
-    for(var co=1; co<=11; co++){
+    for(var co=0; co<11; co++){
         var i=0;
         if (role_number[co]>0){
 			for(i=1; i<=300; i++){
@@ -157,7 +156,9 @@ if (engage=true){
 if (refresh=true) and (obj_controller.settings>0){
     total_role_number=0;
 	total_roles="";
-	for(var i=0; i<11; i++){role_number[i]=0;}
+	for(var i=0; i<11; i++){
+        role_number[i]=0;
+        }
 	for(var i=0; i<61; i++){
 		arm[i]="";
 		arm_n[i]=0;

--- a/objects/obj_shop/Create_0.gml
+++ b/objects/obj_shop/Create_0.gml
@@ -1,207 +1,845 @@
+hover = 0;
+shop = "";
+click = 0;
+click2 = 0;
+discount = 0;
+construction_started = 0;
+eta = 0;
+target_comp = obj_controller.new_vehicles;
 
-hover=0;
-shop="";
-click=0;
-click2=0;
-discount=0;
-construction_started=0;
-eta=0;
-target_comp=obj_controller.new_vehicles;
+tooltip_show = 0;
+tooltip = "";
+tooltip_weapon = 0;
+tooltip_stat1 = 0;
+tooltip_stat2 = 0;
+tooltip_stat3 = 0;
+tooltip_stat4 = 0;
+tooltip_other = "";
+tooltip_x = 0;
+tooltip_y = 0;
+tooltip_width = 0;
+tooltip_height = 0;
 
-tooltip_show=0;
-tooltip="";
-tooltip_weapon=0;
-tooltip_stat1=0;
-tooltip_stat2=0;
-tooltip_stat3=0;
-tooltip_stat4=0;
-tooltip_other="";
-tooltip_x=0;
-tooltip_y=0;
-tooltip_width=0;
-tooltip_height=0;
-
-shop="equipment";
+shop = "equipment";
 /*if (obj_controller.menu=55) then shop="equipment";
 if (obj_controller.menu=56) then shop="vehicles";
 if (obj_controller.menu=57) then shop="warships";
 if (obj_controller.menu=58) then shop="equipment2";*/
-if (instance_number(obj_shop)>1){
-    var war;war=instance_nearest(0,0,obj_shop);
-    shop=war.shop;with(war){instance_destroy();}
-    x=0;y=0;
-}
-
-
-var i,rene;i=-1;rene=0;
-repeat(40){i+=1;
-    item[i]="";x_mod[i]=0;item_stocked[i]=0;mc_stocked[i]=0;item_cost[i]=0;nobuy[i]=0;
-}
-if (obj_controller.faction_status[2]="War"){rene=1;
-    with(obj_temp6){instance_destroy();}
-    with(obj_star){var u;u=0;repeat(4){u+=1;if (p_type[u]="Forge") and (p_owner[u]=1) then instance_create(x,y,obj_temp6);}}
-    if (instance_exists(obj_temp6)) then rene=0;
-    with(obj_temp6){instance_destroy();}
-}
-
-if (shop="equipment"){i=0;
-    i+=1;item[i]="Combat Knife";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=1;
-    i+=1;item[i]="Chainsword";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=4;
-        i+=1;x_mod[i]=9;item[i]="Eviscerator";item_stocked[i]=scr_item_count(item[i]);nobuy[i]=1;
-    i+=1;item[i]="Chainaxe";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=10;
-        i+=1;item[i]="Power Axe";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=40;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-        i+=1;item[i]="Power Sword";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=25;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-        i+=1;item[i]="Power Fist";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=60;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-        i+=1;item[i]="Lightning Claw";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=50;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-        i+=1;item[i]="Chainfist";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=75;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-        i+=1;item[i]="Force Weapon";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=65;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-        i+=1;item[i]="Thunder Hammer";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=90;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;x_mod[i]=9;item[i]="Lascutter";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=15;
-    i+=1;x_mod[i]=9;item[i]="Boarding Shield";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=20;
-    i+=1;x_mod[i]=9;item[i]="Storm Shield";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=50;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;x_mod[i]=9;item[i]="Company Standard";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=400;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-
-    
-    i+=1;item[i]="Bolt Pistol";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=5;
-    i+=1;item[i]="Bolter";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=10;
-    i+=1;item[i]="Stalker Pattern Bolter";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=80;
-    i+=1;x_mod[i]=9;item[i]="Combiflamer";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=35;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Heavy Bolter";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=50;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Storm Bolter";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=50;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Flamer";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=25;
-    i+=1;item[i]="Heavy Flamer";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=40;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-
-    i+=1;item[i]="Incinerator";item_stocked[i]=scr_item_count(item[i]);nobuy[i]=1;
-    i+=1;item[i]="Integrated Bolters";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=120;
-    i+=1;item[i]="Meltagun";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=30;
-    i+=1;item[i]="Multi-Melta";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=60;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Plasma Pistol";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=60;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Plasma Gun";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=100;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-        i+=1;x_mod[i]=9;item[i]="Archeotech Laspistol";item_stocked[i]=scr_item_count(item[i]);nobuy[i]=1;
-        i+=1;x_mod[i]=9;item[i]="Hellrifle";item_stocked[i]=scr_item_count(item[i]);nobuy[i]=1;
-    i+=1;item[i]="Sniper Rifle";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=10;
-
-    i+=1;item[i]="Missile Launcher";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=70;
-    i+=1;item[i]="Lascannon";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=70;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    
-    i=0;repeat(39){i+=1;if (item[i]!="") then mc_stocked[i]=scr_item_count("Master Crafted "+string(item[i]));}
-}
-if (shop="equipment2"){i=0;
-    i+=1;item[i]="MK3 Iron Armour";item_stocked[i]=scr_item_count("MK3 Iron Armour");nobuy[i]=1;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="MK4 Maximus";item_stocked[i]=scr_item_count("MK4 Maximus");nobuy[i]=1;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="MK5 Heresy";item_stocked[i]=scr_item_count("MK5 Heresy");item_cost[i]=45;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="MK6 Corvus";item_stocked[i]=scr_item_count("MK6 Corvus");item_cost[i]=35;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="MK7 Aquila";item_stocked[i]=scr_item_count("MK7 Aquila");item_cost[i]=20;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="MK8 Errant";item_stocked[i]=scr_item_count("MK8 Errant");nobuy[i]=1;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Scout Armour";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=5;
-    i+=1;item[i]="Artificer Armour";item_stocked[i]=scr_item_count("Artificer Armour");nobuy[i]=1;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Terminator Armour";item_stocked[i]=scr_item_count("Terminator Armour");nobuy[i]=1;
-    if (obj_controller.stc_wargear>=6){nobuy[i]=0;item_cost[i]=350;}// if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Tartaros";item_stocked[i]=scr_item_count("Tartaros");nobuy[i]=1;
-
-    i+=1;x_mod[i]=9;item[i]="Jump Pack";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=20;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-
-    i+=1;x_mod[i]=9;item[i]="Servo Arms";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=30;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;x_mod[i]=9;item[i]="Bionics";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=5;
-    i+=1;x_mod[i]=9;item[i]="Narthecium";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=10;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;x_mod[i]=9;item[i]="Psychic Hood";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=100;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;x_mod[i]=9;item[i]="Rosarius";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=100;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;x_mod[i]=9;item[i]="Iron Halo";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=250;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;x_mod[i]=9;item[i]="Plasma Bomb";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=175;
-    i+=1;x_mod[i]=9;item[i]="Exterminatus";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=2500;
-}
-
-
-if (shop="vehicles"){i=0;
-    i+=1;item[i]="Rhino";item_stocked[i]=scr_vehicle_count(item[i],"");item_cost[i]=120;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Predator";item_stocked[i]=scr_vehicle_count(item[i],"");item_cost[i]=240;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Autocannon Turret";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=30;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Twin Linked Lascannon Turret";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=60;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Heavy Bolter Sponsons";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=38;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Heavy Flamer Sponsons";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=50;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Lascannon Sponsons";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=60;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Land Raider";item_stocked[i]=scr_vehicle_count(item[i],"");nobuy[i]=1;
-    if (obj_controller.stc_vehicles>=6){nobuy[i]=0;item_cost[i]=500;}// if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Twin Linked Heavy Bolter Mount";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=28;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Twin Linked Assault Cannon Mount";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=60;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Flamestorm Cannon Sponsons";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=100;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Hurricane Bolter Sponsons";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=70;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Twin Linked Lascannon Sponsons";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=120;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Whirlwind";item_stocked[i]=scr_vehicle_count(item[i],"");item_cost[i]=180;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;x_mod[i]=9;item[i]="HK Missile";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=10;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Land Speeder";item_stocked[i]=scr_vehicle_count(item[i],"");nobuy[i]=1;
-	   i+=1;x_mod[i]=9;item[i]="Twin Linked Bolters";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=8;
-    if (obj_controller.stc_vehicles>=6){nobuy[i]=0;item_cost[i]=200;}// if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Bike";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=35;
-    i+=1;item[i]="Dreadnought";item_stocked[i]=scr_item_count(item[i]);nobuy[i]=1;// if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    if (obj_controller.stc_wargear>=6){nobuy[i]=0;item_cost[i]=700;}// if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Close Combat Weapon";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=45;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Force Weapon";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=80;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-	  i+=1;x_mod[i]=9;item[i]="Twin Linked Heavy Bolter";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=110;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Twin Linked Lascannon";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=110;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Autocannon";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=80;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-	  i+=1;x_mod[i]=9;item[i]="Inferno Cannon";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=115;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-	  i+=1;x_mod[i]=9;item[i]="Assault Cannon";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=75;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Flamestorm Cannon";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=135;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Assault Cannon";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=110;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Twin-Linked Assault Cannon";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=150;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Whirlwind Missile Launcher";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=90;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
+if (instance_number(obj_shop) > 1) {
+    var war;
+    war = instance_nearest(0, 0, obj_shop);
+    shop = war.shop;
+    with(war) {
+        instance_destroy();
     }
-   if (obj_controller.stc_wargear>=6){nobuy[i]=0;item_cost[i]=700;}
-      i+=1;x_mod[i]=9;item[i]="Heavy Conversion Beam Projector";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=100;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-      i+=1;x_mod[i]=9;item[i]="Void Shield";item_stocked[i]=scr_item_count(item[i]);item_cost[i]=250;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-
-
-if (shop="warships"){i=0;
-    i+=1;item[i]="Battle Barge";item_stocked[i]=scr_ship_count(item[i]);item_cost[i]=20000;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Strike Cruiser";item_stocked[i]=scr_ship_count(item[i]);item_cost[i]=8000;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Gladius";item_stocked[i]=scr_ship_count(item[i]);item_cost[i]=2250;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;item[i]="Hunter";item_stocked[i]=scr_ship_count(item[i]);item_cost[i]=3000;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
-    i+=1;x_mod[i]=9;item[i]="Cyclonic Torpedo";item_stocked[i]=scr_item_count(item[i]);nobuy[i]=1;if (rene=1){nobuy[i]=1;item_cost[i]=0;}
+    x = 0;
+    y = 0;
 }
 
 
-
-with(obj_p_fleet){
-    if (capital_number>0) and (action=""){
-        var you;you=instance_nearest(x,y,obj_star);
-        if (you.trader>0) then obj_shop.discount=1;
+var i, rene;
+i = -1;
+rene = 0;
+repeat(40) {
+    i += 1;
+    item[i] = "";
+    x_mod[i] = 0;
+    item_stocked[i] = 0;
+    mc_stocked[i] = 0;
+    item_cost[i] = 0;
+    nobuy[i] = 0;
+}
+if (obj_controller.faction_status[2] = "War") {
+    rene = 1;
+    with(obj_temp6) {
+        instance_destroy();
     }
-}
-with(obj_star){
-    if ((p_owner[1]=1) or (p_owner[2]=1) or (p_owner[3]=1) or (p_owner[4]=1)) and (trader>0) then obj_shop.discount=1;
-}
-
-
-if (shop="equipment") or (shop="equipment2"){var disc;disc=1;
-    if (obj_controller.stc_wargear>=1) then disc=0.92;
-    if (obj_controller.stc_wargear>=3) then disc=0.86;
-    if (obj_controller.stc_wargear>=5) then disc=0.75;
-    i=0;repeat(31){i+=1;if (item_cost[i]>1) then item_cost[i]=round(item_cost[i]*disc);}
-}
-if (shop="vehicles"){var disc;disc=1;
-    if (obj_controller.stc_vehicles>=1) then disc=0.92;
-    if (obj_controller.stc_vehicles>=3) then disc=0.86;
-    if (obj_controller.stc_vehicles>=5) then disc=0.75;
-    i=0;repeat(31){i+=1;var ahuh;ahuh=1;
-        if (i>=7) and (i<=12) then ahuh=0;
-        if (ahuh=1){if (item_cost[i]>1) then item_cost[i]=round(item_cost[i]*disc);}
+    with(obj_star) {
+        var u;
+        u = 0;
+        repeat(4) {
+            u += 1;
+            if (p_type[u] = "Forge") and(p_owner[u] = 1) then instance_create(x, y, obj_temp6);
+        }
     }
-}
-if (shop="warships"){var disc;disc=1;
-    if (obj_controller.stc_ships>=1) then disc=0.92;
-    if (obj_controller.stc_ships>=3) then disc=0.86;
-    if (obj_controller.stc_ships>=5) then disc=0.75;
-    i=0;repeat(31){i+=1;if (item_cost[i]>1) then item_cost[i]=round(item_cost[i]*disc);}
-}
-if (discount=1){discount=2;i=0;
-    repeat(31){i+=1;
-        if (item_cost[i]>=5) then item_cost[i]=round(item_cost[i]*0.8);
-        if (item_cost[i]>1) and (item_cost[i]<5) then item_cost[i]-=1;
+    if (instance_exists(obj_temp6)) then rene = 0;
+    with(obj_temp6) {
+        instance_destroy();
     }
 }
 
-if (rene=1){i=0;repeat(31){i+=1;item_cost[i]=item_cost[i]*2;}}
+if (shop = "equipment") {
+    i = 0;
+    i += 1;
+    item[i] = "Combat Knife";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 1;
+    i += 1;
+    item[i] = "Chainsword";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 4;
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Eviscerator";
+    item_stocked[i] = scr_item_count(item[i]);
+    nobuy[i] = 1;
+    i += 1;
+    item[i] = "Chainaxe";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 10;
+    i += 1;
+    item[i] = "Power Axe";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 40;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Power Sword";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 25;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Power Fist";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 60;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Lightning Claw";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 50;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Chainfist";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 75;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Force Weapon";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 65;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Thunder Hammer";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 90;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Lascutter";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 15;
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Boarding Shield";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 20;
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Storm Shield";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 50;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Company Standard";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 400;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+
+
+    i += 1;
+    item[i] = "Bolt Pistol";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 5;
+    i += 1;
+    item[i] = "Bolter";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 10;
+    i += 1;
+    item[i] = "Stalker Pattern Bolter";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 80;
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Combiflamer";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 35;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Heavy Bolter";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 50;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Storm Bolter";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 50;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Flamer";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 25;
+    i += 1;
+    item[i] = "Heavy Flamer";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 40;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+
+    i += 1;
+    item[i] = "Incinerator";
+    item_stocked[i] = scr_item_count(item[i]);
+    nobuy[i] = 1;
+    i += 1;
+    item[i] = "Integrated Bolters";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 120;
+    i += 1;
+    item[i] = "Meltagun";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 30;
+    i += 1;
+    item[i] = "Multi-Melta";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 60;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Plasma Pistol";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 60;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Plasma Gun";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 100;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Archeotech Laspistol";
+    item_stocked[i] = scr_item_count(item[i]);
+    nobuy[i] = 1;
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Hellrifle";
+    item_stocked[i] = scr_item_count(item[i]);
+    nobuy[i] = 1;
+    i += 1;
+    item[i] = "Sniper Rifle";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 10;
+
+    i += 1;
+    item[i] = "Missile Launcher";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 70;
+    i += 1;
+    item[i] = "Lascannon";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 70;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+
+    i = 0;
+    repeat(39) {
+        i += 1;
+        if (item[i] != "") then mc_stocked[i] = scr_item_count("Master Crafted " + string(item[i]));
+    }
+}
+if (shop = "equipment2") {
+    i = 0;
+    i += 1;
+    item[i] = "MK3 Iron Armour";
+    item_stocked[i] = scr_item_count("MK3 Iron Armour");
+    nobuy[i] = 1;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "MK4 Maximus";
+    item_stocked[i] = scr_item_count("MK4 Maximus");
+    nobuy[i] = 1;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "MK5 Heresy";
+    item_stocked[i] = scr_item_count("MK5 Heresy");
+    item_cost[i] = 45;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "MK6 Corvus";
+    item_stocked[i] = scr_item_count("MK6 Corvus");
+    item_cost[i] = 35;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "MK7 Aquila";
+    item_stocked[i] = scr_item_count("MK7 Aquila");
+    item_cost[i] = 20;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "MK8 Errant";
+    item_stocked[i] = scr_item_count("MK8 Errant");
+    nobuy[i] = 1;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Scout Armour";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 5;
+    i += 1;
+    item[i] = "Artificer Armour";
+    item_stocked[i] = scr_item_count("Artificer Armour");
+    nobuy[i] = 1;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Terminator Armour";
+    item_stocked[i] = scr_item_count("Terminator Armour");
+    nobuy[i] = 1;
+    if (obj_controller.stc_wargear >= 6) {
+        nobuy[i] = 0;
+        item_cost[i] = 350;
+    } // if (rene=1){nobuy[i]=1;item_cost[i]=0;}
+    i += 1;
+    item[i] = "Tartaros";
+    item_stocked[i] = scr_item_count("Tartaros");
+    nobuy[i] = 1;
+
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Jump Pack";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 20;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Servo Arms";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 30;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Bionics";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 5;
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Narthecium";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 10;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Psychic Hood";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 100;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Rosarius";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 100;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Iron Halo";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 250;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Plasma Bomb";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 175;
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Exterminatus";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 2500;
+}
+
+
+if (shop = "vehicles") {
+    i = 0;
+    i += 1;
+    item[i] = "Rhino";
+    item_stocked[i] = scr_vehicle_count(item[i], "");
+    item_cost[i] = 120;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Predator";
+    item_stocked[i] = scr_vehicle_count(item[i], "");
+    item_cost[i] = 240;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Autocannon Turret";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 30;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Twin Linked Lascannon Turret";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 60;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Heavy Bolter Sponsons";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 38;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Heavy Flamer Sponsons";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 50;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Lascannon Sponsons";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 60;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Land Raider";
+    item_stocked[i] = scr_vehicle_count(item[i], "");
+    nobuy[i] = 1;
+    if (obj_controller.stc_vehicles >= 6) {
+        nobuy[i] = 0;
+        item_cost[i] = 500;
+    } // if (rene=1){nobuy[i]=1;item_cost[i]=0;}
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Twin Linked Heavy Bolter Mount";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 28;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Twin Linked Assault Cannon Mount";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 60;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Flamestorm Cannon Sponsons";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 100;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Hurricane Bolter Sponsons";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 70;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Twin Linked Lascannon Sponsons";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 120;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Whirlwind";
+    item_stocked[i] = scr_vehicle_count(item[i], "");
+    item_cost[i] = 180;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "HK Missile";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 10;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Land Speeder";
+    item_stocked[i] = scr_vehicle_count(item[i], "");
+    nobuy[i] = 1;
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Twin Linked Bolters";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 8;
+    if (obj_controller.stc_vehicles >= 6) {
+        nobuy[i] = 0;
+        item_cost[i] = 200;
+    } // if (rene=1){nobuy[i]=1;item_cost[i]=0;}
+    i += 1;
+    item[i] = "Bike";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 35;
+    i += 1;
+    item[i] = "Dreadnought";
+    item_stocked[i] = scr_item_count(item[i]);
+    nobuy[i] = 1; // if (rene=1){nobuy[i]=1;item_cost[i]=0;}
+    if (obj_controller.stc_wargear >= 6) {
+        nobuy[i] = 0;
+        item_cost[i] = 700;
+    } // if (rene=1){nobuy[i]=1;item_cost[i]=0;}
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Close Combat Weapon";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 45;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Force Weapon";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 80;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Twin Linked Heavy Bolter";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 110;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Twin Linked Lascannon";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 110;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Autocannon";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 80;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Inferno Cannon";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 115;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Assault Cannon";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 75;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Flamestorm Cannon";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 135;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Assault Cannon";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 110;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Twin-Linked Assault Cannon";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 150;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Whirlwind Missile Launcher";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 90;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Heavy Conversion Beam Projector";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 100;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Void Shield";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 250;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+}
+
+if (obj_controller.stc_wargear >= 6) {
+    nobuy[i] = 0;
+    item_cost[i] = 700;
+}
+
+if (shop = "warships") {
+    i = 0;
+    i += 1;
+    item[i] = "Battle Barge";
+    item_stocked[i] = scr_ship_count(item[i]);
+    item_cost[i] = 20000;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Strike Cruiser";
+    item_stocked[i] = scr_ship_count(item[i]);
+    item_cost[i] = 8000;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Gladius";
+    item_stocked[i] = scr_ship_count(item[i]);
+    item_cost[i] = 2250;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    item[i] = "Hunter";
+    item_stocked[i] = scr_ship_count(item[i]);
+    item_cost[i] = 3000;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Cyclonic Torpedo";
+    item_stocked[i] = scr_item_count(item[i]);
+    nobuy[i] = 1;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+}
+
+
+
+with(obj_p_fleet) {
+    if (capital_number > 0) and(action = "") {
+        var you;
+        you = instance_nearest(x, y, obj_star);
+        if (you.trader > 0) then obj_shop.discount = 1;
+    }
+}
+with(obj_star) {
+    if ((p_owner[1] = 1) or(p_owner[2] = 1) or(p_owner[3] = 1) or(p_owner[4] = 1)) and(trader > 0) then obj_shop.discount = 1;
+}
+
+
+if (shop = "equipment") or(shop = "equipment2") {
+    var disc;
+    disc = 1;
+    if (obj_controller.stc_wargear >= 1) then disc = 0.92;
+    if (obj_controller.stc_wargear >= 3) then disc = 0.86;
+    if (obj_controller.stc_wargear >= 5) then disc = 0.75;
+    i = 0;
+    repeat(31) {
+        i += 1;
+        if (item_cost[i] > 1) then item_cost[i] = round(item_cost[i] * disc);
+    }
+}
+if (shop = "vehicles") {
+    var disc;
+    disc = 1;
+    if (obj_controller.stc_vehicles >= 1) then disc = 0.92;
+    if (obj_controller.stc_vehicles >= 3) then disc = 0.86;
+    if (obj_controller.stc_vehicles >= 5) then disc = 0.75;
+    i = 0;
+    repeat(31) {
+        i += 1;
+        var ahuh;
+        ahuh = 1;
+        if (i >= 7) and(i <= 12) then ahuh = 0;
+        if (ahuh = 1) {
+            if (item_cost[i] > 1) then item_cost[i] = round(item_cost[i] * disc);
+        }
+    }
+}
+if (shop = "warships") {
+    var disc;
+    disc = 1;
+    if (obj_controller.stc_ships >= 1) then disc = 0.92;
+    if (obj_controller.stc_ships >= 3) then disc = 0.86;
+    if (obj_controller.stc_ships >= 5) then disc = 0.75;
+    i = 0;
+    repeat(31) {
+        i += 1;
+        if (item_cost[i] > 1) then item_cost[i] = round(item_cost[i] * disc);
+    }
+}
+if (discount = 1) {
+    discount = 2;
+    i = 0;
+    repeat(31) {
+        i += 1;
+        if (item_cost[i] >= 5) then item_cost[i] = round(item_cost[i] * 0.8);
+        if (item_cost[i] > 1) and(item_cost[i] < 5) then item_cost[i] -= 1;
+    }
+}
+
+if (rene = 1) {
+    i = 0;
+    repeat(31) {
+        i += 1;
+        item_cost[i] = item_cost[i] * 2;
+    }
+}
 
 
 /* */

--- a/scripts/scr_add_man/scr_add_man.gml
+++ b/scripts/scr_add_man/scr_add_man.gml
@@ -107,7 +107,7 @@ function scr_add_man(man_role, target_company, choice_armour, choice_weapons, ch
 	    obj_ini.role[target_company,good]=man_role;
 	    obj_ini.wep1[target_company,good]="";
 	    obj_ini.wep2[target_company,good]="";
-	    obj_ini.armor[target_company,good]="";
+	    obj_ini.armour[target_company,good]="";
 	    obj_ini.chaos[target_company,good]=corruption;
 	    obj_ini.experience[target_company,good]=spawn_exp;
 	    obj_ini.spe[target_company,good]="";
@@ -118,27 +118,27 @@ function scr_add_man(man_role, target_company, choice_armour, choice_weapons, ch
 			switch(man_role){
 	        case "Skitarii":
 	            obj_ini.wep1[target_company,good]="Hellgun";obj_ini.wep2[target_company,good]="";
-	            obj_ini.armor[target_company,good]="Skitarii Armour";obj_ini.experience[target_company,good]=10;
+	            obj_ini.armour[target_company,good]="Skitarii Armour";obj_ini.experience[target_company,good]=10;
 	            obj_ini.hp[target_company,good]=40;
 	            obj_ini.race[target_company,good]=3;
 				obj_ini.TTRPG[target_company, good] = new TTRPG_stats("mechanicus", target_company, good, "skitarii");
 				break;
 	        case "Techpriest":
 	            obj_ini.wep1[target_company,good]="Power Weapon";obj_ini.wep2[target_company,good]="Conversion Beam Projector";
-	            obj_ini.armor[target_company,good]="Dragon Scales";obj_ini.gear[target_company,good]="Servo Arms";obj_ini.experience[target_company,good]=100;
+	            obj_ini.armour[target_company,good]="Dragon Scales";obj_ini.gear[target_company,good]="Servo Arms";obj_ini.experience[target_company,good]=100;
 	            obj_ini.hp[target_company,good]=50;
 	            obj_ini.race[target_company,good]=3;
 				obj_ini.TTRPG[target_company, good] = new TTRPG_stats("mechanicus", target_company, good, "tech_priest");
 				break
 	        case "Ranger":
 	            obj_ini.wep1[target_company,good]="Ranger Long Rifle";obj_ini.wep2[target_company,good]="Shuriken Pistol";
-	            obj_ini.armor[target_company,good]="";obj_ini.experience[target_company,good]=80;
+	            obj_ini.armour[target_company,good]="";obj_ini.experience[target_company,good]=80;
 	            obj_ini.hp[target_company,good]=30;
 	            obj_ini.race[target_company,good]=6
 				obj_ini.TTRPG[target_company, good] = new TTRPG_stats("mechanicus", target_company, good, "skitarii_ranger");
 				break;
 	         case "Crusader":
-	            obj_ini.wep1[target_company,good]="Power Sword";obj_ini.armor[target_company,good]="Power Armour";
+	            obj_ini.wep1[target_company,good]="Power Sword";obj_ini.armuor[target_company,good]="Power Armour";
 	            obj_ini.gear[target_company,good]="Storm Shield";obj_ini.experience[target_company,good]=10;
 	            obj_ini.hp[target_company,good]=30;
 	            obj_ini.race[target_company,good]=4;
@@ -146,20 +146,20 @@ function scr_add_man(man_role, target_company, choice_armour, choice_weapons, ch
 				break;
 	        case "Sister of Battle":
 	            obj_ini.wep1[target_company,good]="Bolter";obj_ini.wep2[target_company,good]="Sarissa";
-	            obj_ini.armor[target_company,good]="Power Armour";obj_ini.experience[target_company,good]=60;
+	            obj_ini.armour[target_company,good]="Power Armour";obj_ini.experience[target_company,good]=60;
 	            obj_ini.hp[target_company,good]=40;obj_ini.race[target_company,good]=5;
 				obj_ini.TTRPG[target_company, good] = new TTRPG_stats("adeptus_sororitas", target_company, good, "sister_of_battle");
 				break;
 	        case "Sister Hospitaler":
 	            obj_ini.wep1[target_company,good]="Bolter";obj_ini.wep2[target_company,good]="Sarissa";
-	            obj_ini.armor[target_company,good]="Power Armour";obj_ini.experience[target_company,good]=100;
+	            obj_ini.armour[target_company,good]="Power Armour";obj_ini.experience[target_company,good]=100;
 	            obj_ini.gear[target_company,good]="Sororitas Medkit";
 	            obj_ini.hp[target_company,good]=40;obj_ini.race[target_company,good]=5;
 				obj_ini.TTRPG[target_company, good] = new TTRPG_stats("adeptus_sororitas", target_company, good, "sister_hospitaler");
 				break;
 	        case "Ork Sniper":
 	            obj_ini.wep1[target_company,good]="Sniper Rifle";obj_ini.wep2[target_company,good]="Choppa";
-	            obj_ini.armor[target_company,good]="";obj_ini.experience[target_company,good]=20;
+	            obj_ini.armour[target_company,good]="";obj_ini.experience[target_company,good]=20;
 	            obj_ini.hp[target_company,good]=45;
 	            obj_ini.race[target_company,good]=7;
 				obj_ini.TTRPG[target_company, good] = new TTRPG_stats("ork", target_company, good, "ork_Sniper");
@@ -168,7 +168,7 @@ function scr_add_man(man_role, target_company, choice_armour, choice_weapons, ch
 	        
 	        case "Flash Git":
 	            obj_ini.wep1[target_company,good]="Snazzgun";obj_ini.wep2[target_company,good]="Choppa";
-	            obj_ini.armor[target_company,good]="Ork Armour";obj_ini.experience[target_company,good]=40;
+	            obj_ini.armour[target_company,good]="Ork Armour";obj_ini.experience[target_company,good]=40;
 	            obj_ini.hp[target_company,good]=65;
 	            obj_ini.race[target_company,good]=7;
 				obj_ini.TTRPG[target_company, good] = new TTRPG_stats("ork", target_company, good, "flash_git");
@@ -187,7 +187,7 @@ function scr_add_man(man_role, target_company, choice_armour, choice_weapons, ch
     
     
 	    // Weapons
-	    if (choice_weapons=obj_ini.role[100,12]){wep2=obj_ini.wep2[100,12];wep1=obj_ini.wep1[100,12];arm=obj_ini.armor[100,12];}
+	    if (choice_weapons=obj_ini.role[100,12]){wep2=obj_ini.wep2[100,12];wep1=obj_ini.wep1[100,12];arm=obj_ini.armour[100,12];}
     
 	    var good1,good2,good3,good4;
 	    good1=0;good2=0;good3=0;good4=0;
@@ -223,14 +223,14 @@ function scr_add_man(man_role, target_company, choice_armour, choice_weapons, ch
 	            e+=1;
 	            if (e<=100){
 	                if (obj_ini.equipment[e]=arm){
-	                    obj_ini.equipment_number[e]-=1;obj_ini.armor[target_company,good]=arm;
+	                    obj_ini.equipment_number[e]-=1;obj_ini.armour[target_company,good]=arm;
 	                    if (obj_ini.equipment_number[e]=0){obj_ini.equipment[e]="";obj_ini.equipment_type[e]="";}
 	                    e=1000;
 	                }
 	            }
 	        }
         
-	        // show_message(obj_ini.armor[target_company,good]);
+	        // show_message(obj_ini.armour[target_company,good]);
         
 	        e=0;
 	        if (choice_gear!="") then repeat(100){// Gear
@@ -257,7 +257,7 @@ function scr_add_man(man_role, target_company, choice_armour, choice_weapons, ch
         
 	        if (obj_ini.wep1[target_company,good]!=wep1) and (wep1!="") then missing=1;
 	        if (obj_ini.wep2[target_company,good]!=wep2) and (wep2!="") then missing=1;
-	        if (obj_ini.armor[target_company,good]!=arm) and (arm!="") then missing=1;
+	        if (obj_ini.armour[target_company,good]!=arm) and (arm!="") then missing=1;
 	        if (obj_ini.gear[target_company,good]!=choice_gear) and (choice_gear!="") then missing=1;
 	        if (obj_ini.mobi[target_company,good]!=mobility_items) and (mobility_items!="") then missing=1;
         

--- a/scripts/scr_battle_roster/scr_battle_roster.gml
+++ b/scripts/scr_battle_roster/scr_battle_roster.gml
@@ -313,7 +313,7 @@ function scr_battle_roster(_unit_location, _target_location, _is_planet) {
                         if (really = true) then new_combat.really_thirsty += 1;
                         col = max(obj_controller.bat_assault_column, obj_controller.bat_command_column, obj_controller.bat_honor_column, obj_controller.bat_dreadnought_column, obj_controller.bat_veteran_column);
                     }
-                    // info for ai targetting armor and what they think is best. TODO find out what marine_ranged and attack does
+                    // info for ai targetting armour and what they think is best. TODO find out what marine_ranged and attack does
                     if (targ.marine_armour[targ.men] = "Scout Armour") then targ.marine_ac[targ.men] = 8;
                     if (targ.marine_armour[targ.men] = "MK3 Iron Armour") {
                         targ.marine_ac[targ.men] = 20;

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -972,7 +972,7 @@ function scr_initialize_custom() {
 	        if (company=10) then name[company,k]=recruiter_name;
 
 			var oldguard; oldguard=0;
-			// used to randomly make a marine an old guard of their company, giving a bit more xp (TODO) and fancier armor they've hanged onto all these years
+			// used to randomly make a marine an old guard of their company, giving a bit more xp (TODO) and fancier armour they've hanged onto all these years
 
 	        wep2[company,k]=wep2[101,5];
 		  	if(old_guard>=75){armour[company,k]="MK3 Iron Armour"}; // 25% of iron within
@@ -1084,7 +1084,7 @@ function scr_initialize_custom() {
 	                    if (wep1[101,9]!="Heavy Ranged") then wep1[company,k]=wep1[101,9];
 
 							if (old_guard>=99 and old_guard<=97){armour[company,k]="MK4 Maximus"}; // 3% for maximus
-								else if (old_guard>=78 and old_guard<=96){armour[company,k]="MK6 Corvus"}; // 20% chance for devos to have ranged armor, wouldn't want much else
+								else if (old_guard>=78 and old_guard<=96){armour[company,k]="MK6 Corvus"}; // 20% chance for devos to have ranged armour, wouldn't want much else
 									else if (company<=2) then armour[company,k]="MK6 Corvus"; // company 1 and 2 taccies get beakies by default
 										else{armour[company,k]="MK7 Aquila"};
 							
@@ -1143,7 +1143,7 @@ function scr_initialize_custom() {
 					{armour[company,k]="MK7 Aquila"};
 					
 						if (old_guard>=99 and old_guard<=97){armour[company,k]="MK4 Maximus"}; // 3% for maximus
-							else if (old_guard>=78 and old_guard<=96){armour[company,k]="MK6 Corvus"}; // 20% chance for devos to have ranged armor, wouldn't want much else
+							else if (old_guard>=78 and old_guard<=96){armour[company,k]="MK6 Corvus"}; // 20% chance for devos to have ranged armour, wouldn't want much else
 								else{armour[company,k]="MK7 Aquila"};
 					
 	            }

--- a/scripts/scr_ui_display_weapons/scr_ui_display_weapons.gml
+++ b/scripts/scr_ui_display_weapons/scr_ui_display_weapons.gml
@@ -1,4 +1,4 @@
-// Displays weapon based on the armor type to change the art to match the armor type
+// Displays weapon based on the armour type to change the art to match the armour type
 function scr_ui_display_weapons(argument0, termi_tartaros, equiped_weapon) {
 
     // argument0: left?

--- a/scripts/scr_ui_formation_bars/scr_ui_formation_bars.gml
+++ b/scripts/scr_ui_formation_bars/scr_ui_formation_bars.gml
@@ -29,38 +29,38 @@ function scr_ui_formation_bars() {
 
         // Set up the infantry
         if (bat_comm_for[fo] == bar) {
-            init_combat_bars(2, 0, x9, y9, temp, te, "HQ");
+            init_combat_bars(bar, ii, nbar, abar,2, 0, x9, y9, temp, te, "HQ");
         } else if (bat_hono_for[fo] == bar) {
-            init_combat_bars(1, 1, x9, y9, temp, te, "Hono");
+            init_combat_bars(bar, ii, nbar, abar,1, 1, x9, y9, temp, te, "Hono");
         } else if (bat_libr_for[fo] == bar) {
-            init_combat_bars(1, 8, x9, y9, temp, te, "Lib");
+            init_combat_bars(bar, ii, nbar, abar,1, 8, x9, y9, temp, te, "Lib");
         } else if (bat_tech_for[fo] == bar) {
-            init_combat_bars(1, 9, x9, y9, temp, te, "Tech");
+            init_combat_bars(bar, ii, nbar, abar,1, 9, x9, y9, temp, te, "Tech");
         } else if (bat_term_for[fo] == bar) {
-            init_combat_bars(1, 10, x9, y9, temp, te, "Term");
+            init_combat_bars(bar, ii, nbar, abar,1, 10, x9, y9, temp, te, "Term");
         } else if (bat_vete_for[fo] == bar) {
-            init_combat_bars(2, 6, x9, y9, temp, te, "Veteran");
+            init_combat_bars(bar, ii, nbar, abar,2, 6, x9, y9, temp, te, "Veteran");
         } else if (bat_tact_for[fo] == bar) {
-            init_combat_bars(6, 3, x9, y9, temp, te, "Tactical");
+            init_combat_bars(bar, ii, nbar, abar,6, 3, x9, y9, temp, te, "Tactical");
         } else if (bat_deva_for[fo] == bar) {
-            init_combat_bars(3, 2, x9, y9, temp, te, "Devastator");
+            init_combat_bars(bar, ii, nbar, abar,3, 2, x9, y9, temp, te, "Devastator");
         } else if (bat_assa_for[fo] == bar) {
-            init_combat_bars(3, 5, x9, y9, temp, te, "Assault");
+            init_combat_bars(bar, ii, nbar, abar,3, 5, x9, y9, temp, te, "Assault");
         } else if (bat_scou_for[fo] == bar) {
-            init_combat_bars(1, 4, x9, y9, temp, te, "Sco");
+            init_combat_bars(bar, ii, nbar, abar,1, 4, x9, y9, temp, te, "Sco");
         } else if (bat_drea_for[fo] == bar) {
-            init_combat_bars(2, 11, x9, y9, temp, te, "Dread");
+            init_combat_bars(bar, ii, nbar, abar,2, 11, x9, y9, temp, te, "Dread");
         } else if (bat_hire_for[fo] == bar) {
-            init_combat_bars(1, 7, x9, y9, temp, te, "???");
+            init_combat_bars(bar, ii, nbar, abar,1, 7, x9, y9, temp, te, "???");
         }
         // Set up the vehicles
         if (bat_formation_type[fo] != 2) {
             if (bat_rhin_for[fo] == bar) {
-                init_combat_bars(4, 12, x9, y9, temp, te, "Rhino");
+                init_combat_bars(bar, ii, nbar, abar,4, 12, x9, y9, temp, te, "Rhino");
             } else if (bat_pred_for[fo] == bar) {
-                init_combat_bars(2, 13, x9, y9, temp, te, "Predator");
+                init_combat_bars(bar, ii, nbar, abar,2, 13, x9, y9, temp, te, "Predator");
             } else if (bat_land_for[fo] == bar) {
-                init_combat_bars(2, 14, x9, y9, temp, te, "Land Raider");
+                init_combat_bars(bar, ii, nbar, abar,2, 14, x9, y9, temp, te, "Land Raider");
             }
         }
 
@@ -92,7 +92,7 @@ function scr_ui_formation_bars() {
     }
 }
 
-function init_combat_bars(size, image_index, x9, y9, temp, te, unit_type) {
+function init_combat_bars(bar, ii, nbar, abar, size, image_index, x9, y9, temp, te, unit_type) {
     nbar = instance_create(x9, y9 + temp[te], obj_formation_bar);
     nbar.size = size;
     nbar.height = nbar.size * 47;

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -318,7 +318,7 @@ function scr_ui_manage() {
 						}
 	                }
                 
-					// Define armor
+					// Define armour
 	                if (temp[102]="") then armour_sprite=spr_weapon_blank;
 					
 	                if (temp[102]="Scout Armour"){

--- a/scripts/scr_vehicle_count/scr_vehicle_count.gml
+++ b/scripts/scr_vehicle_count/scr_vehicle_count.gml
@@ -27,7 +27,7 @@ function scr_vehicle_count(role, star_system_num) {
 
                 if (star_system_num != "home") and(star_system_num != "field") {
                     if (obj_ini.veh_role[company_number, i] == role) {
-                        var t1 = string(obj_ini.veh_loc[company_number, i]) + "|" + string(obj_ini.veh_wid[com, i]) + "|";
+                        var t1 = string(obj_ini.veh_loc[company_number, i]) + "|" + string(obj_ini.veh_wid[company_number, i]) + "|";
                         if (star_system_num == t1) then vehicle_count++;
                     }
                 }


### PR DESCRIPTION
- renamed remaining 'armor' instances to 'armour', which also fixed a CTD
- fixed vehicle count + armamentarium CTDs (forgot to rename 1 old var)
- fixed adjust formation CTDs
- removed Heavy Conversion Beamers and Void Shields from Armour tab in shop (still visible in Vehicles tab)
- beautified obj_chop/Create_0
- fixed CTD on mass equip

ready for review and merge