### PR TITLE
Fix: crash on turn 1 in armamentorium vehicle tab

### DIFF
--- a/scripts/scr_vehicle_count/scr_vehicle_count.gml
+++ b/scripts/scr_vehicle_count/scr_vehicle_count.gml
@@ -6,24 +6,51 @@ function scr_vehicle_count(role, star_system_num) {
         company_number = 0,
         company_number_derived_from_star_system_num = -999; // TODO refactor star_system_num to actually represent something logical
 
-    if (star_system_num == "0") then company_number_derived_from_star_system_num = 0;
-    else if (star_system_num == "1") then company_number_derived_from_star_system_num = 1;
-    else if (star_system_num == "2") then company_number_derived_from_star_system_num = 2;
-    else if (star_system_num == "3") then company_number_derived_from_star_system_num = 3;
-    else if (star_system_num == "4") then company_number_derived_from_star_system_num = 4;
-    else if (star_system_num == "5") then company_number_derived_from_star_system_num = 5;
-    else if (star_system_num == "6") then company_number_derived_from_star_system_num = 6;
-    else if (star_system_num == "7") then company_number_derived_from_star_system_num = 7;
-    else if (star_system_num == "8") then company_number_derived_from_star_system_num = 8;
-    else if (star_system_num == "9") then company_number_derived_from_star_system_num = 9;
-    else if (star_system_num == "10") then company_number_derived_from_star_system_num = 10;
+    switch (star_system_num) {
+        case "0":
+            company_number_derived_from_star_system_num = 0;
+            break;
+        case "1":
+            company_number_derived_from_star_system_num = 1;
+            break;
+        case "2":
+            company_number_derived_from_star_system_num = 2;
+            break;
+        case "3":
+            company_number_derived_from_star_system_num = 3;
+            break;
+        case "4":
+            company_number_derived_from_star_system_num = 4;
+            break;
+        case "5":
+            company_number_derived_from_star_system_num = 5;
+            break;
+        case "6":
+            company_number_derived_from_star_system_num = 6;
+            break;
+        case "7":
+            company_number_derived_from_star_system_num = 7;
+            break;
+        case "8":
+            company_number_derived_from_star_system_num = 8;
+            break;
+        case "9":
+            company_number_derived_from_star_system_num = 9;
+            break;
+        case "10":
+            company_number_derived_from_star_system_num = 10;
+            break;
+        default:
+            company_number_derived_from_star_system_num = 0; // Assign 0, it avoids crashing the game when nothing is selected
+            break;
+    }
 
     if (company_number_derived_from_star_system_num < 0) {
         for (var j = 0; j < 11; j++) {
             for (var i = 1; i <= 100; i++) {
-                if (obj_ini.veh_role[company_number, i] == role) and(star_system_num == "") then vehicle_count++;
-                if (obj_ini.veh_role[company_number, i] == role) and(obj_ini.veh_loc[company_number, i] == obj_ini.home_name) and(star_system_num = "home") then vehicle_count++;
-                if (obj_ini.veh_role[company_number, i] == role) and(star_system_num == "field") and((obj_ini.loc[company_number, i] != obj_ini.home_name) or(obj_ini.veh_lid[company_number, i] > 0)) then vehicle_count++;
+                if (obj_ini.veh_role[company_number, i] == role) and (star_system_num == "") then vehicle_count++;
+                if (obj_ini.veh_role[company_number, i] == role) and (obj_ini.veh_loc[company_number, i] == obj_ini.home_name) and (star_system_num == "home") then vehicle_count++;
+                if (obj_ini.veh_role[company_number, i] == role) and (star_system_num == "field") and ((obj_ini.loc[company_number, i] != obj_ini.home_name) or (obj_ini.veh_lid[company_number, i] > 0)) then vehicle_count++;
 
                 if (star_system_num != "home") and(star_system_num != "field") {
                     if (obj_ini.veh_role[company_number, i] == role) {
@@ -38,10 +65,9 @@ function scr_vehicle_count(role, star_system_num) {
         company_number = company_number_derived_from_star_system_num;
 
         for (var i = 1; i <= 100; i++) {
-            if (obj_ini.veh_role[company_number, i] = role) then vehicle_count++;
+            if (obj_ini.veh_role[company_number, i] == role) then vehicle_count++;
         }
         company_number++;
     }
-
     return (vehicle_count);
 }


### PR DESCRIPTION
# Fix
- Vehicles Tab in armamentorium Crashes on turn 1 when clicking it