### PR TITLE
fix restart variable crash

### DIFF
--- a/scripts/scr_restart_variables/scr_restart_variables.gml
+++ b/scripts/scr_restart_variables/scr_restart_variables.gml
@@ -4,7 +4,7 @@ function scr_restart_variables(saved_game) {
     
 	    // show_message(instance_number(obj_restart_vars));
     
-	    obj_restart_vars.restart_name=global.chapter_name;
+	    obj_restart_vars.restart_name=obj_creation.chapter;
 	    obj_restart_vars.restart_founding=global.founding;
     
 	    obj_restart_vars.restart_secret=global.founding_secret;


### PR DESCRIPTION
fixes or at the least greatly reduces frequency of the restart variable crash (did 25 game starts with no crashes)
- ok so does not fully eradicate but greatly reduces instances will try adding some error handling maybe