### PR TITLE
unit ui

### DIFF
--- a/ChapterMaster.resource_order
+++ b/ChapterMaster.resource_order
@@ -466,6 +466,7 @@
     {"name":"scr_chapter_random","order":23,"path":"scripts/scr_chapter_random/scr_chapter_random.yy",},
     {"name":"scr_vehicle_order","order":25,"path":"scripts/scr_vehicle_order/scr_vehicle_order.yy",},
     {"name":"scr_icon","order":27,"path":"scripts/scr_icon/scr_icon.yy",},
+    {"name":"scr_squad_names","order":68,"path":"scripts/scr_squad_names/scr_squad_names.yy",},
     {"name":"scr_initialize_custom","order":29,"path":"scripts/scr_initialize_custom/scr_initialize_custom.yy",},
     {"name":"scr_roman_numerals","order":65,"path":"scripts/scr_roman_numerals/scr_roman_numerals.yy",},
     {"name":"scr_restart_variables","order":31,"path":"scripts/scr_restart_variables/scr_restart_variables.yy",},

--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -766,6 +766,7 @@
     {"id":{"name":"scr_chapter_random","path":"scripts/scr_chapter_random/scr_chapter_random.yy",},},
     {"id":{"name":"scr_vehicle_order","path":"scripts/scr_vehicle_order/scr_vehicle_order.yy",},},
     {"id":{"name":"scr_icon","path":"scripts/scr_icon/scr_icon.yy",},},
+    {"id":{"name":"scr_squad_names","path":"scripts/scr_squad_names/scr_squad_names.yy",},},
     {"id":{"name":"scr_initialize_custom","path":"scripts/scr_initialize_custom/scr_initialize_custom.yy",},},
     {"id":{"name":"scr_roman_numerals","path":"scripts/scr_roman_numerals/scr_roman_numerals.yy",},},
     {"id":{"name":"scr_restart_variables","path":"scripts/scr_restart_variables/scr_restart_variables.yy",},},

--- a/code_guidance.md
+++ b/code_guidance.md
@@ -5,6 +5,11 @@ Useful functions:
 TTRPG_stats(faction, comp, mar, class = "marine")
 		creates a new unit struct see scr_marine_struct.gml for more info
 
+
+		unit_Struct.name_role()
+			provides a string representation of the unit name combined with the unit role 
+			taking into account the unit role display name as provided by the units squad type
+
 scr_random_marine(argument0, argument1)
 		selects a random player unit within the parameters given
 		if no marine is available with give parameters returns "none"
@@ -16,4 +21,16 @@ faction key:
 	mechanics:3
 	inquisition:4
 	sororities:5
+
+
+Visual and draw functions
+
+tool_tip_draw(x,y,tool_tip_text)
+	creates a hover over tool tip at the given coordinate where:
+		x is the left most point of the tooltip box
+		y is the topmost point of the tooltip box,
+		tool_tip_text is the text to display (text should be preformatted e.g string_hash_to_newline() to create lines)
+
+scr_convert_company_to_string(marine company)
+	returns a sting representation of a marines compant
 

--- a/code_guidance.md
+++ b/code_guidance.md
@@ -25,11 +25,11 @@ faction key:
 
 Visual and draw functions
 
-tool_tip_draw(x,y,tool_tip_text)
+tooltip_draw(x,y,tooltip_text)
 	creates a hover over tool tip at the given coordinate where:
 		x is the left most point of the tooltip box
 		y is the topmost point of the tooltip box,
-		tool_tip_text is the text to display (text should be preformatted e.g string_hash_to_newline() to create lines)
+		tooltip_text is the text to display (text should be preformatted e.g string_hash_to_newline() to create lines)
 
 scr_convert_company_to_string(marine company)
 	returns a sting representation of a marines compant

--- a/objects/obj_controller/Alarm_5.gml
+++ b/objects/obj_controller/Alarm_5.gml
@@ -431,7 +431,7 @@ if (psyker_points>=round(goal/2)) and (psyker_aspirant!=0) and (recruit_count==0
 if (psyker_points>=goal){
     if (recruit_count>0){
         marine_position=0;
-        random_marine=scr_random_marine(novice_type,0, {"trait":"warp_touched"});
+        random_marine=scr_random_marine(novice_type,0,{"stat":[["psionic", 8, "more"]]});
         if (random_marine != "none"){
             marine_position = random_marine[1];
             psyker_points-=48;
@@ -447,7 +447,7 @@ if (psyker_points>=round(goal/2)) and (psyker_aspirant==0){
     marine_position=0;
     marine_company=0;
 
-    random_marine=scr_random_marine([obj_ini.role[100,8], obj_ini.role[100,18], obj_ini.role[100,9], obj_ini.role[100,10]],30, {"trait":"warp_touched"});
+    random_marine=scr_random_marine([obj_ini.role[100,8], obj_ini.role[100,18], obj_ini.role[100,9], obj_ini.role[100,10]],30, {"stat":[["psionic", 8, "more"]]});
     if (random_marine == "none"){
         training_psyker=0;
         scr_alert("red","recruitment","No remaining warp sensitive marines for training",0,0);

--- a/objects/obj_controller/Alarm_5.gml
+++ b/objects/obj_controller/Alarm_5.gml
@@ -554,6 +554,8 @@ if (tech_points>=360){
                 if (obj_ini.gear[0,marine_position]!="") then scr_add_item(obj_ini.gear[0,marine_position],1);
                 obj_ini.gear[0,marine_position]="Servo Arms";
             }
+            obj_ini.TTRPG[0,marine_position].religion="cult_mechanicus";
+            obj_ini.TTRPG[0,marine_position].add_trait("mars_trained");
             scr_alert("green","recruitment",string(obj_ini.name[0,marine_position])+" returns from Mars, a "+string(obj_ini.role[100,16])+".",0,0);
             
             if (eq1+eq2!=2){

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -728,12 +728,16 @@ function scr_initialize_custom() {
 	    name[0,i]="";
 	    role[0,i]="";
 	    wep1[0,i]="";
-	    bio[0,i]=0;lid[0,i]=0;wid[0,i]=2;spe[0,i]="";
+	    bio[0,i]=0;
+	    lid[0,i]=0;
+	    wid[0,i]=2;
+	    spe[0,i]="";
 	    wep2[0,i]="";
 	    armour[0,i]="";
 	    gear[0,i]="";
 	    mobi[0,i]="";
-	    chaos[0,i]=0;experience[0,i]=0;
+	    chaos[0,i]=0;
+	    experience[0,i]=0;
 	    hp[0,i]=0;
 	    age[0,i]=((millenium*1000)+year)-10;
 	    god[0,i]=0;

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -77,10 +77,25 @@ function scr_initialize_custom() {
 
 	// Initializes all of the marine/vehicle/ship variables for the chapter.
 
-	techs=20;epistolary=5;apothecary=6;codiciery=6;lexicanum=10;terminator=30;veteran=70;
-	second=100;third=100;fourth=100;fifth=100;sixth=100;seventh=100;eighth=100;
-	ninth=100;tenth=100;
-	assault=20;siege=0;devastator=20;
+	techs=20;
+	epistolary=5;
+	apothecary=6;
+	codiciery=6;
+	lexicanum=10;
+	terminator=30;
+	veteran=70;
+	second=100;
+	third=100;
+	fourth=100;
+	fifth=100;
+	sixth=100;s
+	eventh=100;
+	eighth=100;
+	ninth=100;
+	tenth=100;
+	assault=20;
+	siege=0;
+	devastator=20;
 
 	recruit_trial=obj_creation.aspirant_trial;
 
@@ -104,45 +119,42 @@ function scr_initialize_custom() {
 	    }*/
 	}
 
-
-
-
 	if (progenitor=10){// Pretty sure that's random?
-	    var heh;heh=floor(random(17))+1;
-
-	    if (heh=1) then global.founding_secret="Dark Angels";
-	    if (heh=2) then global.founding_secret="Emperor's Children";
-	    if (heh=3) then global.founding_secret="Iron Warriors";
-	    if (heh=4) then global.founding_secret="White Scars";
-	    if (heh=5) then global.founding_secret="Space Wolves";
-	    if (heh=6) then global.founding_secret="Imperial Fists";
-	    if (heh=7) then global.founding_secret="Night Lords";
-	    if (heh=8) then global.founding_secret="Blood Angels";
-	    if (heh=9) then global.founding_secret="Iron Hands";
-	    if (heh=10) then global.founding_secret="World Eaters";
-	    if (heh=11) then global.founding_secret="Ultramarines";
-	    if (heh=12) then global.founding_secret="Death Guard";
-	    if (heh=13) then global.founding_secret="Thousand Sons";
-	    if (heh=14) then global.founding_secret="Black Legion";
-	    if (heh=15) then global.founding_secret="Word Bearers";
-	    if (heh=16) then global.founding_secret="Salamanders";
-	    if (heh=17) then global.founding_secret="Raven Guard";
+	var legions=["Dark Angels",
+				"Emperor's Children",
+				"Iron Warriors",
+				"White Scars",
+				"Space Wolves",
+				"Imperial Fists",
+				"Night Lords",
+				"Blood Angels",
+				"Iron Hands",
+				"World Eaters",
+				"Ultramarines",
+				"Death Guard",
+				"Thousand Sons",
+				"Black Legion",
+				"Word Bearers",
+				"Salamanders",
+				"Raven Guard"]		
+		global.founding_secret = legions[irandom(16)];
 	}
 
 
 
 
 	company_title[0]="";
-	var i;i=0;repeat(40){i+=1;company_title[i]=obj_creation.company_title[i];}
+	array_copy(company_title, 1, obj_creation.company_title, 1, 40);
 
 
 
 
-
-	home_name=obj_creation.homeworld_name;obj_creation.restart_home_name=home_name;
+	home_name=obj_creation.homeworld_name;
+	obj_creation.restart_home_name=home_name;
 	chapter_name=obj_creation.chapter;
 	// fortress_name="";
-	flagship_name=obj_creation.flagship_name;obj_creation.restart_flagship_name=flagship_name;
+	flagship_name=obj_creation.flagship_name;
+	obj_creation.restart_flagship_name=flagship_name;
 	sector_name=scr_sector_name();
 	icon=obj_creation.icon;
 	icon_name=obj_creation.icon_name;
@@ -247,7 +259,7 @@ function scr_initialize_custom() {
 	    if (global.chapter_name!="Lamenters") and (global.chapter_name!="Doom Benefactors") and (global.chapter_name!="Blood Ravens") then battle_barges+=2;
 	}
 
-	var i, v;i=-1;v=0;
+	var i=-1;v=0;
 	/*repeat(110){i+=1;
 	    ship[i]="";ship_owner[i]=0;ship_class[i]="";ship_size[i]=0;
 	    ship_leadership[i]=0;ship_hp[i]=0;ship_maxhp[i]=0;ship_location[i]="";ship_shields[i]=0;
@@ -262,69 +274,142 @@ function scr_initialize_custom() {
 	    ship_capacity[i]=0;ship_carrying[i]=0;ship_contents[i]="";ship_turrets[i]=0;
 	}*/
 
-	var ship_names;ship_names="";
+	var ship_names=[];
 
-	if (battle_barges>=1) then repeat(battle_barges){v+=1;
-	    if (flagship_name!="") and (v=1) then ship[v]=flagship_name;
-	    if (flagship_name="") or (v>1) then ship[v]=scr_ship_name("imperial");
-	    ship_uid[v]=floor(random(99999999))+1;
-	    ship_owner[v]=1;ship_class[v]="Battle Barge";ship_size[v]=3;ship_location[v]="home";
-	    ship_leadership[v]=100;ship_hp[v]=1200;ship_maxhp[v]=1200;
-	    ship_conditions[v]="";ship_speed[v]=20;ship_turning[v]=45;
-	    ship_front_armour[v]=6;ship_other_armour[v]=6;ship_weapons[v]=5;ship_shields[v]=12;
-	    ship_wep[v,1]="Weapons Battery";ship_wep_facing[v,1]="left";ship_wep_condition[v,1]="";
-	    ship_wep[v,2]="Weapons Battery";ship_wep_facing[v,2]="right";ship_wep_condition[v,2]="";
-	    ship_wep[v,3]="Thunderhawk Launch Bays";ship_wep_facing[v,3]="special";ship_wep_condition[v,3]="";
-	    ship_wep[v,4]="Torpedo Tubes";ship_wep_facing[v,4]="front";ship_wep_condition[v,4]="";
-	    ship_wep[v,5]="Bombardment Cannons";ship_wep_facing[v,5]="most";ship_wep_condition[v,5]="";
-	    ship_capacity[v]=600;ship_carrying[v]=0;ship_contents[v]="";ship_turrets[v]=3;
-	    ship_names+=string(ship[v])+"|";
+	if (battle_barges>=1){
+	 	for (v=1;v<=battle_barges;v++){
+		    if (flagship_name!="") and (v=1) then ship[v]=flagship_name;
+		    if (flagship_name="") or (v>1) then ship[v]=scr_ship_name("imperial");
+		    ship_uid[v]=floor(random(99999999))+1;
+		    ship_owner[v]=1;ship_class[v]="Battle Barge";
+		    ship_size[v]=3;
+		    ship_location[v]="home";
+		    ship_leadership[v]=100;
+		    ship_hp[v]=1200;
+		    ship_maxhp[v]=1200;
+		    ship_conditions[v]="";
+		    ship_speed[v]=20;ship_turning[v]=45;
+		    ship_front_armour[v]=6;ship_other_armour[v]=6;
+		    ship_weapons[v]=5;
+		    ship_shields[v]=12;
+		    ship_wep[v,1]="Weapons Battery";
+		    ship_wep_facing[v,1]="left";
+		    ship_wep_condition[v,1]="";
+		    ship_wep[v,2]="Weapons Battery";
+		    ship_wep_facing[v,2]="right";
+		    ship_wep_condition[v,2]="";
+		    ship_wep[v,3]="Thunderhawk Launch Bays";
+		    ship_wep_facing[v,3]="special";
+		    ship_wep_condition[v,3]="";
+		    ship_wep[v,4]="Torpedo Tubes";ship_wep_facing[v,4]="front";
+		    ship_wep_condition[v,4]="";
+		    ship_wep[v,5]="Bombardment Cannons";
+		    ship_wep_facing[v,5]="most";
+		    ship_wep_condition[v,5]="";
+		    ship_capacity[v]=600;ship_carrying[v]=0;
+		    ship_contents[v]="";
+		    ship_turrets[v]=3;
+		    array_push(ship_names,ship[v])
+		}
 	}
 
-	repeat(strike_cruisers){v+=1;
-	    ship[v]=scr_ship_name("imperial");ship_owner[v]=1;ship_class[v]="Strike Cruiser";ship_size[v]=2;
+	for(i=0;i<strike_cruisers;i++){
+		v+=1;
+	    ship[v]=scr_ship_name("imperial");
+	    ship_owner[v]=1;
+	    ship_class[v]="Strike Cruiser";ship_size[v]=2;
 	    ship_uid[v]=floor(random(99999999))+1;
-	    ship_leadership[v]=100;ship_hp[v]=600;ship_maxhp[v]=600;ship_location[v]="home";
-	    ship_conditions[v]="";ship_speed[v]=25;ship_turning[v]=90;
-	    ship_front_armour[v]=6;ship_other_armour[v]=6;ship_weapons[v]=4;ship_shields[v]=6;
-	    ship_wep[v,1]="Weapons Battery";ship_wep_facing[v,1]="left";ship_wep_condition[v,1]="";
-	    ship_wep[v,2]="Weapons Battery";ship_wep_facing[v,2]="right";ship_wep_condition[v,2]="";
-	    ship_wep[v,3]="Thunderhawk Launch Bays";ship_wep_facing[v,3]="special";ship_wep_condition[v,3]="";
-	    ship_wep[v,4]="Bombardment Cannons";ship_wep_facing[v,4]="most";ship_wep_condition[v,4]="";
-	    ship_capacity[v]=250;ship_carrying[v]=0;ship_contents[v]="";ship_turrets[v]=1;
-	    repeat(5){if (string_count(ship[v],ship_names)!=0) then ship[v]=scr_ship_name("imperial");}
-	    ship_names+=string(ship[v])+"|";
+	    ship_leadership[v]=100;ship_hp[v]=600;
+	    ship_maxhp[v]=600;
+	    ship_location[v]="home";
+	    ship_conditions[v]="";
+	    ship_speed[v]=25;
+	    ship_turning[v]=90;
+	    ship_front_armour[v]=6;ship_other_armour[v]=6;
+	    ship_weapons[v]=4;ship_shields[v]=6;
+	    ship_wep[v,1]="Weapons Battery";
+	    ship_wep_facing[v,1]="left";
+	    ship_wep_condition[v,1]="";
+	    ship_wep[v,2]="Weapons Battery";ship_wep_facing[v,2]="right";
+	    ship_wep_condition[v,2]="";
+	    ship_wep[v,3]="Thunderhawk Launch Bays";ship_wep_facing[v,3]="special";
+	    ship_wep_condition[v,3]="";
+	    ship_wep[v,4]="Bombardment Cannons";ship_wep_facing[v,4]="most";
+	    ship_wep_condition[v,4]="";
+	    ship_capacity[v]=250;ship_carrying[v]=0;
+	    ship_contents[v]="";
+	    ship_turrets[v]=1;
+	    while (array_contains(ship_names,ship[v])){
+	    	ship[v]=scr_ship_name("imperial");
+	    }
+	    array_push(ship_names,ship[v])
 	}
 
-	repeat(gladius){v+=1;// Single weapon battery has 25% more damage than the hunter class destroyer
-	    ship[v]=scr_ship_name("imperial");ship_owner[v]=1;ship_class[v]="Gladius";ship_size[v]=1;
+
+	for(i=0;i<gladius;i++){
+		v+=1;// Single weapon battery has 25% more damage than the hunter class destroyer
+	    ship[v]=scr_ship_name("imperial");
+	    ship_owner[v]=1;
+	    ship_class[v]="Gladius";ship_size[v]=1;
 	    ship_uid[v]=floor(random(99999999))+1;
-	    ship_leadership[v]=100;ship_hp[v]=200;ship_maxhp[v]=200;ship_location[v]="home";
-	    ship_conditions[v]="";ship_speed[v]=30;ship_turning[v]=90;
-	    ship_front_armour[v]=5;ship_other_armour[v]=5;ship_weapons[v]=1;ship_shields[v]=1;
-	    ship_wep[v,1]="Weapons Battery";ship_wep_facing[v,1]="most";ship_wep_condition[v,1]="";
-	    ship_capacity[v]=100;ship_carrying[v]=0;ship_contents[v]="";ship_turrets[v]=1;
-	    repeat(5){if (string_count(ship[v],ship_names)!=0) then ship[v]=scr_ship_name("imperial");}
-	    ship_names+=string(ship[v])+"|";
+	    ship_leadership[v]=100;
+	    ship_hp[v]=200;
+	    ship_maxhp[v]=200;
+	    ship_location[v]="home";
+	    ship_conditions[v]="";
+	    ship_speed[v]=30;
+	    ship_turning[v]=90;
+	    ship_front_armour[v]=5;
+	    ship_other_armour[v]=5;
+	    ship_weapons[v]=1;
+	    ship_shields[v]=1;
+	    ship_wep[v,1]="Weapons Battery";
+	    ship_wep_facing[v,1]="most";
+	    ship_wep_condition[v,1]="";
+	    ship_capacity[v]=100;ship_carrying[v]=0;ship_contents[v]="";
+	    ship_turrets[v]=1;
+	    while (array_contains(ship_names,ship[v])){
+	    	ship[v]=scr_ship_name("imperial");
+	    }
+	    array_push(ship_names,ship[v])
 	}
 
-	repeat(hunters){v+=1;
-	    ship[v]=scr_ship_name("imperial");ship_owner[v]=1;ship_class[v]="Hunter";ship_size[v]=1;
+	for(i=0;i<hunters;i++){
+		v+=1;
+	    ship[v]=scr_ship_name("imperial");
+	    ship_owner[v]=1;
+	    ship_class[v]="Hunter";
+	    ship_size[v]=1;
 	    ship_uid[v]=floor(random(99999999))+1;
-	    ship_leadership[v]=100;ship_hp[v]=200;ship_maxhp[v]=200;ship_location[v]="home";
-	    ship_conditions[v]="";ship_speed[v]=35;ship_turning[v]=90;
-	    ship_front_armour[v]=5;ship_other_armour[v]=5;ship_weapons[v]=2;ship_shields[v]=1;
-	    ship_wep[v,1]="Torpedoes";ship_wep_facing[v,1]="front";ship_wep_condition[v,1]="";
-	    ship_wep[v,2]="Weapons Battery";ship_wep_facing[v,2]="most";ship_wep_condition[v,2]="";
-	    ship_capacity[v]=50;ship_carrying[v]=0;ship_contents[v]="";ship_turrets[v]=1;
-	    repeat(5){if (string_count(ship[v],ship_names)!=0) then ship[v]=scr_ship_name("imperial");}
-	    ship_names+=string(ship[v])+"|";
+	    ship_leadership[v]=100;ship_hp[v]=200;
+	    ship_maxhp[v]=200;
+	    ship_location[v]="home";
+	    ship_conditions[v]="";
+	    ship_speed[v]=35;
+	    ship_turning[v]=90;
+	    ship_front_armour[v]=5;
+	    ship_other_armour[v]=5;
+	    ship_weapons[v]=2;
+	    ship_shields[v]=1;
+	    ship_wep[v,1]="Torpedoes";
+	    ship_wep_facing[v,1]="front";
+	    ship_wep_condition[v,1]="";
+	    ship_wep[v,2]="Weapons Battery";
+	    ship_wep_facing[v,2]="most";
+	    ship_wep_condition[v,2]="";
+	    ship_capacity[v]=50;
+	    ship_carrying[v]=0;ship_contents[v]="";
+	    ship_turrets[v]=1;
+	    while (array_contains(ship_names,ship[v])){
+	    	ship[v]=scr_ship_name("imperial");
+	    }
+	    array_push(ship_names,ship[v])
 	}
 
 	var j=0,f=0;
 	var total_ship_count = battle_barges+strike_cruisers+gladius+hunters;
-	for (f=1;f<total_ship_count+1;f++){
-	    for(j=1;j<31;j++){
+	for (f=1;f<=total_ship_count;f++){
+	    for(j=1;j<=30;j++){
 	    	if (ship_uid[f]=ship_uid[j]) and (f!=j) then ship_uid[j]=floor(random(99999999))+1;
 	    }
 	}
@@ -336,12 +421,35 @@ function scr_initialize_custom() {
 
 
 	// :D :D :D
-	master_tau=0;master_battlesuits=0;master_kroot=0;master_tau_vehicles=0;
-	master_ork_boyz=0;master_ork_nobz=0;master_ork_warboss=0;master_ork_vehicles=0;
-	master_heretics=0;master_chaos_marines=0;master_lesser_demons=0;master_greater_demons=0;master_chaos_vehicles=0;
-	master_gaunts=0;master_warriors=0;master_carnifex=0;master_synapse=0;master_tyrant=0;master_gene=0;
-	master_avatar=0;master_farseer=0;master_autarch=0;master_eldar=0;master_aspect=0;master_eldar_vehicles=0;
-	master_necron_overlord=0;master_destroyer=0;master_necron=0;master_wraith=0;master_necron_vehicles=0;master_monolith=0;
+	master_tau=0;
+	master_battlesuits=0;
+	master_kroot=0;
+	master_tau_vehicles=0;
+	master_ork_boyz=0;master_ork_nobz=0;
+	master_ork_warboss=0;
+	master_ork_vehicles=0;
+	master_heretics=0;
+	master_chaos_marines=0;
+	master_lesser_demons=0;
+	master_greater_demons=0;
+	master_chaos_vehicles=0;
+	master_gaunts=0;
+	master_warriors=0;
+	master_carnifex=0;
+	master_synapse=0;
+	master_tyrant=0;
+	master_gene=0;
+	master_avatar=0;
+	master_farseer=0;master_autarch=0;
+	master_eldar=0;
+	master_aspect=0;
+	master_eldar_vehicles=0;
+	master_necron_overlord=0;
+	master_destroyer=0;
+	master_necron=0;
+	master_wraith=0;
+	master_necron_vehicles=0;
+	master_monolith=0;
 	master_special_killed="";
 
 	check_number=5;
@@ -353,10 +461,10 @@ function scr_initialize_custom() {
 	var company=0;
 	var chaap=1,whirlwind;
 	var second=100,third=100,fourth=100,fifth=100,sixth=100,seventh=100,eighth=100,ninth=100,tenth=100;
-	var assult =20,siege,temp1=0,temp2=0, intolerant=0;
+	var assault=20,siege=0,temp1=0,temp2=0, intolerant=0;
 	var size_relative, k, i, v, t;k=0;i=0;v=0;
 	var techs=20,epistolary=4,apothecary=6,codiciery=6,lexicanum=10,terminator=10,veteran=89;
-	siege=0;devastator=20;
+	devastator=20;
 
 	whirlwind=4;
 
@@ -413,7 +521,7 @@ function scr_initialize_custom() {
 	    if (obj_creation.strength<=2) then seventh=0;
 	    if (obj_creation.strength<=1) then sixth=0;
 
-	    var bonus_marines,o;bonus_marines=0;o=0;
+	    var bonus_marines=0,o=0;
 	    if (obj_creation.strength>5) then bonus_marines=(obj_creation.strength-5)*50;
 
 	    /*repeat(20){
@@ -431,7 +539,7 @@ function scr_initialize_custom() {
 	}
 
 	if (obj_creation.custom!=0){
-	    var bonus_marines,o;bonus_marines=0;o=0;
+	    var bonus_marines=0,o=0;
 	    if (obj_creation.strength>5) then bonus_marines=(obj_creation.strength-5)*50;
 	    i=0
 	    while(bonus_marines>=5){
@@ -473,26 +581,76 @@ function scr_initialize_custom() {
 
 
 
-
-	if (global.chapter_name="Salamanders"){veteran+=20;second+=20;third+=20;fourth+=20;fifth+=20;sixth+=20;seventh=0;eighth=0;ninth=0;tenth-=40;}
-	if (global.chapter_name="Blood Angels"){chaap=3;apothecary=10;epistolary=6;codiciery=6;lexicanum=8;}
-	if (global.chapter_name="Dark Angels"){veteran=0;terminator+=80;}
-	if (global.chapter_name="Lamenters"){
-	    tenth=0;ninth=0;eighth=0;seventh=0;sixth=0;fifth=0;
-	    techs=8;epistolary=6;apothecary=5;codiciery=3;lexicanum=5;terminator=5;veteran+=10;
-	}
-	if (global.chapter_name="Soul Drinkers"){
-		tenth-=38;seventh=0;sixth=40; assault-=10;
-		fifth-=20;fourth-=20;third-=20;second-=20;terminator-=5;veteran-=20;
-	}
-	if (global.chapter_name="Crimson Fists"){
-	    veteran+=30;
-	}
-	if (global.chapter_name="Space Wolves"){
-	    veteran+=40;second+=40;third+=40;fourth+=40;fifth+=40;sixth+=40;seventh+=40;eighth+=40;ninth+=40;tenth+=60;
-	}
-	if (global.chapter_name="Iron Hands"){
-	    terminator=0;veteran+=10;
+	switch(global.chapter_name){
+		case "Salamanders":
+			veteran+=20;
+			second+=20;
+			third+=20;
+			fourth+=20;
+			fifth+=20;
+			sixth+=20;
+			seventh=0;
+			eighth=0;
+			ninth=0;
+			tenth-=40;
+			break;
+		case "Blood Angels":
+			chaap=3;
+			apothecary=10;
+			epistolary=6;
+			codiciery=6;
+			lexicanum=8;
+			break;
+		case "Dark Angels":
+			veteran=0;
+			terminator+=80;
+			break;
+		case "Lamenters":
+		    tenth=0;
+		    ninth=0;
+		    eighth=0;
+		    seventh=0;
+		    sixth=0;
+		    fifth=0;
+		    techs=8;
+		    epistolary=6;
+		    apothecary=5;
+		    codiciery=3;
+		    lexicanum=5;
+		    terminator=5;
+		    veteran+=10;
+		    break;
+		case "Soul Drinkers":
+			tenth-=38;
+			seventh=0;
+			sixth=40; 
+			assault-=10;
+			fifth-=20;
+			fourth-=20;
+			third-=20;
+			second-=20;
+			terminator-=5;
+			veteran-=20;
+			break;
+		case "Crimson Fists":
+			veteran+=30;
+			break;
+		case "Space Wolves":
+	    	veteran+=40;
+	    	second+=40;
+	    	third+=40;
+	    	fourth+=40;
+	    	fifth+=40;
+	    	sixth+=40;
+	    	seventh+=40;
+	    	eighth+=40;
+	    	ninth+=40;
+	    	tenth+=60;
+	    	break;
+	    case "Iron Hands":
+		    terminator=0;
+		    veteran+=10;
+		    break;
 	}
 	if (obj_creation.custom=0) and (global.chapter_name!="Iron Hands") and (global.chapter_name!="Doom Benefactors"){
 	    if (veteran>=20) and (global.founding=0){veteran-=20;terminator+=20;}
@@ -541,8 +699,7 @@ function scr_initialize_custom() {
 
 	company=0;
 	// Initialize default marines for loadouts
-	for(i=0;i<101;i++){
-		i+=1;
+	for(i=0;i<=100;i++){
 	    race[100,i]=1;
 	    loc[100,i]="";
 	    name[100,i]="";
@@ -563,7 +720,7 @@ function scr_initialize_custom() {
 	    if (global.chapter_name="Iron Hands") then bio[100,i]=choose(3,4,5);
 	}initialized=500;
 	// Initialize special marines
-	i=-1;repeat(501){i+=1;
+	for(i=0;i<=500;i++){
 	    race[0,i]=1;
 	    loc[0,i]="";
 	    name[0,i]="";
@@ -581,7 +738,7 @@ function scr_initialize_custom() {
 	    bio[0,i]=0;
 		TTRPG[0,i] = new TTRPG_stats("chapter", 0,i,"blank");
 	}
-	i=-1;repeat(101){i+=1;
+	for(i=0;i<=100;i++){i+=1;
 	    role[100,i]="";
 	    wep1[100,i]="";
 	    wep2[100,i]="";
@@ -693,7 +850,7 @@ function scr_initialize_custom() {
 		mobi[i,19]="";
 		gear[i,19]="";	
 	}// 100 is defaults, 101 is the allowable starting equipment // info
-	i=-1;repeat(21){i+=1;
+	for(i=0;i<=20;i++){i+=1;
 	    race[100,i]=obj_creation.race[100,i];
 	    role[100,i]=obj_creation.role[100,i];
 	    wep1[100,i]=obj_creation.wep1[100,i];
@@ -957,7 +1114,7 @@ function scr_initialize_custom() {
 	}
 
 
-	for (i=0;i<20;i++;){
+	for (i=0;i<=20;i++;){
 	    if (role[100,i]!="") then scr_start_allow(i,"wep1",wep1[100,i]);
 	    if (role[100,i]!="") then scr_start_allow(i,"wep2",wep2[100,i]);
 	    if (role[100,i]!="") then scr_start_allow(i,"mobi",mobi[100,i]);
@@ -966,7 +1123,8 @@ function scr_initialize_custom() {
 	}
 
 	initialized=500;// How many array variables have been prepared
-	v=0;company=0;
+	v=0;
+	company=0;
 
 
 
@@ -978,43 +1136,115 @@ function scr_initialize_custom() {
 	role[company,1]="Chapter Master";
 	TTRPG[company,1]=new TTRPG_stats("chapter", company,1, "chapter_master");
 	var chapter_master = TTRPG[company,1]
-	if (master_melee=1) then wep1[0,1]="Power Fist&DUB|";
-	if (master_melee=2) then wep1[0,1]="Relic Blade&MNR|";
-	if (master_melee=3) then wep1[0,1]="Master Crafted Thunder Hammer";
-	if (master_melee=4) then wep1[0,1]="Master Crafted Power Sword";
-	if (master_melee=5) then wep1[0,1]="Master Crafted Power Axe";
-	if (master_melee=6) then wep1[0,1]="Master Crafted Eviscerator";
-	if (master_melee=7) then wep1[0,1]="Master Crafted Force Weapon";
-
-	if (master_ranged=1) then wep2[0,1]="Integrated Bolters";
-	if (master_ranged=2) then wep2[0,1]="Infernus Pistol";
-	if (master_ranged=3) then wep2[0,1]="Master Crafted Plasma Pistol";
-	if (master_ranged=4) then wep2[0,1]="Master Crafted Plasma Gun";
-	if (master_ranged=5) then wep2[0,1]="Master Crafted Heavy Bolter";
-	if (master_ranged=6) then wep2[0,1]="Master Crafted Meltagun";
-	if (master_ranged=7) then wep2[0,1]="Storm Shield";
-
-	if (global.chapter_name="Dark Angels") then wep2[0,1]="Plasma Gun&UBL|";
-	if (global.chapter_name="Blood Angels") then wep1[0,1]="Master Crafted Power Axe";
-	if (global.chapter_name="Iron Hands"){wep1[0,1]="Power Axe&ADA|";
-		wep2[0,1]="Storm Shield";
-		repeat(10){chapter_master.add_bionics()};
+	switch (master_melee){
+		case 1:
+			wep1[0,1]="Power Fist&DUB|";
+			break;
+		case 2:
+			wep1[0,1]="Relic Blade&MNR|";
+			break;
+		case 3:
+			wep1[0,1]="Master Crafted Thunder Hammer";
+			break;
+		case 4:
+			wep1[0,1]="Master Crafted Power Sword";
+			break;
+		case 5:
+			wep1[0,1]="Master Crafted Power Axe";
+			break;
+		case 6:
+			wep1[0,1]="Master Crafted Eviscerator";
+			break;
+		case 7:
+			wep1[0,1]="Master Crafted Force Weapon";
+			break;	
 	}
-	if (global.chapter_name="Doom Benefactors") then repeat(4){chapter_master.add_bionics()};
+	switch (master_ranged){
+		case 1:
+			wep2[0,1]="Integrated Bolters";
+			break;
+		case 2:
+			wep2[0,1]="Infernus Pistol";
+			break;
+		case 3:
+			wep2[0,1]="Master Crafted Plasma Pistol";
+			break;
+		case 4:
+			wep2[0,1]="Master Crafted Plasma Gun";
+			break;
+		case 5:
+			wep2[0,1]="Master Crafted Heavy Bolter";
+			break;
+		case 6:
+			wep2[0,1]="Master Crafted Meltagun";
+			break;
+		case 7:
+			wep2[0,1]="Storm Shield";
+			break;	
+	}	
 
 	armour[company,1]="Artificer Armour";
+	switch(global.chapter_name) {
+		case "Dark Angels":
+			wep2[0,1]="Plasma Gun&UBL|";
+			break;
+		case "Blood Angels":
+			wep1[0,1]="Master Crafted Power Axe";
+			break;
+		case "Iron Hands":
+			wep1[0,1]="Power Axe&ADA|";
+			wep2[0,1]="Storm Shield";
+			for (i=0;i<10;i++){
+				chapter_master.add_bionics();
+			}
+			break;
+		case "Doom Benefactors":
+			for (i=0;i<4;i++){
+				chapter_master.add_bionics();
+			}
+			break;
+		case "Ultramarines":
+			for (i=0;i<4;i++){
+				chapter_master.add_bionics();
+				armour[company,1]="Terminator Armour";
+			}
+	}
 	spe[company,1]="";
-	if (obj_creation.chapter_master_specialty=1){experience[company,1]=550;spe[company,1]+="$";}
-	if (obj_creation.chapter_master_specialty=2){experience[company,1]=650;spe[company,1]+="@";}
-	if (obj_creation.chapter_master_specialty=3){experience[company,1]=550;
+
+	//builds in which of the three chapter master types your CM is
+	switch(obj_creation.chapter_master_specialty){
+		case 1:
+			experience[company,1]=550;
+			spe[company,1]+="$";
+			break;
+		case 2:
+			experience[company,1]=650;
+			spe[company,1]+="@";
+			break;
+		case 3:
+			experience[company,1]=550;
 		gear[company,1]="Psychic Hood";
-	    var let,letmax;let="";letmax=0;
-	    if (obj_creation.discipline="default"){let="D";letmax=7;}
-	    if (obj_creation.discipline="biomancy"){let="B";letmax=5;}
-	    if (obj_creation.discipline="pyromancy"){let="P";letmax=5;}
-	    if (obj_creation.discipline="telekinesis"){let="T";letmax=5;}
-	    if (obj_creation.discipline="rune Magick"){let="R";letmax=5;}
-	    spe[company,1]+=string(let)+"0|";scr_powers_new(company,1);
+		    var let="";letmax=5;
+
+		    switch(obj_creation.discipline){
+		    	case "default":
+		    		let="D";
+		    		letmax=7;
+		    		break;
+		    	case "biomancy":
+		    		let="B";
+		    		break;
+		    	case "pyromancy":
+		    		let="P";
+		    		break;
+		    	case "telekinesis":
+		    		let="T";
+		    		break;
+		    	case "rune Magick":
+		    		let="R";
+		    		break;
+		    }
+		    spe[company,1]+=string(let)+"0|";scr_powers_new(company,1);			
 	}
 	mobi[company,1]=mobi[100,2];
 	if (string_count("Paragon",strin)>0) then chapter_master.add_trait("paragon")
@@ -1039,7 +1269,7 @@ function scr_initialize_custom() {
 	spawn_unit.add_bionics("right_arm");
 	if (global.chapter_name="Lamenters") then armour[company,2]="MK6 Corvus";
 	if (global.chapter_name="Iron Hands"){
-		repeat(9){spawn_unit.add_bionics("right_arm");}
+		repeat(9){spawn_unit.add_bionics();}
 	} else{
 	    repeat(irandom(3)){spawn_unit.add_bionics()};
 	}
@@ -1500,13 +1730,26 @@ function scr_initialize_custom() {
 		name[company,k]=scr_marine_name();
 	}
 
-	repeat(4){v+=1;man_size+=10;
-	    veh_race[company,v]=1;veh_loc[company,v]=home_name;veh_role[company,v]="Rhino";veh_wep1[company,v]="Storm Bolter";veh_wep2[company,v]="HK Missile";veh_wep3[company,v]="";
-	    veh_upgrade[company,v]="Artificer Hull";veh_acc[company,v]="Dozer Blades";veh_hp[company,v]=100;veh_chaos[company,v]=0;veh_pilots[company,v]=0;veh_lid[company,v]=0;veh_wid[company,v]=2;
+	for(i=0;i<4;i++){
+		v+=1;
+		man_size+=10;
+	    veh_race[company,v]=1;
+	    veh_loc[company,v]=home_name;
+	    veh_role[company,v]="Rhino";veh_wep1[company,v]="Storm Bolter";
+	    veh_wep2[company,v]="HK Missile";
+	    veh_wep3[company,v]="";
+	    veh_upgrade[company,v]="Artificer Hull";
+	    veh_acc[company,v]="Dozer Blades";
+	    veh_hp[company,v]=100;
+	    veh_chaos[company,v]=0;
+	    veh_pilots[company,v]=0;
+	    veh_lid[company,v]=0;veh_wid[company,v]=2;
 	}
-	var predrelic;predrelic=2;
+	var predrelic=2;
 	if (global.chapter_name="Iron Hands") then predrelic=3;
-	repeat(predrelic){v+=1;man_size+=10;
+	repeat(predrelic){
+		v+=1;
+		man_size+=10;
 		var predtype;
 		predtype=choose(1,2,3,4)
 		veh_race[company,v]=1;veh_loc[company,v]=home_name;veh_role[company,v]="Predator";
@@ -1527,12 +1770,11 @@ function scr_initialize_custom() {
 
 
 
-
-	repeat(9){
-	    company+=1;
-
+	//non HQ and non firsst company initialised here
+	for(company=2;company<11;company++){
 	    // Initialize marines
-	    i=-1;repeat(501){i+=1;
+	    for(i=0;i<501;i++){
+	    	i+=1;
 	        race[company,i]=1;
 	        loc[company,i]="";
 	        name[company,i]="";
@@ -1554,10 +1796,12 @@ function scr_initialize_custom() {
 			TTRPG[company,i]= new TTRPG_stats("chapter", company,i, "blank");
 	    }
 
-	    var company_experience, company_unit2, company_unit3, dready, rhinoy, whirly, speedy,stahp;
-	    company_experience=0;company_unit2="";company_unit3="";stahp=0;
+	    var company_experience=0, company_unit2="", company_unit3="", dready=0, rhinoy=0, whirly=0, speedy=0,stahp=0;
 
-	    v=0;i=-1;k=0;v=0;dready=0;rhinoy=0;whirly=0;speedy=0;
+	    v=0;
+	    i=-1;
+	    k=0;
+	    v=0;
 
 
 	    if (obj_creation.equal_specialists=1){
@@ -1644,16 +1888,21 @@ function scr_initialize_custom() {
 	            if (eighth=0) then stahp=1;
 	        }
 	        if (company=9){
-	            temp1=ninth;company_unit2="";company_unit3="";
-	            temp1-=2;
+	            temp1=ninth-2;
+	            company_unit2="";
+	            company_unit3="";
 	            if (obj_creation.custom=0) then dready=2;
 	            rhinoy=2;whirly=0;speedy=0;
 	            if (ninth=0) then stahp=1;
 	        }
 	        if (company=10){
-	            temp1=tenth;company_unit2="";company_unit3="";
-	            temp1-=2;
-	            dready=0;rhinoy=8;whirly=0;speedy=0;
+	            temp1=tenth-2;
+	            company_unit2="";c
+	            ompany_unit3="";
+	            dready=0;
+	            rhinoy=8;
+	            whirly=0;
+	            speedy=0;
 
 	            // if (obj_creation.custom=0) then temp1-=5;
 

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -88,8 +88,8 @@ function scr_initialize_custom() {
 	third=100;
 	fourth=100;
 	fifth=100;
-	sixth=100;s
-	eventh=100;
+	sixth=100;
+	seventh=100;
 	eighth=100;
 	ninth=100;
 	tenth=100;
@@ -1774,7 +1774,6 @@ function scr_initialize_custom() {
 	for(company=2;company<11;company++){
 	    // Initialize marines
 	    for(i=0;i<501;i++){
-	    	i+=1;
 	        race[company,i]=1;
 	        loc[company,i]="";
 	        name[company,i]="";
@@ -1897,8 +1896,8 @@ function scr_initialize_custom() {
 	        }
 	        if (company=10){
 	            temp1=tenth-2;
-	            company_unit2="";c
-	            ompany_unit3="";
+	            company_unit2="";
+	            company_unit3="";
 	            dready=0;
 	            rhinoy=8;
 	            whirly=0;

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -98,6 +98,8 @@ function scr_initialize_custom() {
 	devastator=20;
 
 	recruit_trial=obj_creation.aspirant_trial;
+	purity=obj_creation.purity;
+	stability=obj_creation.stability;
 
 	// show_message(instance_number(obj_controller));
 
@@ -1223,9 +1225,9 @@ function scr_initialize_custom() {
 			break;
 		case 3:
 			experience[company,1]=550;
-		gear[company,1]="Psychic Hood";
+			gear[company,1]="Psychic Hood";
 		    var let="";letmax=5;
-
+		    chapter_master.psionic = choose(15,16);
 		    switch(obj_creation.discipline){
 		    	case "default":
 		    		let="D";
@@ -1271,7 +1273,7 @@ function scr_initialize_custom() {
 	if (global.chapter_name="Iron Hands"){
 		repeat(9){spawn_unit.add_bionics();}
 	} else{
-	    repeat(irandom(3)){spawn_unit.add_bionics()};
+	    repeat(irandom(5)+3){spawn_unit.add_bionics()};
 	}
 	// Master of Sanctity (Chaplain)
 	TTRPG[company,3]=new TTRPG_stats("chapter", company,3);
@@ -1304,6 +1306,7 @@ function scr_initialize_custom() {
 	gear[company,4]=gear[101,15];
 	chaos[company,4]=0;experience[company,4]=500;
 	if (global.chapter_name="Lamenters") then armour[company,4]="MK6 Corvus";
+
 	// Chief Librarian
 	TTRPG[company,5]=new TTRPG_stats("chapter", company,5);
 	race[company,5]=1;
@@ -1322,6 +1325,7 @@ function scr_initialize_custom() {
 	if (obj_creation.discipline="telekinesis"){let="T";letmax=5;}
 	if (obj_creation.discipline="rune Magick"){let="R";letmax=5;}
 	spe[company,5]=string(let)+"0|";scr_powers_new(company,5);
+	TTRPG[company,5].psionics = choose(13,14,15,16);
 	TTRPG[company,5].add_trait("warp_touched");
 	k=0;
 	commands+=5;
@@ -1390,7 +1394,8 @@ function scr_initialize_custom() {
 	    if (obj_creation.discipline="rune Magick"){let="R";letmax=5;}
 	    spe[company,k]+=string(let)+"0|";scr_powers_new(company,k);
 	    TTRPG[company,k].spawn_old_guard();
-	    TTRPG[company,k].add_trait("warp_touched");    
+	    TTRPG[company,k].add_trait("warp_touched");  
+	    TTRPG[company,k].psionics = choose(13,14,15,16);  
 	}
 	// Codiciery
 	repeat(codiciery){
@@ -1416,7 +1421,8 @@ function scr_initialize_custom() {
 	    if (obj_creation.discipline="rune Magick"){let="R";letmax=5;}
 	    spe[company,k]+=string(let)+"0|";scr_powers_new(company,k);
 	    TTRPG[company,k].spawn_old_guard();
-	    TTRPG[company,k].add_trait("warp_touched");    
+	    TTRPG[company,k].add_trait("warp_touched");
+	    TTRPG[company,k].psionics = choose(11,12,13,14,15);     
 	}
 	// Lexicanum
 	repeat(lexicanum){k+=1;commands+=1;man_size+=1;
@@ -1440,6 +1446,7 @@ function scr_initialize_custom() {
 	    spe[company,k]+=string(let)+"0|";
 	    TTRPG[company,k].spawn_old_guard();
 	    TTRPG[company,k].add_trait("warp_touched");
+	    TTRPG[company,k].psionics = choose(8,9,10,11,12,13,14);     
 	}
 	// Apothecary
 	repeat(apothecary){

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -78,7 +78,8 @@ function scr_initialize_custom() {
 	// Initializes all of the marine/vehicle/ship variables for the chapter.
 
 	techs=20;epistolary=5;apothecary=6;codiciery=6;lexicanum=10;terminator=30;veteran=70;
-	second=100;third=100;fourth=100;fifth=100;sixth=100;seventh=100;eighth=100;ninth=100;tenth=100;
+	second=100;third=100;fourth=100;fifth=100;sixth=100;seventh=100;eighth=100;
+	ninth=100;tenth=100;
 	assault=20;siege=0;devastator=20;
 
 	recruit_trial=obj_creation.aspirant_trial;
@@ -161,7 +162,11 @@ function scr_initialize_custom() {
 	other1_disposition=0;
 	other1="";
 
-	tolerant=0;var o;o=0;repeat(4){o+=1;if (obj_creation.dis[o]="Tolerant") then tolerant=1;adv[o]=obj_creation.adv[o];dis[o]=obj_creation.dis[o];}
+	if (array_contains(obj_creation.dis, "Tolerant")){
+		tolerant=1;
+	}
+	adv = obj_creation.adv;
+	dis = obj_creation.dis;
 
 	battle_barges=0;
 	strike_cruisers=0;
@@ -316,9 +321,12 @@ function scr_initialize_custom() {
 	    ship_names+=string(ship[v])+"|";
 	}
 
-	var j,f;j=0;f=0;
-	repeat(battle_barges+strike_cruisers+gladius+hunters){f+=1;j=0;
-	    repeat(30){j+=1;if (ship_uid[f]=ship_uid[j]) and (f!=j) then ship_uid[j]=floor(random(99999999))+1;}
+	var j=0,f=0;
+	var total_ship_count = battle_barges+strike_cruisers+gladius+hunters;
+	for (f=1;f<total_ship_count+1;f++){
+	    for(j=1;j<31;j++){
+	    	if (ship_uid[f]=ship_uid[j]) and (f!=j) then ship_uid[j]=floor(random(99999999))+1;
+	    }
 	}
 
 
@@ -342,14 +350,13 @@ function scr_initialize_custom() {
 	if (obj_creation.chapter_year!=0) then year=obj_creation.chapter_year;
 	millenium=41;
 
-	var company;company=0;
-	var techs, epistolary, apothecary, chaap, codiciery, lexicanum, terminator, veteran, whirlwind;
-	var second, third, fourth, fifth, sixth, seventh, eighth, ninth, tenth;
-	var assult,siege;temp1=0;temp2=0;
-	var size_relative, k, temp1, temp2, i, v, t;k=0;i=0;v=0;
-	techs=20;epistolary=4;apothecary=6;codiciery=6;lexicanum=10;terminator=10;veteran=89;
-	second=100;third=100;fourth=100;fifth=100;sixth=100;seventh=100;eighth=100;ninth=100;tenth=100;
-	assault=20;siege=0;devastator=20;chaap=1;
+	var company=0;
+	var chaap=1,whirlwind;
+	var second=100,third=100,fourth=100,fifth=100,sixth=100,seventh=100,eighth=100,ninth=100,tenth=100;
+	var assult =20,siege,temp1=0,temp2=0, intolerant=0;
+	var size_relative, k, i, v, t;k=0;i=0;v=0;
+	var techs=20,epistolary=4,apothecary=6,codiciery=6,lexicanum=10,terminator=10,veteran=89;
+	siege=0;devastator=20;
 
 	whirlwind=4;
 
@@ -364,27 +371,41 @@ function scr_initialize_custom() {
 	catalepsean=obj_creation.catalepsean;secretions=obj_creation.secretions;occulobe=obj_creation.occulobe;mucranoid=obj_creation.mucranoid;
 
 	/*techs=20;epistolary=5;apothecary=6;codiciery=6;lexicanum=10;terminator=30;veteran=30;
-	second=9;third=9;fourth=9;fifth=9;sixth=9;seventh=9;eighth=9;ninth=9;tenth=10;
+	second=9;third=9;fourth=9;fifth=9;sixth=9;seventh=9;ei;
+	ninth=9;tenth=10;
 	assault=2;siege=0;devastator=2;*/
 
 	var chapter_option,o,psyky;psyky=0;
-
-	o=0;chapter_option=0;repeat(4){o+=1;if (obj_creation.adv[o]="Tech-Brothers") then chapter_option=1;}if (chapter_option=1){techs+=10;tenth-=10;}
-	o=0;chapter_option=0;repeat(4){o+=1;if (obj_creation.adv[o]="Melee Enthusiasts") then chapter_option=1;}if (chapter_option=1){assault=30;}
-	o=0;chapter_option=0;repeat(4){o+=1;if (obj_creation.adv[o]="Siege Masters") then chapter_option=1;}if (chapter_option=1) then siege=1;
-	o=0;chapter_option=0;repeat(4){o+=1;if (obj_creation.adv[o]="Crafters") then chapter_option=1;}if (chapter_option=1){techs+=5;terminator+=5;tenth-=10;}
-	o=0;chapter_option=0;repeat(4){o+=1;if (obj_creation.adv[o]="Psyker Abundance") then chapter_option=1;}if (chapter_option=1){tenth-=10;epistolary+=2;codiciery+=3;lexicanum+=5;psyky=1;}
-	var intolerant;intolerant=0;
-	o=0;chapter_option=0;repeat(4){o+=1;if (obj_creation.dis[o]="Psyker Intolerant") then chapter_option=1;}if (chapter_option=1){epistolary=0;codiciery=0;lexicanum=0;veteran+=10;tenth+=10;intolerant=1;}
-	o=0;chapter_option=0;repeat(4){o+=1;if (obj_creation.dis[o]="Sieged") then chapter_option=1;}
-	if (chapter_option=1){
-	    techs-=10;epistolary-=3;apothecary-=4;codiciery-=3;lexicanum-=5;terminator-=10;veteran-=50;
-	    second-=30;third-=30;fourth-=30;fifth-=60;sixth-=60;seventh-=60;eighth-=70;ninth-=70;tenth-=70;// 370
-	    assault=10;siege=0;devastator=10;
+	if (array_contains(obj_creation.adv,"Tech-Brothers")){techs+=10;tenth-=10;}
+	if (array_contains(obj_creation.adv,"Melee Enthusiasts")){assault=30;}
+	if (array_contains(obj_creation.adv,"Siege Masters")){siege=1;}
+	if (array_contains(obj_creation.adv,"Crafters")){techs+=5;terminator+=5;tenth-=10;}
+	if (array_contains(obj_creation.adv,"Psyker Abundance")){tenth-=10;epistolary+=2;codiciery+=3;lexicanum+=5;psyky=1;}
+	if (array_contains(obj_creation.adv,"Psyker Intolerant")){epistolary=0;codiciery=0;lexicanum=0;veteran+=10;tenth+=10;intolerant=1;}
+	if (array_contains(obj_creation.adv,"Sieged")){
+		techs-=10;
+		epistolary-=3;
+		apothecary-=4;
+		codiciery-=3;
+		lexicanum-=5;
+		terminator-=10;
+		veteran-=50;
+	    second-=30;
+	    third-=30;
+	    fourth-=30;
+	    fifth-=60;
+	    sixth-=60;
+	    seventh-=60;
+	    eighth-=70;
+	    ninth-=70;
+	    tenth-=70;// 370
+	    assault=10;
+	    siege=0;
+	    devastator=10;
 	}
-	o=0;chapter_option=0;repeat(4){o+=1;if (obj_creation.dis[o]="Tech-Heresy") then chapter_option=1;}if (chapter_option=1){techs-=10;tenth+=1;}
-	o=0;chapter_option=0;repeat(4){o+=1;if (obj_creation.adv[o]="Reverent Guardians") then chapter_option=1;}if (chapter_option=1){chaap+=10;tenth-=10;}
 
+	if (array_contains(obj_creation.adv,"Tech-Heresy")){techs-=10;tenth+=1;}
+	if (array_contains(obj_creation.adv,"Reverent Guardians")){chaap+=10;tenth-=10;}
 	// if (obj_creation.custom>0) or ((global.chapter_name="Doom Benefactors") and (obj_creation.custom=0)){
 	if ((progenitor>=1) and (progenitor<=10)) or ((global.chapter_name="Doom Benefactors") and (obj_creation.custom=0)){
 	    if (obj_creation.strength<=4) then ninth=0;
@@ -412,26 +433,48 @@ function scr_initialize_custom() {
 	if (obj_creation.custom!=0){
 	    var bonus_marines,o;bonus_marines=0;o=0;
 	    if (obj_creation.strength>5) then bonus_marines=(obj_creation.strength-5)*50;
-
-	    repeat(20){
-	        if (bonus_marines>=5) and (veteran>0){bonus_marines-=5;veteran+=5;}
-	        if (bonus_marines>=5) and (second>0){bonus_marines-=5;second+=5;}
-	        if (bonus_marines>=5) and (third>0){bonus_marines-=5;third+=5;}
-	        if (bonus_marines>=5) and (fourth>0){bonus_marines-=5;fourth+=5;}
-	        if (bonus_marines>=5) and (fifth>0){bonus_marines-=5;fifth+=5;}
-	        if (bonus_marines>=5) and (sixth>0){bonus_marines-=5;sixth+=5;}
-	        if (bonus_marines>=5) and (seventh>0){bonus_marines-=5;seventh+=5;}
-	        if (bonus_marines>=5) and (eighth>0){bonus_marines-=5;eighth+=5;}
-	        if (bonus_marines>=5) and (ninth>0){bonus_marines-=5;ninth+=5;}
-	        if (bonus_marines>=5) and (tenth>0){bonus_marines-=5;tenth+=5;}
+	    i=0
+	    while(bonus_marines>=5){
+	    	switch(i%10){
+	    		case 0:
+	    			if (veteran>0){bonus_marines-=5;veteran+=5;}
+	    			break;
+	    		case 1:
+	    			if (second>0){bonus_marines-=5;second+=5;}
+	    			break;
+	    		case 2:
+	    			if (third>0){bonus_marines-=5;third+=5;}
+	    			break;
+	    		case 3:
+	    			if (fourth>0){bonus_marines-=5;fourth+=5;}
+	    			break;	    			
+	    		case 4:
+	    			if (fifth>0){bonus_marines-=5;fifth+=5;}
+	    			break;
+	    		case 5:
+	    			if (sixth>0){bonus_marines-=5;sixth+=5;}
+	    			break;
+	    		case 6:
+	    			if (seventh>0){bonus_marines-=5;seventh+=5;}
+	    			break;
+	    		case 7:
+	    			if (eighth>0){bonus_marines-=5;eighth+=5;}
+	    			break;	
+	    		case 8:
+	    			if (ninth>0){bonus_marines-=5;ninth+=5;}
+	    			break;	
+	    		case 9:
+	    			if (tenth>0){bonus_marines-=5;tenth+=5;}
+	    			break;		    				    			    			
+	    	}
+	    	i++;
 	    }
 	}
 
 
 
 
-		if (global.chapter_name="Salamanders"){veteran+=20;second+=20;third+=20;fourth+=20;fifth+=20;sixth+=20;seventh=0;eighth=0;ninth=0;tenth-=40;}
-	// if (global.chapter_name="Salamanders"){veteran+=12;second+=2;third+=2;fourth+=2;fifth+=4;sixth+=4;seventh+=4;eighth=0;ninth=0;}
+	if (global.chapter_name="Salamanders"){veteran+=20;second+=20;third+=20;fourth+=20;fifth+=20;sixth+=20;seventh=0;eighth=0;ninth=0;tenth-=40;}
 	if (global.chapter_name="Blood Angels"){chaap=3;apothecary=10;epistolary=6;codiciery=6;lexicanum=8;}
 	if (global.chapter_name="Dark Angels"){veteran=0;terminator+=80;}
 	if (global.chapter_name="Lamenters"){
@@ -498,39 +541,157 @@ function scr_initialize_custom() {
 
 	company=0;
 	// Initialize default marines for loadouts
-	i=-1;repeat(101){i+=1;
-	    race[100,i]=1;loc[100,i]="";name[100,i]="";role[100,i]="";wep1[100,i]="";bio[100,i]=0;lid[100,i]=0;wid[100,i]=2;spe[100,i]="";
-	    wep2[100,i]="";armour[100,i]="";gear[100,i]="";mobi[100,i]="";chaos[100,i]=0;experience[100,i]=0;hp[100,i]=0;
-	    age[100,i]=((millenium*1000)+year)-10;god[100,i]=0;if (global.chapter_name="Iron Hands") then bio[100,i]=choose(3,4,5);
+	for(i=0;i<101;i++){
+		i+=1;
+	    race[100,i]=1;
+	    loc[100,i]="";
+	    name[100,i]="";
+	    role[100,i]="";
+	    wep1[100,i]="";
+	    bio[100,i]=0;
+	    lid[100,i]=0;
+	    wid[100,i]=2;
+	    spe[100,i]="";
+	    wep2[100,i]="";
+	    armour[100,i]="";
+	    gear[100,i]="";
+	    mobi[100,i]="";
+	    chaos[100,i]=0;experience[100,i]=0;
+	    hp[100,i]=0;
+	    age[100,i]=((millenium*1000)+year)-10;
+	    god[100,i]=0;
+	    if (global.chapter_name="Iron Hands") then bio[100,i]=choose(3,4,5);
 	}initialized=500;
 	// Initialize special marines
 	i=-1;repeat(501){i+=1;
-	    race[0,i]=1;loc[0,i]="";name[0,i]="";role[0,i]="";wep1[0,i]="";bio[0,i]=0;lid[0,i]=0;wid[0,i]=2;spe[0,i]="";
-	    wep2[0,i]="";armour[0,i]="";gear[0,i]="";mobi[0,i]="";chaos[0,i]=0;experience[0,i]=0;hp[0,i]=0;
-	    age[0,i]=((millenium*1000)+year)-10;god[0,i]=0;if (global.chapter_name="Iron Hands") then bio[0,i]=choose(3,4,5);
-		TTRPG[0,i]= new TTRPG_stats("chapter", 0,i);
+	    race[0,i]=1;
+	    loc[0,i]="";
+	    name[0,i]="";
+	    role[0,i]="";
+	    wep1[0,i]="";
+	    bio[0,i]=0;lid[0,i]=0;wid[0,i]=2;spe[0,i]="";
+	    wep2[0,i]="";
+	    armour[0,i]="";
+	    gear[0,i]="";
+	    mobi[0,i]="";
+	    chaos[0,i]=0;experience[0,i]=0;
+	    hp[0,i]=0;
+	    age[0,i]=((millenium*1000)+year)-10;
+	    god[0,i]=0;
+	    bio[0,i]=0;
+		TTRPG[0,i] = new TTRPG_stats("chapter", 0,i,"blank");
 	}
 	i=-1;repeat(101){i+=1;
-	    role[100,i]="";wep1[100,i]="";wep2[100,i]="";armour[100,i]="";gear[100,i]="";mobi[100,i]="";//hirelings??
-	    role[102,i]="";wep1[102,i]="";wep2[102,i]="";armour[102,i]="";gear[102,i]="";mobi[102,i]="";//hirelings??
+	    role[100,i]="";
+	    wep1[100,i]="";
+	    wep2[100,i]="";
+	    armour[100,i]="";
+	    gear[100,i]="";
+	    mobi[100,i]="";//hirelings??
+	    role[102,i]="";
+	    wep1[102,i]="";
+	    wep2[102,i]="";
+	    armour[102,i]="";
+	    gear[102,i]="";
+	    mobi[102,i]="";//hirelings??
 	}
-	i=99;repeat(3){i+=1; // gear 
-	    role[i,2]="Honor Guard";wep1[i,2]="Power Sword";wep2[i,2]="Storm Bolter";armour[i,2]="Power Armour";mobi[i,2]="";gear[i,2]="";
-	    role[i,3]="Veteran";wep1[i,3]="Chainsword";wep2[i,3]="Combiflamer";armour[i,3]="Power Armour";mobi[i,3]="";gear[i,3]="";
-	    role[i,4]="Terminator";wep1[i,4]="Power Fist";wep2[i,4]="Storm Bolter";armour[i,4]="Terminator Armour";mobi[i,4]="";gear[i,4]="";
-	    role[i,5]="Captain";wep1[i,5]="Power Fist";wep2[i,5]="Bolt Pistol";armour[i,5]="Power Armour";mobi[i,5]="";gear[i,5]="";
-	    role[i,6]="Dreadnought";wep1[i,6]="Close Combat Weapon";wep2[i,6]="Lascannon";armour[i,6]="Dreadnought";mobi[i,6]="";gear[i,6]="";
-	    role[i,7]="Company Champion";wep1[i,7]="Power Sword";wep2[i,7]="Storm Shield";armour[i,7]="Power Armour";mobi[i,7]="";gear[i,7]="";
-	    role[i,8]="Tactical Marine";wep1[i,8]="Bolter";wep2[i,8]="Chainsword";armour[i,8]="Power Armour";mobi[i,8]="";gear[i,8]="";
-	    role[i,9]="Devastator";wep1[i,9]="Heavy Ranged";wep2[i,9]="Combat Knife";armour[i,9]="Power Armour";mobi[i,9]="";gear[i,9]="";
-	    role[i,10]="Assault Marine";wep1[i,10]="Chainsword";wep2[i,10]="Bolt Pistol";armour[i,10]="Power Armour";mobi[i,10]="Jump Pack";gear[i,10]="";
-	    role[i,12]="Scout";wep1[i,12]="Sniper Rifle";wep2[i,12]="Combat Knife";armour[i,12]="Scout Armour";mobi[i,12]="";gear[i,12]="";
-	    role[i,14]="Chaplain";wep1[i,14]="Power Sword";wep2[i,14]="Storm Bolter";armour[i,14]="Power Armour";gear[i,14]="Rosarius";mobi[i,14]="";
-	    role[i,15]="Apothecary";wep1[i,15]="Power Sword";wep2[i,15]="Storm Bolter";armour[i,15]="Power Armour";gear[i,15]="Narthecium";mobi[i,15]="";
-	    role[i,16]="Techmarine";wep1[i,16]="Power Axe";wep2[i,16]="Storm Bolter";armour[i,16]="Power Armour";gear[i,16]="Servo Arms";mobi[i,16]="";
-	    role[i,17]="Librarian";wep1[i,17]="Force Weapon";wep2[i,17]="Storm Bolter";armour[i,17]="Power Armour";gear[i,17]="Psychic Hood";mobi[i,17]="";
-		role[i,18]="Sergeant";wep1[i,18]="Chainsword";wep2[i,18]="Combiflamer";armour[i,18]="Power Armour";mobi[i,18]="";gear[i,18]="";
-		role[i,19]="Veteran Sergeant";wep1[i,19]="Chainsword";wep2[i,19]="Combiflamer";armour[i,19]="Power Armour";mobi[i,19]="";gear[i,19]="";	
+	for(i=100;i<103;i++){ // gear 
+	    role[i,2]="Honor Guard";
+	    wep1[i,2]="Power Sword";
+	    wep2[i,2]="Storm Bolter";
+	    armour[i,2]="Power Armour";
+	    mobi[i,2]="";
+	    gear[i,2]="";
+	    role[i,3]="Veteran";
+	    wep1[i,3]="Chainsword";
+	    wep2[i,3]="Combiflamer";
+	    armour[i,3]="Power Armour";
+	    mobi[i,3]="";
+	    gear[i,3]="";
+	    role[i,4]="Terminator";
+	    wep1[i,4]="Power Fist";
+	    wep2[i,4]="Storm Bolter";
+	    armour[i,4]="Terminator Armour";
+	    mobi[i,4]="";
+	    gear[i,4]="";
+	    role[i,5]="Captain";
+	    wep1[i,5]="Power Fist";
+	    wep2[i,5]="Bolt Pistol";
+	    armour[i,5]="Power Armour";
+	    mobi[i,5]="";
+	    gear[i,5]="";
+	    role[i,6]="Dreadnought";
+	    wep1[i,6]="Close Combat Weapon";
+	    wep2[i,6]="Lascannon";
+	    armour[i,6]="Dreadnought";
+	    mobi[i,6]="";
+	    gear[i,6]="";
+	    role[i,7]="Company Champion";
+	    wep1[i,7]="Power Sword";
+	    wep2[i,7]="Storm Shield";
+	    armour[i,7]="Power Armour";
+	    mobi[i,7]="";
+	    gear[i,7]="";
+	    role[i,8]="Tactical Marine";
+	    wep1[i,8]="Bolter";
+	    wep2[i,8]="Chainsword";
+	    armour[i,8]="Power Armour";
+	    mobi[i,8]="";
+	    gear[i,8]="";
+	    role[i,9]="Devastator";
+	    wep1[i,9]="Heavy Ranged";
+	    wep2[i,9]="Combat Knife";
+	    armour[i,9]="Power Armour";
+	    mobi[i,9]="";
+	    gear[i,9]="";
+	    role[i,10]="Assault Marine";
+	    wep1[i,10]="Chainsword";
+	    wep2[i,10]="Bolt Pistol";
+	    armour[i,10]="Power Armour";
+	    mobi[i,10]="Jump Pack";
+	    gear[i,10]="";
+	    role[i,12]="Scout";
+	    wep1[i,12]="Sniper Rifle";
+	    wep2[i,12]="Combat Knife";
+	    armour[i,12]="Scout Armour";
+	    mobi[i,12]="";
+	    gear[i,12]="";
+	    role[i,14]="Chaplain";
+	    wep1[i,14]="Power Sword";
+	    wep2[i,14]="Storm Bolter";
+	    armour[i,14]="Power Armour";
+	    gear[i,14]="Rosarius";
+	    mobi[i,14]="";
+	    role[i,15]="Apothecary";
+	    wep1[i,15]="Power Sword";
+	    wep2[i,15]="Storm Bolter";
+	    armour[i,15]="Power Armour";
+	    gear[i,15]="Narthecium";
+	    mobi[i,15]="";
+	    role[i,16]="Techmarine";
+	    wep1[i,16]="Power Axe";
+	    wep2[i,16]="Storm Bolter";
+	    armour[i,16]="Power Armour";
+	    gear[i,16]="Servo Arms";
+	    mobi[i,16]="";
+	    role[i,17]="Librarian";
+	    wep1[i,17]="Force Weapon";
+	    wep2[i,17]="Storm Bolter";
+	    armour[i,17]="Power Armour";
+	    gear[i,17]="Psychic Hood";
+	    mobi[i,17]="";
+		role[i,18]="Sergeant";
+		wep1[i,18]="Chainsword";
+		wep2[i,18]="Combiflamer";
+		armour[i,18]="Power Armour";
+		mobi[i,18]="";
+		gear[i,18]="";
+		role[i,19]="Veteran Sergeant";
+		wep1[i,19]="Chainsword";
+		wep2[i,19]="Combiflamer";
+		armour[i,19]="Power Armour";
+		mobi[i,19]="";
+		gear[i,19]="";	
 	}// 100 is defaults, 101 is the allowable starting equipment // info
 	i=-1;repeat(21){i+=1;
 	    race[100,i]=obj_creation.race[100,i];
@@ -542,10 +703,13 @@ function scr_initialize_custom() {
 	    mobi[100,i]=obj_creation.mobi[100,i];
 	}
 		//made all the exp buffs sort into neat little structs so theyre easier to dev and player modify
-	company_spawn_buffs = [0,0,[110,10],[105,10],[95,10],[80,15],[65,5],[55,5],[45,5],[35,5],[3,4]]
+		//value 1 = mean, value 10 = sd
+	company_spawn_buffs = [0,[130,10],[110,10],[105,10],[95,10],[80,15],[65,5],[55,5],[45,5],[35,5],[3,4]]
 	role_spawn_buffs = {}
 	variable_struct_set(role_spawn_buffs,role[100,5],[70,40]);
-	variable_struct_set(role_spawn_buffs,role[100,14],[120,30]);
+	variable_struct_set(role_spawn_buffs,role[100,4],[30,10]);
+	variable_struct_set(role_spawn_buffs,role[100,3],[10,5]);
+	variable_struct_set(role_spawn_buffs,role[100,14],[60,30]);
 	variable_struct_set(role_spawn_buffs,role[100,15],[95,20]);
 	variable_struct_set(role_spawn_buffs,role[100,16],[95,20]);
 	variable_struct_set(role_spawn_buffs,"Standard Bearer",[30,30]);
@@ -580,17 +744,18 @@ function scr_initialize_custom() {
 		"command_squad" :[
 				[role[100,5], {"max":1,"min":1}],		//captain
 				[role[100,7], {"max":1,"min":1}],		//company_champion
-				[role[100,15], {"max":1,"min":1}],		//Apothecary
-				[role[100,14], {"max":1,"min":0}],		//chaplain
+				[role[100,15], {"max":1,"min":1, "role":"Company Apothecary"}],		//Apothecary
+				[role[100,14], {"max":1,"min":0, "role":"Company Chaplain"}],		//chaplain
 				["Standard Bearer" , {"max":1,"min":1}],//standard bearer
-				[role[100,3] , {"max":5,"min":0}],		//veterans
+				[role[100,3] , {"max":5,"min":0, "role":"Company Command Veteran"}],		//veterans
+				["display_name" , "Command Squad"]
 			],
 			"terminator_squad": [
-				[role[100,19], {"max":1,"min":1}],			//Veteran sergeant terminator
+				[role[100,19], {"max":1,"min":1, "role":"Veteran Sergeant Terminator"}],			//Veteran sergeant terminator
 				[role[100,4], {"max":9,"min":3,"loadout":{//terminator
 					"required":{
-						"wep1":["Power Fist",1], 
-						"wep2":["Storm Bolter",1]
+						"wep1":[wep1[100,4],4],
+						"wep2":[wep2[100,4],4], 
 					},
 					"option" :{
 						"wep1":[
@@ -604,12 +769,13 @@ function scr_initialize_custom() {
 						],
 					} 
 				}}],
+				["display_name" , "Terminator Squad"]
 			],
 			"veteran_squad": [
 				[role[100,3], {"max":9,"min":4, "loadout":{//tactical marine
 					"required":{
-						"wep1":["Chainsword",4],
-						"wep2":["Bolter",4], 
+						"wep1":[wep1[100,3],4],
+						"wep2":[wep2[100,3],4], 
 					},
 					"option" :{
 						"wep1":[
@@ -626,6 +792,7 @@ function scr_initialize_custom() {
 					} 
 				}}],		//veterans
 				[role[100,19], {"max":1,"min":1}],
+				["display_name" , "Veteran Squad"]
 			],
 			"devestator_squad": [
 				[role[100,9], {"max":9,"min":4,"loadout":{//devestator
@@ -633,13 +800,14 @@ function scr_initialize_custom() {
 						"wep1":["Bolter",4], 
 						"wep2":["Combat Knife",4]
 					}}}],		//veterans
-				[role[100,18], {"max":1,"min":1}],//sergeant
+				[role[100,18], {"max":1,"min":1, "role":"Devestator Sergeant"}],//sergeant
+				["display_name" , "Devestator Squad"]
 			],				
 			"tactical_squad":[
 				[role[100,8], {"max":9,"min":4, "loadout":{//tactical marine
 					"required":{
-						"wep1":["Bolter",4], 
-						"wep2":["Combat Knife",4]
+						"wep1":[wep1[100,8],4], 
+						"wep2":[wep2[100,8],4]
 					},
 					"option" :{
 						"wep1":[
@@ -654,7 +822,8 @@ function scr_initialize_custom() {
 						]
 					} 
 				}}],		//tactical marine
-				[role[100,18], {"max":1,"min":1}],		// sergeant
+				[role[100,18], {"max":1,"min":1, "role":"Tactical Sergeant"}],		// sergeant
+				["display_name" , "Tactical Squad"]
 			],
 			"assault_squad" : [
 				[role[100,10] , {
@@ -662,8 +831,8 @@ function scr_initialize_custom() {
 					"min":4, 
 					"loadout":{
 						"required" : {
-							"wep1" : ["Chainsword", 4],
-							"wep2":["Bolt Pistol",4]
+							"wep1": [wep1[100,10],4],
+							"wep2": [wep2[100,10],4], 
 						},
 						"option" : {
 							"wep1":[
@@ -676,15 +845,16 @@ function scr_initialize_custom() {
 					}
 				}
 			],
-			[role[100,18], {"max":1,"min":1}],		// sergeant
+			[role[100,18], {"max":1,"min":1, "role":"Assualt Sergeant"}],		// sergeant
+			["display_name" , "Tactical Squad"]
 		]		
 	};
 	if (global.chapter_name="Salamanders"){ //salamanders squads
 		variable_struct_set(st , "assault_squad",[
                 [role[100,10], {"max":9,"min":4, "loadout":{//assault_marine
                     "required":{
-                        "wep1":["Bolt Pistol",4], 
-                        "wep2":["Chainsword",4]
+							"wep1": [wep1[100,10],4],
+							"wep2": [wep2[100,10],4], 
                     },
                     "option" :{
                         "wep1":[
@@ -708,14 +878,19 @@ function scr_initialize_custom() {
 				            "wep1":[[["Power Sword","Thunder Hammer","Power Fist","Chainsword"],1]],
 				            "wep2":[[["Plasma Pistol","Combiflamer","Meltagun"],1]]
 			            }
-			      }}]])
+			       },
+			       "role":"Assualt Sergeant"
+			  	}],
+			      ["display_name" , "Assault Squad"]
+			      ]
+			      )
 	}
 	if (global.chapter_name == "White Scars"){
 		variable_struct_set(st , "bikers",[
 		[role[100,8], {"max":9,"min":4, "loadout":{ //tactical marine
 			"required":{
-				"wep1":["Bolter",4], 
-				"wep2":["Chainsword",4],
+				"wep1": [wep1[100,8],4],
+				"wep2": [wep2[100,8],4], 
 				"mobi":["Bike","max"]
 			},
 			"option" :{
@@ -744,15 +919,17 @@ function scr_initialize_custom() {
 						[["Plasma Pistol","Storm Bolter","Plasma Gun"],1]
 					]
 				}
-			}
-		}
-	]
+			},
+			"role":"Tactical Bike Sergeant"
+		},
+	],
+	["display_name" , "Tactical Bike Squad"]
 	])
 	variable_struct_set(st , "tactical_squad",[
                 [role[100,8], {"max":9,"min":4, "loadout":{//tactical marine
                     "required":{
-                        "wep1":["Bolter",4], 
-                        "wep2":["Combat Knife",4]
+						"wep1": [wep1[100,8],4],
+						"wep2": [wep2[100,8],4], 
                     },
                     "option" :{
                         "wep1":[
@@ -765,7 +942,8 @@ function scr_initialize_custom() {
                         ]
                     } 
                 }}],   
-                [role[100,18], {"max":1,"min":1}],        // sergeant
+                [role[100,18], {"max":1,"min":1, "role":"Tactical Sergeant"}],        // sergeant
+                ["display_name" , "Tactical Squad"]
             ])
 	}
 
@@ -779,9 +957,7 @@ function scr_initialize_custom() {
 	}
 
 
-
-	i=-1;
-	repeat(19){i+=1;
+	for (i=0;i<20;i++;){
 	    if (role[100,i]!="") then scr_start_allow(i,"wep1",wep1[100,i]);
 	    if (role[100,i]!="") then scr_start_allow(i,"wep2",wep2[100,i]);
 	    if (role[100,i]!="") then scr_start_allow(i,"mobi",mobi[100,i]);
@@ -796,9 +972,12 @@ function scr_initialize_custom() {
 
 	// Chapter Master
 	// This needs work
-	race[company,1]=1;loc[company,1]=home_name;name[company,1]=obj_creation.chapter_master_name;role[company,1]="Chapter Master";
-	 TTRPG[company,1]=new TTRPG_stats("chapter", company,1, "chapter_master");
-	 var chapter_master = TTRPG[company,1]
+	race[company,1]=1;
+	loc[company,1]=home_name;
+	name[company,1]=obj_creation.chapter_master_name;
+	role[company,1]="Chapter Master";
+	TTRPG[company,1]=new TTRPG_stats("chapter", company,1, "chapter_master");
+	var chapter_master = TTRPG[company,1]
 	if (master_melee=1) then wep1[0,1]="Power Fist&DUB|";
 	if (master_melee=2) then wep1[0,1]="Relic Blade&MNR|";
 	if (master_melee=3) then wep1[0,1]="Master Crafted Thunder Hammer";
@@ -817,13 +996,18 @@ function scr_initialize_custom() {
 
 	if (global.chapter_name="Dark Angels") then wep2[0,1]="Plasma Gun&UBL|";
 	if (global.chapter_name="Blood Angels") then wep1[0,1]="Master Crafted Power Axe";
-	if (global.chapter_name="Iron Hands"){wep1[0,1]="Power Axe&ADA|";wep2[0,1]="Storm Shield";bio[0,1]=10;}
-	if (global.chapter_name="Doom Benefactors") then bio[0,1]=4;
+	if (global.chapter_name="Iron Hands"){wep1[0,1]="Power Axe&ADA|";
+		wep2[0,1]="Storm Shield";
+		repeat(10){chapter_master.add_bionics()};
+	}
+	if (global.chapter_name="Doom Benefactors") then repeat(4){chapter_master.add_bionics()};
 
-	armour[company,1]="Artificer Armour";spe[company,1]="";
+	armour[company,1]="Artificer Armour";
+	spe[company,1]="";
 	if (obj_creation.chapter_master_specialty=1){experience[company,1]=550;spe[company,1]+="$";}
 	if (obj_creation.chapter_master_specialty=2){experience[company,1]=650;spe[company,1]+="@";}
-	if (obj_creation.chapter_master_specialty=3){experience[company,1]=550;gear[company,1]="Psychic Hood";
+	if (obj_creation.chapter_master_specialty=3){experience[company,1]=550;
+		gear[company,1]="Psychic Hood";
 	    var let,letmax;let="";letmax=0;
 	    if (obj_creation.discipline="default"){let="D";letmax=7;}
 	    if (obj_creation.discipline="biomancy"){let="B";letmax=5;}
@@ -836,24 +1020,71 @@ function scr_initialize_custom() {
 	if (string_count("Paragon",strin)>0) then chapter_master.add_trait("paragon")
 
 	// Forge Master
-	race[company,2]=1;loc[company,2]=home_name;role[company,2]="Forge Master";wep1[company,2]="Conversion Beam Projector";name[company,2]=obj_creation.fmaster;
-	wep2[company,2]="Power Weapon";armour[company,2]="Artificer Armour";gear[company,2]="Master Servo Arms";chaos[company,2]=0;experience[company,2]=475;
-	if (global.chapter_name="Lamenters") then armour[company,2]="MK6 Corvus";bio[company,2]=8;if (global.chapter_name="Iron Hands") then bio[company,k]=10;
+	TTRPG[company,2]=new TTRPG_stats("chapter", company,2);
+	race[company,2]=1;
+	loc[company,2]=home_name;
+	role[company,2]="Forge Master";
+	wep1[company,2]="Conversion Beam Projector";
+	name[company,2]=obj_creation.fmaster;
+	wep2[company,2]="Power Weapon";
+	armour[company,2]="Artificer Armour";
+	gear[company,2]="Master Servo Arms";
+	chaos[company,2]=0;
+	experience[company,2]=475;
+	spawn_unit = TTRPG[company,2];
+	if (spawn_unit.technology<40){
+		spawn_unit.technology=40;
+	}
+	spawn_unit.add_trait("mars_trained");
+	spawn_unit.add_bionics("right_arm");
+	if (global.chapter_name="Lamenters") then armour[company,2]="MK6 Corvus";
+	if (global.chapter_name="Iron Hands"){
+		repeat(9){spawn_unit.add_bionics("right_arm");}
+	} else{
+	    repeat(irandom(3)){spawn_unit.add_bionics()};
+	}
 	// Master of Sanctity (Chaplain)
-	race[company,3]=1;loc[company,3]=home_name;role[company,3]="Master of Sanctity";wep1[company,3]=wep1[101,14];name[company,3]=obj_creation.hchaplain;
-	wep2[company,3]=wep2[101,14];armour[company,3]="Artificer Armour";gear[company,3]=gear[101,14];chaos[company,3]=-100;experience[company,3]=525;
+	TTRPG[company,3]=new TTRPG_stats("chapter", company,3);
+	race[company,3]=1;
+	loc[company,3]=home_name;
+	role[company,3]="Master of Sanctity";
+	wep1[company,3]=wep1[101,14];
+	name[company,3]=obj_creation.hchaplain;
+	wep2[company,3]=wep2[101,14];
+	armour[company,3]="Artificer Armour";
+	gear[company,3]=gear[101,14];
+	chaos[company,3]=-100;
+	experience[company,3]=525;
 	if (global.chapter_name="Lamenters") then armour[company,3]="MK6 Corvus";
+	spawn_unit = TTRPG[company,3];
+	if (spawn_unit.piety<45){
+		spawn_unit.piety = 45;
+	}
+	spawn_unit.add_trait("zealous_faith");
+
 	// Maser of the Apothecarion (Apothecary)
-	race[company,4]=1;loc[company,4]=home_name;role[company,4]="Master of the Apothecarion";wep1[company,4]=wep1[101,15];name[company,4]=obj_creation.hapothecary;
-	wep2[company,4]=wep2[100,15];armour[company,4]="Artificer Armour";gear[company,4]=gear[101,15];chaos[company,4]=0;experience[company,4]=500;
+	TTRPG[company,4]=new TTRPG_stats("chapter", company,4);
+	race[company,4]=1;
+	loc[company,4]=home_name;
+	role[company,4]="Master of the Apothecarion";
+	wep1[company,4]=wep1[101,15];
+	name[company,4]=obj_creation.hapothecary;
+	wep2[company,4]=wep2[100,15];
+	armour[company,4]="Artificer Armour";
+	gear[company,4]=gear[101,15];
+	chaos[company,4]=0;experience[company,4]=500;
 	if (global.chapter_name="Lamenters") then armour[company,4]="MK6 Corvus";
 	// Chief Librarian
+	TTRPG[company,5]=new TTRPG_stats("chapter", company,5);
 	race[company,5]=1;
 	loc[company,5]=home_name;
 	role[company,5]=string("Chief {0}",role[100,17]);
 	wep1[company,5]=wep1[101,17];
 	name[company,5]=obj_creation.clibrarian;
-	wep2[company,5]=wep2[101,17];armour[company,5]="Artificer Armour";gear[company,5]=gear[101,17];chaos[company,5]=0;experience[company,5]=550;
+	wep2[company,5]=wep2[101,17];
+	armour[company,5]="Artificer Armour";
+	gear[company,5]=gear[101,17];
+	chaos[company,5]=0;experience[company,5]=550;
 	if (global.chapter_name="Lamenters") then armour[company,5]="MK6 Corvus";
 	if (obj_creation.discipline="default"){let="D";letmax=7;}
 	if (obj_creation.discipline="biomancy"){let="B";letmax=5;}
@@ -861,26 +1092,64 @@ function scr_initialize_custom() {
 	if (obj_creation.discipline="telekinesis"){let="T";letmax=5;}
 	if (obj_creation.discipline="rune Magick"){let="R";letmax=5;}
 	spe[company,5]=string(let)+"0|";scr_powers_new(company,5);
-	k=0;commands+=6;k+=6;
 	TTRPG[company,5].add_trait("warp_touched");
+	k=0;
+	commands+=5;
+	k=5;
+	man_size=5;
 
 	if (intolerant==1){
-	    race[company,5]=0;loc[company,5]="";role[company,5]="";wep1[company,5]="";name[company,5]="";
-	    wep2[company,5]="";armour[company,5]="";gear[company,5]="";hp[company,5]=0;chaos[company,5]=0;experience[company,5]=0;
-	    man_size-=1;commands-=1;
+	    race[company,5]=0;
+	    loc[company,5]="";
+	    role[company,5]="";
+	    wep1[company,5]="";
+	    name[company,5]="";
+	    wep2[company,5]="";
+	    armour[company,5]="";
+	    gear[company,5]="";
+	    hp[company,5]=0;
+	    chaos[company,5]=0;
+	    experience[company,5]=0;
+	    man_size-=1;
+	    commands-=1;
+	    TTRPG[company,5] = new TTRPG_stats("chapter", company,1, "blank");
 	}
-	man_size+=6;
 
 	// Tech Marines
-	repeat(techs){k+=1;commands+=1;man_size+=1;
-	    race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,16];wep1[company,k]=wep1[101,16];name[company,k]=scr_marine_name();
-	    wep2[company,k]=wep2[101,16];armour[company,k]="Power Armour";gear[company,k]=gear[101,16];chaos[company,k]=0;experience[company,k]=100;
-	    bio[company,k]=4+choose(0,1,2);if (global.chapter_name="Iron Hands") then bio[company,k]=choose(7,8);
+	repeat(techs){
+		k+=1;
+		commands+=1;
+		man_size+=1;
+		TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	    race[company,k]=1;
+	    loc[company,k]=home_name;
+	    role[company,k]=role[100,16];
+	    wep1[company,k]=wep1[101,16];
+	    name[company,k]=scr_marine_name();
+	    wep2[company,k]=wep2[101,16];
+	    armour[company,k]="Power Armour";
+	    gear[company,k]=gear[101,16];
+	    chaos[company,k]=0;
+	    experience[company,k]=100;
+		spawn_unit = TTRPG[company,k];
+		spawn_unit.spawn_old_guard();
 	}
 	// Librarians
-	repeat(epistolary){k+=1;commands+=1;man_size+=1;
-	    race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,17];wep1[company,k]=wep1[101,17];name[company,k]=scr_marine_name();
-	    wep2[company,k]=wep2[101,17];armour[company,k]="MK7 Aquila";gear[company,k]=gear[101,17];chaos[company,k]=0;experience[company,k]=125;
+	repeat(epistolary){
+		k+=1;
+		commands+=1;
+		man_size+=1;
+		TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	    race[company,k]=1;
+	    loc[company,k]=home_name;
+	    role[company,k]=role[100,17];
+	    wep1[company,k]=wep1[101,17];
+	    name[company,k]=scr_marine_name();
+	    wep2[company,k]=wep2[101,17];
+	    armour[company,k]="MK7 Aquila";
+	    gear[company,k]=gear[101,17];
+	    chaos[company,k]=0;
+	    experience[company,k]=125;
 	    if (psyky=1) then experience[company,k]+=10;
 
 	    var let,letmax;let="";letmax=0;
@@ -890,12 +1159,23 @@ function scr_initialize_custom() {
 	    if (obj_creation.discipline="telekinesis"){let="T";letmax=5;}
 	    if (obj_creation.discipline="rune Magick"){let="R";letmax=5;}
 	    spe[company,k]+=string(let)+"0|";scr_powers_new(company,k);
+	    TTRPG[company,k].spawn_old_guard();
 	    TTRPG[company,k].add_trait("warp_touched");    
 	}
 	// Codiciery
-	repeat(codiciery){k+=1;commands+=1;man_size+=1;
-	    race[company,k]=1;loc[company,k]=home_name;role[company,k]="Codiciery";wep1[company,k]="Power Sword";name[company,k]=scr_marine_name();
-	    wep2[company,k]="Bolt Pistol";armour[company,k]="MK7 Aquila";gear[company,k]="Psychic Hood";chaos[company,k]=0;experience[company,k]=80;
+	repeat(codiciery){
+		k+=1;
+		commands+=1;
+		man_size+=1;
+		TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	    race[company,k]=1;
+	    loc[company,k]=home_name;
+	    role[company,k]="Codiciery";
+	    wep1[company,k]="Power Sword";
+	    name[company,k]=scr_marine_name();
+	    wep2[company,k]="Bolt Pistol";
+	    gear[company,k]="Psychic Hood";
+	    chaos[company,k]=0;experience[company,k]=80;
 	    if (psyky=1) then experience[company,k]+=10;
 
 	    var let,letmax;let="";letmax=0;
@@ -905,12 +1185,20 @@ function scr_initialize_custom() {
 	    if (obj_creation.discipline="telekinesis"){let="T";letmax=4;}
 	    if (obj_creation.discipline="rune Magick"){let="R";letmax=5;}
 	    spe[company,k]+=string(let)+"0|";scr_powers_new(company,k);
+	    TTRPG[company,k].spawn_old_guard();
 	    TTRPG[company,k].add_trait("warp_touched");    
 	}
 	// Lexicanum
 	repeat(lexicanum){k+=1;commands+=1;man_size+=1;
-	    race[company,k]=1;loc[company,k]=home_name;role[company,k]="Lexicanum";wep1[company,k]="Bolter";name[company,k]=scr_marine_name();
-	    wep2[company,k]="Chainsword";armour[company,k]="MK7 Aquila";chaos[company,k]=0;experience[company,k]=40;
+		TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	    race[company,k]=1;
+	    loc[company,k]=home_name;
+	    role[company,k]="Lexicanum";
+	    wep1[company,k]="Bolter";
+	    name[company,k]=scr_marine_name();
+	    wep2[company,k]="Chainsword";
+	    chaos[company,k]=0;
+	    experience[company,k]=40;
 	    if (psyky=1) then experience[company,k]+=10;
 
 	    var let,letmax;let="";letmax=0;
@@ -920,30 +1208,58 @@ function scr_initialize_custom() {
 	    if (obj_creation.discipline="telekinesis"){let="T";letmax=4;}
 	    if (obj_creation.discipline="rune Magick"){let="R";letmax=5;}
 	    spe[company,k]+=string(let)+"0|";
+	    TTRPG[company,k].spawn_old_guard();
 	    TTRPG[company,k].add_trait("warp_touched");
 	}
 	// Apothecary
-	repeat(apothecary){k+=1;commands+=1;man_size+=1;
-	    race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,15];wep1[company,k]=wep1[101,15];name[company,k]=scr_marine_name();
-	    wep2[company,k]=wep2[101,15];armour[company,k]="MK7 Aquila";gear[company,k]=gear[101,15];chaos[company,k]=0;experience[company,k]=100;
+	repeat(apothecary){
+		k+=1;
+		commands+=1;
+		man_size+=1;
+		TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	    race[company,k]=1;
+	    loc[company,k]=home_name;
+	    role[company,k]=role[100,15];
+	    wep1[company,k]=wep1[101,15];
+	    name[company,k]=scr_marine_name();
+	    wep2[company,k]=wep2[101,15];
+	    armour[company,k]="MK7 Aquila";
+	    gear[company,k]=gear[101,15];
+	    chaos[company,k]=0;
+	    experience[company,k]=100;
+		spawn_unit.spawn_old_guard();
+		spawn_unit.spawn_exp();
 	}
 
 
 	// Honor Guard
 
 	var hong,chapter_option,o;hong=0;
-	o=0;chapter_option=0;repeat(4){o+=1;if (obj_creation.adv[o]="Brothers, All") then chapter_option=1;}if (chapter_option=1) then hong+=20;
+	o=0;chapter_option=0;repeat(4){o+=1;
+	if (obj_creation.adv[o]="Brothers, All") then chapter_option=1;}
+	if (chapter_option=1) then hong+=20;
 	if (progenitor=0) and (obj_creation.custom=0) then hong+=10;
-	if (hong>0) then repeat(10){k+=1;commands+=1;man_size+=1;
-	    race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,2];name[company,k]=scr_marine_name();gear[company,k]=gear[100,2];mobi[company,k]=mobi[100,2];
+	if (hong==0){hong=3}
+	for (i=0;i<min(hong, 20);i++){
+		k+=1;
+		commands+=1;
+		man_size+=1;
+		TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	    race[company,k]=1;
+	    loc[company,k]=home_name;
+	    role[company,k]=role[100,2];
+	    name[company,k]=scr_marine_name();
+	    gear[company,k]=gear[100,2];
+	    mobi[company,k]=mobi[100,2];
 // wep1 power sword // wep2 storm bolter default
-
-		
 		wep1[company,k]=wep1[101,2];
 
-	    wep2[company,k]=wep2[101,2];armour[company,k]="MK4 Maximus";
+	    wep2[company,k]=wep2[101,2];
+	    armour[company,k]="MK4 Maximus";
 
-	    chaos[company,k]=0;experience[company,k]=210+irandom(30);
+	    chaos[company,k]=0;
+	    experience[company,k]=210+irandom(30);
+	    TTRPG[company,k].spawn_old_guard();
 	}
 
 
@@ -953,20 +1269,47 @@ function scr_initialize_custom() {
 
 
 	// First Company
-	i=-1;company=1;
-	repeat(501){i+=1;
-	    race[company,i]=1;loc[company,i]="";name[company,i]="";role[company,i]="";wep1[company,i]="";lid[company,i]=0;wid[company,i]=2;spe[company,i]="";
-	    wep2[company,i]="";armour[company,i]="";chaos[company,i]=0;experience[company,i]=0;gear[company,i]="";mobi[company,i]="";hp[company,i]=100;
-	    age[company,i]=((millenium*1000)+year)-10;god[company,i]=0;bio[company,i]=0;if (global.chapter_name="Iron Hands") then bio[company,i]=choose(3,4,5);
-		TTRPG[company,i]= new TTRPG_stats("chapter", company,i);
+    company=1;
+	for (i =0; i<501; i++){
+	    race[company,i]=1;
+	    loc[company,i]="";
+	    name[company,i]="";
+	    role[company,i]="";
+	    wep1[company,i]="";
+	    lid[company,i]=0;
+	    wid[company,i]=2;
+	    spe[company,i]="";
+	    wep2[company,i]="";
+	    armour[company,i]="";
+	    chaos[company,i]=0;
+	    experience[company,i]=0;
+	    gear[company,i]="";
+	    mobi[company,i]="";
+	    hp[company,i]=100;
+	    age[company,i]=((millenium*1000)+year)-10;
+	    god[company,i]=0;
+	    bio[company,i]=0;
+		TTRPG[company,i]= new TTRPG_stats("chapter", company,i,"blank");
 	}initialized=200;// How many array variables have been prepared
 
 	k=0;
 
 	if (veteran+terminator>0){
-	    k+=1;commands+=1;// Captain
-	    race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,5];wep1[company,k]=wep1[101,5];name[company,k]=scr_marine_name();
-	    wep2[company,k]=wep2[101,5];armour[company,k]="Terminator Armour";chaos[company,k]=0;experience[company,k]=220;gear[company,k]=gear[101,5];
+	    k+=1;
+	    commands+=1;// Captain
+	    TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	    race[company,k]=1;
+	    loc[company,k]=home_name;
+	    role[company,k]=role[100,5];
+	    wep1[company,k]=wep1[101,5];
+	    name[company,k]=scr_marine_name();
+	    wep2[company,k]=wep2[101,5];
+	    chaos[company,k]=0;
+	    gear[company,k]=gear[101,5];
+	    spawn_unit = TTRPG[company,k]
+		spawn_unit.spawn_old_guard();
+		spawn_unit.spawn_exp();
+		armour[company,k]="Terminator Armour";
 	    if (string_count("Crafter",strin)>0) then armour[company,k]="Tartaros";
 	    if (terminator<=0) then armour[company,k]="MK6 Corvus";
 	    if (global.chapter_name="Iron Hands") then armour[company,k]="Terminator Armour";
@@ -980,11 +1323,26 @@ function scr_initialize_custom() {
 	    }
 
 	    if (global.chapter_name!="Space Wolves") and (global.chapter_name!="Iron Hands"){
-	        var skl;skl=1;if (chaap>0){skl=2;chaap-=1;}
+	        var skl;skl=1;
+	        if (chaap>0){
+	        	skl=2;
+	        	chaap-=1;
+	        }
 	        repeat(skl){
-	            k+=1;commands+=1;// Chaplain
-	            race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,14];wep1[company,k]=wep1[101,14];name[company,k]=scr_marine_name();
-	            wep2[company,k]=wep2[101,14];armour[company,k]="Terminator Armour";gear[company,k]=gear[101,14]chaos[company,k]=0;experience[company,k]=150;
+	            k+=1;
+	            commands+=1;// Chaplain
+	            TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	            race[company,k]=1;
+	            loc[company,k]=home_name;
+	            role[company,k]=role[100,14];
+	            wep1[company,k]=wep1[101,14];
+	     		name[company,k]=scr_marine_name();
+	            wep2[company,k]=wep2[101,14];
+	            spawn_unit = TTRPG[company,k]
+				spawn_unit.spawn_old_guard();
+				spawn_unit.spawn_exp();
+	            armour[company,k]="Terminator Armour";
+	            gear[company,k]=gear[101,14]chaos[company,k]=0;
 	            if (string_count("Crafter",strin)>0) then armour[company,k]="Tartaros";
 	            if (terminator<=0) then armour[company,k]="MK6 Corvus";
 	            if (mobi[101,14]!="") then mobi[company,k]=mobi[101,14];
@@ -992,42 +1350,98 @@ function scr_initialize_custom() {
 	        }
 	    }
 
-	    k+=1;commands+=1;// Apothecary
-	    race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,15];wep1[company,k]=wep1[101,15];name[company,k]=scr_marine_name();
-	    wep2[company,k]=wep2[101,15];armour[company,k]="Terminator Armour";gear[company,k]=gear[101,15];chaos[company,k]=0;experience[company,k]=130;
+	    k+=1;
+	    commands+=1;// Apothecary
+	    race[company,k]=1;
+	    TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	    loc[company,k]=home_name;
+	    role[company,k]=role[100,15];
+	    wep1[company,k]=wep1[101,15];
+	    name[company,k]=scr_marine_name();
+	    wep2[company,k]=wep2[101,15];
+	    spawn_unit = TTRPG[company,k]
+		spawn_unit.spawn_old_guard();
+		spawn_unit.spawn_exp();
+	    armour[company,k]="Terminator Armour";
+	    gear[company,k]=gear[101,15];
+	    chaos[company,k]=0;
 	    if (string_count("Crafter",strin)>0) then armour[company,k]="Tartaros";
 	    if (terminator<=0) then armour[company,k]="MK6 Corvus";
 	    if (mobi[101,15]!="") then mobi[company,k]=mobi[101,15];
 	    if (armour[company,k]="Terminator") or (armour[company,k]="Tartaros") then man_size+=1;
 
 	    if (global.chapter_name="Space Wolves"){
-	        k+=1;commands+=1;// Apothecary
-	        race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,15];wep1[company,k]=wep1[101,15];name[company,k]=scr_marine_name();
-	        wep2[company,k]=wep2[101,15];armour[company,k]="Terminator Armour";gear[company,k]=gear[101,15];chaos[company,k]=0;experience[company,k]=110;
+	        k+=1;
+	        commands+=1;// Apothecary
+	        TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	        race[company,k]=1;
+	        loc[company,k]=home_name;
+	        role[company,k]=role[100,15];
+	        wep1[company,k]=wep1[101,15]
+	  ;
+	  name[company,k]=scr_marine_name();
+	        wep2[company,k]=wep2[101,15];
+	        armour[company,k]="Terminator Armour";
+	        gear[company,k]=gear[101,15];
+	        chaos[company,k]=0;
+	        spawn_unit = TTRPG[company,k]
+			spawn_unit.spawn_old_guard();
+			spawn_unit.spawn_exp();
 	        if (string_count("Crafter",strin)>0) then armour[company,k]="Tartaros";
 	        if (terminator<=0) then armour[company,k]="MK6 Corvus";
 	        if (mobi[101,15]!="") then mobi[company,k]=mobi[101,15];
 	        if (armour[company,k]="Terminator") or (armour[company,k]="Tartaros") then man_size+=1;
 	    }
 	    if (global.chapter_name="Iron Hands"){
-	        k+=1;commands+=1;
-	        race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,16];wep1[company,k]=wep1[101,16];name[company,k]=scr_marine_name();
-	        wep2[company,k]=wep2[101,16];armour[company,k]="Power Armour";gear[company,k]=gear[101,16];chaos[company,k]=0;experience[company,k]=100;
-	        bio[company,k]=4+choose(0,1,2);if (global.chapter_name="Iron Hands") then bio[company,k]=choose(7,8);
+	        k+=1;
+	        commands+=1;
+	        TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	        race[company,k]=1;
+	        loc[company,k]=home_name;
+	        role[company,k]=role[100,16];
+	        wep1[company,k]=wep1[101,16];
+	  		name[company,k]=scr_marine_name();
+	        wep2[company,k]=wep2[101,16];
+	        gear[company,k]=gear[101,16];
+	        spawn_unit = TTRPG[company,k]
+			spawn_unit.spawn_old_guard();
+			spawn_unit.spawn_exp();
+	        chaos[company,k]=0;
 	        if (mobi[101,16]!="") then mobi[company,k]=mobi[101,16];
 	        if (armour[company,k]="Terminator") or (armour[company,k]="Tartaros") then man_size+=1;
 	    }
 
 	    k+=1;// Standard bearer
-	    race[company,k]=1;loc[company,k]=home_name;role[company,k]="Standard Bearer";wep1[company,k]="Company Standard";name[company,k]=scr_marine_name();
-	    wep2[company,k]="Power Fist";armour[company,k]="Terminator Armour";chaos[company,k]=0;experience[company,k]=90;
+	    race[company,k]=1;
+	    TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	    loc[company,k]=home_name;
+	    role[company,k]="Standard Bearer";
+	    wep1[company,k]="Company Standard";
+	    name[company,k]=scr_marine_name();
+	    wep2[company,k]="Power Fist";
+	    armour[company,k]="Terminator Armour";
+	    spawn_unit = TTRPG[company,k]
+		spawn_unit.spawn_old_guard();
+		spawn_unit.spawn_exp();
+	    chaos[company,k]=0;
 	    if (string_count("Crafter",strin)>0) then armour[company,k]="Tartaros";
 	    if (terminator<=0) then armour[company,k]="MK6 Corvus";
 	    if (armour[company,k]="Terminator") or (armour[company,k]="Tartaros") then man_size+=1;
 
-	    k+=1;man_size+=1;// Company Champion
-	    race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,7];wep1[company,k]=wep1[100,7];name[company,k]=scr_marine_name();
-	    wep2[company,k]=wep2[100,7];armour[company,k]="Terminator Armour";chaos[company,k]=0;experience[company,k]=200;
+	    k+=1;
+	    man_size+=1;
+	    TTRPG[company,k]=new TTRPG_stats("chapter", company,k);// Company Champion
+	    race[company,k]=1;
+	    loc[company,k]=home_name;
+	    role[company,k]=role[100,7];
+	    wep1[company,k]=wep1[100,7];
+	    name[company,k]=scr_marine_name();
+	    wep2[company,k]=wep2[100,7];
+	    spawn_unit = TTRPG[company,k]
+		spawn_unit.spawn_old_guard();
+		spawn_unit.spawn_exp();
+	    armour[company,k]="Terminator Armour";
+	    chaos[company,k]=0;
 	    if (string_count("Crafter",strin)>0) then armour[company,k]="Tartaros";
 	    if (terminator<=0) then armour[company,k]="MK6 Corvus";
 	    if (armour[company,k]="Terminator") or (armour[company,k]="Tartaros") then man_size+=1;
@@ -1035,29 +1449,56 @@ function scr_initialize_custom() {
 
 	// go 5 under the required xp amount 
 	
-	var terminator_random_xp;
-	var veteran_random_xp;
-	
-	if (terminator-1>0) then repeat(terminator-1){k+=1;man_size+=2; terminator_random_xp = irandom(20)+175;
+	if (terminator-1>0) then repeat(terminator-1){
+		k+=1;
+		man_size+=2
 	// repeat(max(terminator-4,0)){k+=1;man_size+=2;
-	    race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,4];wep1[company,k]=wep1[101,4];name[company,k]=scr_marine_name();
-	    wep2[company,k]=wep2[101,4];armour[company,k]="Terminator Armour";chaos[company,k]=0;experience[company,k]=terminator_random_xp;
+	    race[company,k]=1;
+	    TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	    loc[company,k]=home_name;
+	    role[company,k]=role[100,4];
+	    wep1[company,k]=wep1[101,4];
+	    name[company,k]=scr_marine_name();
+	    wep2[company,k]=wep2[101,4];
+	    spawn_unit = TTRPG[company,k]
+		spawn_unit.spawn_old_guard();
+		spawn_unit.spawn_exp();
+	    armour[company,k]="Terminator Armour";
+	    chaos[company,k]=0;
 	    if (string_count("Crafter",strin)>0) and (k<=20) then armour[company,k]="Tartaros";
 	}
-	repeat(veteran){k+=1;man_size+=1;  veteran_random_xp = irandom(20)+145;
-	    race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,3];wep1[company,k]=wep1[101,3];name[company,k]=scr_marine_name();
-	    wep2[company,k]=wep2[101,3];armour[company,k]="MK6 Corvus";chaos[company,k]=0;
-	    experience[company,k]=veteran_random_xp;mobi[company,k]=mobi[101,3];
+	repeat(veteran){
+		k+=1;
+		man_size+=1;
+		TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	    race[company,k]=1;
+	    loc[company,k]=home_name;
+	    role[company,k]=role[100,3];
+	    wep1[company,k]=wep1[101,3];
+	    name[company,k]=scr_marine_name();
+	    wep2[company,k]=wep2[101,3];
+	    armour[company,k]="MK6 Corvus";
+	    chaos[company,k]=0;
+	    mobi[company,k]=mobi[101,3];
+	    spawn_unit = TTRPG[company,k]
+		spawn_unit.spawn_old_guard();
+		spawn_unit.spawn_exp();	
 	}
 
-	k+=1;commands+=1;
-	race[company,k]=1;loc[company,k]=home_name;role[company,k]="Venerable "+string(role[100,6]);wep1[company,k]=wep1[101,6];man_size+=8;
-	wep2[company,k]=wep2[101,6];armour[company,k]="Dreadnought";chaos[company,k]=0;experience[company,k]=400;name[company,k]=scr_marine_name();
-	k+=1;commands+=1;
-	race[company,k]=1;loc[company,k]=home_name;role[company,k]="Venerable "+string(role[100,6]);wep1[company,k]=wep1[101,6];man_size+=8;
-	wep2[company,k]=wep2[101,6];armour[company,k]="Dreadnought";chaos[company,k]=0;experience[company,k]=400;name[company,k]=scr_marine_name();
-	// :D :D :D
-
+	for (i=0;i<2;i++){
+		k+=1;
+		commands+=1;
+		TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+		race[company,k]=1;
+		loc[company,k]=home_name;
+		role[company,k]="Venerable "+string(role[100,6]);
+		wep1[company,k]=wep1[101,6];man_size+=8;
+		wep2[company,k]=wep2[101,6];
+		armour[company,k]="Dreadnought";
+		chaos[company,k]=0;
+		experience[company,k]=400;
+		name[company,k]=scr_marine_name();
+	}
 
 	repeat(4){v+=1;man_size+=10;
 	    veh_race[company,v]=1;veh_loc[company,v]=home_name;veh_role[company,v]="Rhino";veh_wep1[company,v]="Storm Bolter";veh_wep2[company,v]="HK Missile";veh_wep3[company,v]="";
@@ -1066,7 +1507,8 @@ function scr_initialize_custom() {
 	var predrelic;predrelic=2;
 	if (global.chapter_name="Iron Hands") then predrelic=3;
 	repeat(predrelic){v+=1;man_size+=10;
-		var predtype;predtype=choose(1,2,3,4)
+		var predtype;
+		predtype=choose(1,2,3,4)
 		veh_race[company,v]=1;veh_loc[company,v]=home_name;veh_role[company,v]="Predator";
 		if (predtype=1){veh_wep1[company,v]="Plasma Destroyer Turret";veh_wep2[company,v]="Lascannon Sponsons";veh_wep3[company,v]="HK Missile";veh_upgrade[company,v]="Artificer Hull";veh_acc[company,v]="Searchlight";}
 		if (predtype=2){veh_wep1[company,v]="Heavy Conversion Beamer Turret";veh_wep2[company,v]="Lascannon Sponsons";veh_wep3[company,v]="HK Missile";veh_upgrade[company,v]="Artificer Hull";veh_acc[company,v]="Searchlight";}
@@ -1108,8 +1550,8 @@ function scr_initialize_custom() {
 	        experience[company,i]=0;
 	        age[company,i]=((millenium*1000)+year)-10;
 	        god[company,i]=0;
-	        bio[company,i]=0;if (global.chapter_name="Iron Hands") then bio[company,i]=choose(3,4,5);
-			TTRPG[company,i]= new TTRPG_stats("chapter", company,i);
+	        bio[company,i]=0;
+			TTRPG[company,i]= new TTRPG_stats("chapter", company,i, "blank");
 	    }
 
 	    var company_experience, company_unit2, company_unit3, dready, rhinoy, whirly, speedy,stahp;
@@ -1134,7 +1576,8 @@ function scr_initialize_custom() {
 	        // temp1=(100-(assault*devastator))*10;company_experience=(16-company)*5;
 	        // temp1-=1;
 
-	        // if (company=2){dready=1;if (string_count("Sieged",strin2)>0) or (obj_creation.custom=0) then dready+=1;}
+	        // if (company=2){dready=1;
+	        	if (string_count("Sieged",strin2)>0) or (obj_creation.custom=0) then dready+=1;
 	        rhinoy=8;whirly=whirlwind;speedy=2;
 	    }
 
@@ -1148,7 +1591,8 @@ function scr_initialize_custom() {
 	            temp1=(second-(assault+devastator));company_unit2="assault";company_unit3="devastator";
 	            temp1-=2;
 
-	            dready=1;if (string_count("Sieged",strin2)>0) or (obj_creation.custom=0) then dready+=1;
+	            dready=1;
+	            if (string_count("Sieged",strin2)>0) or (obj_creation.custom=0) then dready+=1;
 	            rhinoy=8;whirly=whirlwind;speedy=2;
 	            if (second=0) then stahp=1;
 			
@@ -1219,8 +1663,13 @@ function scr_initialize_custom() {
 
 	    var spawn_unit;
 	    if (stahp=0){
-	        k+=1;commands+=1;// Captain
-	        race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,5];wep1[company,k]=wep1[101,5];
+	        k+=1;
+	        commands+=1;// Captain
+	        TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	        race[company,k]=1;
+	        loc[company,k]=home_name;
+	        role[company,k]=role[100,5];
+	        wep1[company,k]=wep1[101,5];
 	        name[company,k]=scr_marine_name();
 
 	        if (company=4) then name[company,k]=lord_admiral_name;
@@ -1241,48 +1690,77 @@ function scr_initialize_custom() {
 	        if (global.chapter_name="Iron Hands") then armour[company,k]="Terminator Armour";
 
 	        if (global.chapter_name!="Space Wolves") and (global.chapter_name!="Iron Hands"){
-	            var skl;skl=1;if (chaap>0){skl=2;chaap-=1;}
+	            var skl;skl=1;
+	            if (chaap>0){skl=2;chaap-=1;}
 	            repeat(skl){
 	                k+=1;commands+=1;// Chaplain
-	                race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,14];wep1[company,k]=wep1[101,14];name[company,k]=scr_marine_name();
+	                race[company,k]=1;
+	                TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	                loc[company,k]=home_name;
+	                role[company,k]=role[100,14];
+	                wep1[company,k]=wep1[101,14];
+	          		name[company,k]=scr_marine_name();
 	                wep2[company,k]=wep2[101,14];
-	                armour[company,k]="MK7 Aquila";if (company<=2) then armour[company,k]=choose("MK8 Errant","MK6 Corvus");
-	                gear[company,k]=gear[101,14];chaos[company,k]=0;
+	                armour[company,k]="MK7 Aquila";
+	                if (company<=2) then armour[company,k]=choose("MK8 Errant","MK6 Corvus");
+	                gear[company,k]=gear[101,14];
+	                chaos[company,k]=0;
 	                if (company=8) then mobi[company,k]="Jump Pack";
 	                if (mobi[101,14]!="") then mobi[company,k]=mobi[101,14];
 					spawn_unit = TTRPG[company,k]
 					spawn_unit.spawn_exp();
-          spawn_unit.spawn_old_guard();
+          			spawn_unit.spawn_old_guard();
 	            }
 	        }
 
 	        k+=1;commands+=1;// Apothecary
-	        race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,15];wep1[company,k]=wep1[101,15];name[company,k]=scr_marine_name();
+	        race[company,k]=1;
+	        loc[company,k]=home_name;
+	        TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	        role[company,k]=role[100,15];
+	        wep1[company,k]=wep1[101,15];
+	    	name[company,k]=scr_marine_name();
 	        wep2[company,k]=wep2[101,15];
 	        spawn_unit = TTRPG[company,k]
 			spawn_unit.spawn_exp();
 	        spawn_unit.spawn_old_guard();
-	        gear[company,k]=gear[101,15];chaos[company,k]=0;
+	        gear[company,k]=gear[101,15];
+	        chaos[company,k]=0;
 	        if (company=8) then mobi[company,k]="Jump Pack";
 	        if (mobi[101,15]!="") then mobi[company,k]=mobi[101,15];
 
 	        if (global.chapter_name="Space Wolves"){
 	            k+=1;commands+=1;// Apothecary
-	            race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,15];wep1[company,k]=wep1[101,15];name[company,k]=scr_marine_name();
+	            race[company,k]=1;
+	            TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	            loc[company,k]=home_name;
+	            role[company,k]=role[100,15];
+	            wep1[company,k]=wep1[101,15];
+	        	name[company,k]=scr_marine_name();
 	            wep2[company,k]=wep2[101,15];
-	            armour[company,k]="MK7 Aquila";if (company<=2) then armour[company,k]=choose("MK8 Errant","MK6 Corvus");
-	            gear[company,k]=gear[101,15];chaos[company,k]=0;
+	            armour[company,k]="MK7 Aquila";
+	            if (company<=2) then armour[company,k]=choose("MK8 Errant","MK6 Corvus");
+	            gear[company,k]=gear[101,15];
+	            chaos[company,k]=0;
 	            if (company=8) then mobi[company,k]="Jump Pack";
 	            if (mobi[101,15]!="") then mobi[company,k]=mobi[101,15];
-					        spawn_unit = TTRPG[company,k]
-			spawn_unit.spawn_exp();
-	        spawn_unit.spawn_old_guard();
+				spawn_unit = TTRPG[company,k]
+				spawn_unit.spawn_exp();
+		        spawn_unit.spawn_old_guard();
 	        }
 	        if (global.chapter_name="Iron Hands"){
-	            k+=1;commands+=1;
-	            race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,16];wep1[company,k]=wep1[101,16];name[company,k]=scr_marine_name();
-	            wep2[company,k]=wep2[101,16];armour[company,k]="Power Armour";gear[company,k]=gear[101,16];chaos[company,k]=0;
-	            bio[company,k]=4+choose(0,1,2);if (global.chapter_name="Iron Hands") then bio[company,k]=choose(7,8);
+	            k+=1;
+	            commands+=1;
+	            race[company,k]=1;
+	            TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	            loc[company,k]=home_name;
+	            role[company,k]=role[100,16];
+	            wep1[company,k]=wep1[101,16];
+	      		name[company,k]=scr_marine_name();
+	            wep2[company,k]=wep2[101,16];
+	            armour[company,k]="Power Armour";
+	            gear[company,k]=gear[101,16];
+	            chaos[company,k]=0;
 	            if (mobi[101,16]!="") then mobi[company,k]=mobi[101,16];
 				spawn_unit = TTRPG[company,k]
 				spawn_unit.spawn_exp();
@@ -1290,17 +1768,29 @@ function scr_initialize_custom() {
 	        }
 
 	        k+=1;// Standard Bearer
-	        race[company,k]=1;loc[company,k]=home_name;role[company,k]="Standard Bearer";wep1[company,k]="Chainsword";name[company,k]=scr_marine_name();
+	        race[company,k]=1;
+	        loc[company,k]=home_name;
+	        TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	        role[company,k]="Standard Bearer";
+	        wep1[company,k]="Chainsword";
+	  		name[company,k]=scr_marine_name();
 	        wep2[company,k]="Company Standard";
 	        armour[company,k]="MK5 Heresy";
-	        chaos[company,k]=0;if (company=8) then mobi[company,k]="Jump Pack";
+	        chaos[company,k]=0;
+	        if (company=8) then mobi[company,k]="Jump Pack";
 	        spawn_unit = TTRPG[company,k];
 			spawn_unit.spawn_exp();
 	        spawn_unit.spawn_old_guard();      
 
 	        k+=1;man_size+=1;// Company Champion
-	        race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,7];wep1[company,k]=wep1[100,7];name[company,k]=scr_marine_name();
-	        wep2[company,k]=wep2[100,7];armour[company,k]="MK4 Maximus";
+	        race[company,k]=1;
+	        TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	        loc[company,k]=home_name;
+	        role[company,k]=role[100,7];
+	        wep1[company,k]=wep1[100,7];
+	  		name[company,k]=scr_marine_name();
+	        wep2[company,k]=wep2[100,7];
+	        armour[company,k]="MK4 Maximus";
 	        chaos[company,k]=0;
 			spawn_unit = TTRPG[company,k];
 			spawn_unit.add_trait("champion");
@@ -1313,36 +1803,58 @@ function scr_initialize_custom() {
 	        if (obj_creation.equal_specialists=1){
 	            if (company<10){
 					
-	                repeat(temp1){k+=1;man_size+=1;
+	                repeat(temp1){
+	                	k+=1;man_size+=1;
+	                	TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
 
-	                race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,8];wep1[company,k]=wep1[101,8];wep2[company,k]=wep2[101,8];name[company,k]=scr_marine_name();
-	                chaos[company,k]=0;
+		                race[company,k]=1;
+		                loc[company,k]=home_name;
+		                role[company,k]=role[100,8];
+		                wep1[company,k]=wep1[101,8];
+		                wep2[company,k]=wep2[101,8];
+		          name[company,k]=scr_marine_name();
+		                chaos[company,k]=0;
 
-			        spawn_unit = TTRPG[company,k]
-					spawn_unit.spawn_exp();
-					spawn_unit.spawn_old_guard();
+				        spawn_unit = TTRPG[company,k];
+						spawn_unit.spawn_exp();
+						spawn_unit.spawn_old_guard();
 
 	                }
-	                repeat(assault){k+=1;man_size+=1;
+	                repeat(assault){
+	                	k+=1;
+	                	man_size+=1;
+	                	TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
 
-	                race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,10];wep1[company,k]=wep1[101,10];name[company,k]=scr_marine_name();
-					mobi[company,k]="Jump Pack";chaos[company,k]=0;
-					wep2[company,k]=wep2[101,10]; 
+		                race[company,k]=1;
+		                loc[company,k]=home_name;
+		                role[company,k]=role[100,10];
+		                wep1[company,k]=wep1[101,10];
+		                name[company,k]=scr_marine_name();
+						mobi[company,k]="Jump Pack";
+						chaos[company,k]=0;
+						wep2[company,k]=wep2[101,10]; 
+							
+				        spawn_unit = TTRPG[company,k];
+						spawn_unit.spawn_exp();
+						spawn_unit.spawn_old_guard();
 						
-			        spawn_unit = TTRPG[company,k]
-					spawn_unit.spawn_exp();
-					spawn_unit.spawn_old_guard();
-					
 	                }
-	                repeat(devastator){k+=1;man_size+=1;
+	                repeat(devastator){
+	                	k+=1;
+	                	man_size+=1;
 
-	                race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,9];wep2[company,k]=wep2[101,9];name[company,k]=scr_marine_name();
-	                chaos[company,k]=0;
+		                race[company,k]=1;
+		                loc[company,k]=home_name;
+		                role[company,k]=role[100,9];
+		                wep2[company,k]=wep2[101,9];
+		                name[company,k]=scr_marine_name();
+		                chaos[company,k]=0;
+		                TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
 
 	                    if (wep1[101,9]="Heavy Ranged") then wep1[company,k]=choose("Lascannon","Missile Launcher","Heavy Bolter");
 	                    if (wep1[101,9]!="Heavy Ranged") then wep1[company,k]=wep1[101,9];
 
-			        spawn_unit = TTRPG[company,k]
+			        spawn_unit = TTRPG[company,k];
 					spawn_unit.spawn_exp();
 					spawn_unit.spawn_old_guard();
 							
@@ -1350,33 +1862,57 @@ function scr_initialize_custom() {
 	            }
 	            if (company=10){
 	                repeat(temp1){k+=1;man_size+=1;
+	                	TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
 					
-	                    race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,12];
-	                    wep1[company,k]=wep1[101,12];name[company,k]=scr_marine_name();
-	                    wep2[company,k]=wep2[101,12];armour[company,k]="Scout Armour";
+	                    race[company,k]=1;
+	                    loc[company,k]=home_name;
+	                    role[company,k]=role[100,12];
+	                    wep1[company,k]=wep1[101,12];
+	              ;
+	              name[company,k]=scr_marine_name();
+	                    wep2[company,k]=wep2[101,12];
+	                    armour[company,k]="Scout Armour";
 	                    chaos[company,k]=0;
-				        spawn_unit = TTRPG[company,k]
-				        spawn_unit.spawn_exp()
+				        spawn_unit = TTRPG[company,k];
+				        spawn_unit.spawn_exp();
 	                }
 	            }
 	        }
 
 	        if (obj_creation.equal_specialists=0){
-	             if (company<8) then repeat(temp1){k+=1;man_size+=1;
+	             if (company<8) then repeat(temp1){
+	             	k+=1;
+	             	man_size+=1;
+	             	TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
 					
-	                race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,8];wep1[company,k]=wep1[101,8];wep2[company,k]=wep2[101,8];name[company,k]=scr_marine_name();
+	                race[company,k]=1;
+	                loc[company,k]=home_name;
+	                role[company,k]=role[100,8];
+	                wep1[company,k]=wep1[101,8];
+	                wep2[company,k]=wep2[101,8];
+	          		name[company,k]=scr_marine_name();
 	                chaos[company,k]=0;
 
 					
-			        spawn_unit = TTRPG[company,k]
+			        spawn_unit = TTRPG[company,k];
 					spawn_unit.spawn_exp();
 					spawn_unit.spawn_old_guard();
 					
 	            } // reserve company only of assault
-	            if (company=8) then repeat(temp1){k+=1;man_size+=1; // assault reserve company
+	            if (company=8) then repeat(temp1){
+	            	k+=1;
+	            	man_size+=1; // assault reserve company
+	            	TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
 
-	            	race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,10];wep1[company,k]=wep1[101,10];wep2[company,k]=wep2[101,10];name[company,k]=scr_marine_name();
-	            	chaos[company,k]=0;mobi[company,k]="Jump Pack";
+	            	race[company,k]=1;
+	            	loc[company,k]=home_name;
+	            	role[company,k]=role[100,10];
+	            	wep1[company,k]=wep1[101,10];
+	            	wep2[company,k]=wep2[101,10];
+	       ;
+	       name[company,k]=scr_marine_name();
+	            	chaos[company,k]=0;
+	            	mobi[company,k]="Jump Pack";
 					
 			        spawn_unit = TTRPG[company,k]
 					spawn_unit.spawn_exp();
@@ -1384,8 +1920,14 @@ function scr_initialize_custom() {
 				
 	            } // reserve company only devo
 	            if (company=9) then repeat(temp1){k+=1;man_size+=1; 
+	            	TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
 
-	                race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,9];name[company,k]=scr_marine_name();wep2[company,k]=wep2[101,9];
+	                race[company,k]=1;
+	                loc[company,k]=home_name;
+	                role[company,k]=role[100,9];
+	          ;
+	          name[company,k]=scr_marine_name();
+	                wep2[company,k]=wep2[101,9];
 	                chaos[company,k]=0;
 	                if (wep1[101,9]="Heavy Ranged") then wep1[company,k]=choose("Lascannon","Missile Launcher","Heavy Bolter");
 	                if (wep1[101,9]!="Heavy Ranged") then wep1[company,k]=wep1[101,9];
@@ -1394,33 +1936,51 @@ function scr_initialize_custom() {
 					spawn_unit.spawn_old_guard();
 								
 	            }
-	            if (company=10) then repeat(temp1){k+=1;man_size+=1;
-	                race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,12];wep1[company,k]=wep1[101,12];name[company,k]=scr_marine_name();
-	                wep2[company,k]=wep2[101,12];armour[company,k]="Scout Armour";
+	            if (company=10) then for(var i=0;i<temp1;i++){
+	            	k+=1;
+	            	man_size+=1;
+	            	TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	                race[company,k]=1;
+	                loc[company,k]=home_name;
+	                role[company,k]=role[100,12];
+	                wep1[company,k]=wep1[101,12];
+	            	name[company,k]=scr_marine_name();
+	                wep2[company,k]=wep2[101,12];
+	                armour[company,k]="Scout Armour";
 	                chaos[company,k]=0;
 	            } 
 	            if (company_unit2="assault") then repeat(assault){k+=1;man_size+=1;
+	            	TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
 
-	                race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,10];wep1[company,k]=wep1[101,10];wep2[company,k]=wep2[101,10];name[company,k]=scr_marine_name();
-	                mobi[company,k]=mobi[101,10];chaos[company,k]=0;
+	                race[company,k]=1;
+	                loc[company,k]=home_name;
+	                role[company,k]=role[100,10];
+	                wep1[company,k]=wep1[101,10];
+	                wep2[company,k]=wep2[101,10];
+	            	name[company,k]=scr_marine_name();
+	                mobi[company,k]=mobi[101,10];
+	                chaos[company,k]=0;
 			        spawn_unit = TTRPG[company,k]
 					spawn_unit.spawn_exp();
-					spawn_unit.spawn_old_guard();
-				
-					
+					spawn_unit.spawn_old_guard();	
 	            }
 	            if (company_unit3="devastator") then repeat(devastator){k+=1;man_size+=1;
+	            	TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
 
-	                race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,9];name[company,k]=scr_marine_name();wep2[company,k]=wep2[101,9];
+	                race[company,k]=1;
+	                loc[company,k]=home_name;
+	                role[company,k]=role[100,9];
+	          		name[company,k]=scr_marine_name();
+	                wep2[company,k]=wep2[101,9];
 					chaos[company,k]=0;
 					
 
 	                if (wep1[101,9]="Heavy Ranged") then wep1[company,k]=choose("Lascannon","Missile Launcher","Heavy Bolter");
 	                if (wep1[101,9]!="Heavy Ranged") then wep1[company,k]=wep1[101,9];
 					
-			        spawn_unit = TTRPG[company,k]
+			        spawn_unit = TTRPG[company,k];
 			        spawn_unit.spawn_old_guard();
-			        spawn_unit.spawn_exp()
+			        spawn_unit.spawn_exp();
 				
 	                
 	            }
@@ -1429,8 +1989,16 @@ function scr_initialize_custom() {
 	        if (dready>0){
 	            repeat(dready){
 	                k+=1;man_size+=10;commands+=1;
-	                race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,6];wep1[company,k]="Close Combat Weapon";name[company,k]=scr_marine_name();
-	                wep2[company,k]=wep2[101,6];armour[company,k]="Dreadnought";chaos[company,k]=0;experience[company,k]=300;
+	                TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	                race[company,k]=1;
+	                loc[company,k]=home_name;
+	                role[company,k]=role[100,6];
+	                wep1[company,k]="Close Combat Weapon"
+	          ;
+	          name[company,k]=scr_marine_name();
+	                wep2[company,k]=wep2[101,6];
+	                armour[company,k]="Dreadnought";
+	                chaos[company,k]=0;experience[company,k]=300;
 	                if (company=9) then wep1[company,k]="Missile Launcher";
 	            }
 	        }
@@ -1484,10 +2052,16 @@ function scr_initialize_custom() {
 	if (global.chapter_name!="Space Wolves") and (global.chapter_name!="Iron Hands"){
 	    if (chaap>0) then repeat(chaap){
 	        k+=1;commands+=1;// Chaplain
-	        race[company,k]=1;loc[company,k]=home_name;role[company,k]=role[100,14];wep1[company,k]=wep1[101,14];name[company,k]=scr_marine_name();
+	        TTRPG[company,k]=new TTRPG_stats("chapter", company,k);
+	        race[company,k]=1;
+	        loc[company,k]=home_name;
+	        role[company,k]=role[100,14];
+	        wep1[company,k]=wep1[101,14];
+	  		name[company,k]=scr_marine_name();
 	        wep2[company,k]=wep2[101,14];
 	        armour[company,k]="MK7 Aquila";// if (company<=2) then armour[company,k]=choose("MK8 Errant","MK6 Corvus");
-	        gear[company,k]=gear[101,14];chaos[company,k]=0;experience[company,k]=100;
+	        gear[company,k]=gear[101,14];
+	        chaos[company,k]=0;experience[company,k]=100;
 	        bio[company,k]=0;
 	        // if (company=8) then mobi[company,k]="Jump Pack";
 	        if (mobi[101,14]!="") then mobi[company,k]=mobi[101,14];
@@ -1526,7 +2100,8 @@ function scr_initialize_custom() {
 	    scr_add_item("Force Weapon",4);
 	    scr_add_item("Plasma Pistol",4);
 
-	    o=0;chapter_option=0;repeat(4){o+=1;if (obj_creation.adv[o]="Crafters") then chapter_option=1;}
+	    o=0;chapter_option=0;repeat(4){o+=1;
+	    	if (obj_creation.adv[o]="Crafters") then chapter_option=1;}
 	    if (chapter_option=1) then scr_add_item("Tartaros",10);
 	    else{scr_add_item("Terminator Armour",10);}
 
@@ -1560,7 +2135,8 @@ function scr_initialize_custom() {
 
 
 
-	var o,bloo;bloo=0;o=0;repeat(4){o+=1;if (obj_creation.dis[o]="Blood Debt") then bloo=1;}
+	var o,bloo;bloo=0;o=0;repeat(4){o+=1;
+		if (obj_creation.dis[o]="Blood Debt") then bloo=1;}
 	if (bloo=1) and (instance_exists(obj_controller)){obj_controller.blood_debt=1;}
 	if (bloo=1){
 	    penitent=1;penitent_max=(obj_creation.strength*1000)+300;

--- a/scripts/scr_load/scr_load.gml
+++ b/scripts/scr_load/scr_load.gml
@@ -95,6 +95,8 @@ function scr_load(argument0, argument1) {
 	    obj_controller.tau_messenger=ini_read_real("Controller","tau_messenger",0);
 	    obj_controller.fleet_all=ini_read_real("Controller","fleet_all",0);
 	    obj_ini.tolerant=ini_read_real("Controller","tolerant",0);
+	    obj_ini.stability=ini_read_real("Controller","stability",5);
+	    obj_ini.purity=ini_read_real("Controller","purity",5);
 	    obj_controller.tolerant=ini_read_real("Controller","tolerant",0);
 	    obj_controller.unload=ini_read_real("Controller","unload",0);
 	    obj_controller.diplomacy=0;

--- a/scripts/scr_load/scr_load.gml
+++ b/scripts/scr_load/scr_load.gml
@@ -4,7 +4,7 @@ function scr_load(argument0, argument1) {
 			var marStruct = ini_read_string("Mar","Struct"+string(company)+"."+string(marine),"");
 			if (marStruct != ""){
 				marStruct = json_parse(base64_decode(marStruct));
-				obj_ini.TTRPG[company, marine] = new TTRPG_stats("chapter", company, marine);
+				obj_ini.TTRPG[company, marine] = new TTRPG_stats("chapter", company, marine, "blank");
 				obj_ini.TTRPG[company, marine].load_json_data(marStruct);
 			} else {obj_ini.TTRPG[company, marine] = new TTRPG_stats("chapter", company, marine,"blank");}		
 	};
@@ -728,66 +728,61 @@ function scr_load(argument0, argument1) {
 	            obj_ini.gear[coh,mah]=ini_read_string("Mar","ge"+string(coh)+"."+string(mah),"");
 	            obj_ini.mobi[coh,mah]=ini_read_string("Mar","mb"+string(coh)+"."+string(mah),"");	
 	        }
-	        good=0;coh=10;mah=600;
-	        repeat(6600){
-	            if (good=0){
-	                mah-=1;
-	                if (mah=0){mah=600;coh-=1;}
-	                if (coh=0) and (mah=-1) then good=1;
-	                if (coh<0) then good=1;
+	        for (coh=0;coh<=10;coh++){
+	        	for (mah=0;mah<=500;mah++){
 
 	                // var temp_name;temp_name="";
 	                // temp_name=ini_read_string("Mar","rol"+string(coh)+"."+string(mah),"Error");
 
-	                if (good=0){
-	                    obj_ini.race[coh,mah]=ini_read_real("Mar","co"+string(coh)+"."+string(mah),0);
-	                    obj_ini.loc[coh,mah]=ini_read_string("Mar","lo"+string(coh)+"."+string(mah),"");
-	                    obj_ini.name[coh,mah]=ini_read_string("Mar","num"+string(coh)+"."+string(mah),"");
-	                    obj_ini.role[coh,mah]=ini_read_string("Mar","rol"+string(coh)+"."+string(mah),"");// temp_name;
-	                    obj_ini.lid[coh,mah]=ini_read_real("Mar","li"+string(coh)+"."+string(mah),0);
-	                    obj_ini.bio[coh,mah]=ini_read_real("Mar","bio"+string(coh)+"."+string(mah),0);
-	                    obj_ini.wid[coh,mah]=ini_read_real("Mar","wi"+string(coh)+"."+string(mah),0);								
+                    obj_ini.race[coh,mah]=ini_read_real("Mar","co"+string(coh)+"."+string(mah),0);
+                    obj_ini.loc[coh,mah]=ini_read_string("Mar","lo"+string(coh)+"."+string(mah),"");
+                    obj_ini.name[coh,mah]=ini_read_string("Mar","num"+string(coh)+"."+string(mah),"");
+                    obj_ini.role[coh,mah]=ini_read_string("Mar","rol"+string(coh)+"."+string(mah),"");// temp_name;
+                    obj_ini.lid[coh,mah]=ini_read_real("Mar","li"+string(coh)+"."+string(mah),0);
+                    obj_ini.bio[coh,mah]=ini_read_real("Mar","bio"+string(coh)+"."+string(mah),0);
+                    obj_ini.wid[coh,mah]=ini_read_real("Mar","wi"+string(coh)+"."+string(mah),0);								
 
-	                    if (coh=0){
-	                        if (obj_ini.role[coh,mah]="Chapter Master") then obj_ini.race[coh,mah]=1;
-	                        if (obj_ini.role[coh,mah]="Master of Sanctity") then obj_ini.race[coh,mah]=1;
-	                        if (obj_ini.role[coh,mah]="Master of the Apothecarion") then obj_ini.race[coh,mah]=1;
-	                        if (obj_ini.role[coh,mah]="Forge Master") then obj_ini.race[coh,mah]=1;
-	                        if (string_count("Chief",obj_ini.role[coh,mah])>0) then obj_ini.race[coh,mah]=1;
-	                    }
+                    if (coh=0){
+                        if (obj_ini.role[coh,mah]="Chapter Master"){
+                        	obj_ini.race[coh,mah]=1;
+                        }else if (obj_ini.role[coh,mah]="Master of Sanctity"){
+                        	obj_ini.race[coh,mah]=1;
+                        }else if (obj_ini.role[coh,mah]="Master of the Apothecarion"){
+                        	obj_ini.race[coh,mah]=1;
+                        } else if (obj_ini.role[coh,mah]="Forge Master") then obj_ini.race[coh,mah]=1;
+                        if (string_count("Chief",obj_ini.role[coh,mah])>0) then obj_ini.race[coh,mah]=1;
+                    }
 
-	                    obj_ini.wep1[coh,mah]=ini_read_string("Mar","w1"+string(coh)+"."+string(mah),"");
-	                    obj_ini.wep2[coh,mah]=ini_read_string("Mar","w2"+string(coh)+"."+string(mah),"");
-	                    obj_ini.armour[coh,mah]=ini_read_string("Mar","ar"+string(coh)+"."+string(mah),"");
-	                    obj_ini.gear[coh,mah]=ini_read_string("Mar","ge"+string(coh)+"."+string(mah),"");
-	                    obj_ini.mobi[coh,mah]=ini_read_string("Mar","mb"+string(coh)+"."+string(mah),"");
+                    obj_ini.wep1[coh,mah]=ini_read_string("Mar","w1"+string(coh)+"."+string(mah),"");
+                    obj_ini.wep2[coh,mah]=ini_read_string("Mar","w2"+string(coh)+"."+string(mah),"");
+                    obj_ini.armour[coh,mah]=ini_read_string("Mar","ar"+string(coh)+"."+string(mah),"");
+                    obj_ini.gear[coh,mah]=ini_read_string("Mar","ge"+string(coh)+"."+string(mah),"");
+                    obj_ini.mobi[coh,mah]=ini_read_string("Mar","mb"+string(coh)+"."+string(mah),"");
 
-	                    var arc,teh,teh2;arc=0;teh="";teh2="";// Give daemon weapons their dialogue lines
-	                    repeat(5){arc+=1;teh2=choose("Daemonic1a|","Daemonic2a|","Daemonic3a|","Daemonic4a|");
-	                        if (arc=1) then teh=obj_ini.wep1[coh,mah];
-	                        if (arc=2) then teh=obj_ini.wep2[coh,mah];
-	                        if (arc=3) then teh=obj_ini.armour[coh,mah];
-	                        if (arc=4) then teh=obj_ini.gear[coh,mah];
-	                        if (arc=5) then teh=obj_ini.mobi[coh,mah];
-	                        if (string_pos("&",teh)>0){
-	                            if (string_count("Daemonic|",teh)>0) then teh=string_replace(teh,"Daemonic|",teh2);
-	                            if (arc=1) then obj_ini.wep1[coh,mah]=teh;
-	                            if (arc=2) then obj_ini.wep2[coh,mah]=teh;
-	                            if (arc=3) then obj_ini.armour[coh,mah]=teh;
-	                            if (arc=4) then obj_ini.gear[coh,mah]=teh;
-	                            if (arc=5) then obj_ini.mobi[coh,mah]=teh;
-	                        }
-	                    }
-
-	                    obj_ini.hp[coh,mah]=ini_read_real("Mar","hp"+string(coh)+"."+string(mah),0);
-	                    obj_ini.chaos[coh,mah]=ini_read_real("Mar","cha"+string(coh)+"."+string(mah),0);
-	                    obj_ini.experience[coh,mah]=ini_read_real("Mar","exp"+string(coh)+"."+string(mah),0);
-	                    obj_ini.age[coh,mah]=ini_read_real("Mar","ag"+string(coh)+"."+string(mah),0);
-	                    obj_ini.spe[coh,mah]=ini_read_string("Mar","spe"+string(coh)+"."+string(mah),"");
-	                    obj_ini.god[coh,mah]=ini_read_real("Mar","god"+string(coh)+"."+string(mah),0);
-						load_marine_struct(coh,mah);
-	                }
-
+                    var arc,teh,teh2;arc=0;teh="";teh2="";// Give daemon weapons their dialogue lines
+                    for (arc=1;arc<6;arc++){
+                    	teh2=choose("Daemonic1a|","Daemonic2a|","Daemonic3a|","Daemonic4a|");
+                        if (arc=1) then teh=obj_ini.wep1[coh,mah];
+                        if (arc=2) then teh=obj_ini.wep2[coh,mah];
+                        if (arc=3) then teh=obj_ini.armour[coh,mah];
+                        if (arc=4) then teh=obj_ini.gear[coh,mah];
+                        if (arc=5) then teh=obj_ini.mobi[coh,mah];
+                        if (string_pos("&",teh)>0){
+                            if (string_count("Daemonic|",teh)>0) then teh=string_replace(teh,"Daemonic|",teh2);
+                            if (arc=1) then obj_ini.wep1[coh,mah]=teh;
+                            if (arc=2) then obj_ini.wep2[coh,mah]=teh;
+                            if (arc=3) then obj_ini.armour[coh,mah]=teh;
+                            if (arc=4) then obj_ini.gear[coh,mah]=teh;
+                            if (arc=5) then obj_ini.mobi[coh,mah]=teh;
+                        }
+                    }
+                    obj_ini.hp[coh,mah]=ini_read_real("Mar","hp"+string(coh)+"."+string(mah),0);
+                    obj_ini.chaos[coh,mah]=ini_read_real("Mar","cha"+string(coh)+"."+string(mah),0);
+                    obj_ini.experience[coh,mah]=ini_read_real("Mar","exp"+string(coh)+"."+string(mah),0);
+                    obj_ini.age[coh,mah]=ini_read_real("Mar","ag"+string(coh)+"."+string(mah),0);
+                    obj_ini.spe[coh,mah]=ini_read_string("Mar","spe"+string(coh)+"."+string(mah),"");
+                    obj_ini.god[coh,mah]=ini_read_real("Mar","god"+string(coh)+"."+string(mah),0);
+                    load_marine_struct(coh,mah);
 	            }
 	        }
 

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -18,7 +18,11 @@
 		the string (usually max) is guidance so in the instance of max it will pick the larger value of the mean and the gauss function return
 */
 global.stat_list = ["constitution", "strength", "luck", "dexterity", "wisdom", "piety", "charisma", "technology","intelligence", "weapon_skill", "ballistic_skill"];
-global.body_parts = ["left_leg", "right_leg", "torso", "right_arm", "left_arm", "left_eye", "right_eye"];
+
+// will swap these out for enums or some better method as i develop where this is going
+global.body_parts = ["left_leg", "right_leg", "torso", "right_arm", "left_arm", "left_eye", "right_eye", "throat", "jaw"];
+global.body_parts_display = ["Left Leg", "Right Leg", "Torso", "Right Arm", "Left Arm", "Left Eye", "Right eye", "Throat", "Jaw"];
+global.religions={"imperial_cult":{"name":"Imperial Cult"}, "cult_mechanicus":{"name":"Cult Mechanicus"}}
 enum location_types {
 	planet,
 	ship,
@@ -31,7 +35,7 @@ global.trait_list = {
 		weapon_skill : [10,5,"max"],      
 		ballistic_skill:[10,5, "max"],
 		display_name : "Champion",
-		flavour_text : "Through either natural talent, or obsessive training {0} is a master of arms"
+		flavour_text : "Through either natural talent, or obsessive training {0} is a master of arms",
 	},
 	"lightning_warriors":{
 		constitution: -6,
@@ -70,8 +74,8 @@ global.trait_list = {
 	"paragon":{
 		constitution:12,
 		luck:2,
-		strength:6,
-		dexterity:6,
+		strength:10,
+		dexterity:10,
 		intelligence:6,
 		charisma:6,
 		weapon_skill:10,
@@ -82,7 +86,7 @@ global.trait_list = {
 	},
 	"warp_touched":{
 		intelligence:4,
-		flavour_text : "has phychic potential even if unknown to them",
+		flavour_text : "has phychic potential even if unknown to them (can be recruited to the librarius)",
 		display_name : "Warp Touched",		
 	},
 	"lucky":{
@@ -117,7 +121,92 @@ global.trait_list = {
 		wisdom : 5,
 		flavour_text : "{0} is truly Ancient. While his body may ache his, skills and wisdom are to be respected",
 		display_name : "Ancient",		
-	}	
+	},
+	"tinkerer":{
+		technology:[5,2,"max"],
+		display_name:"Tinkerer",
+		flavour_text:"{0} has a knack for tinkering around with various technological devices and apparatuses",
+	},
+	"lead_example":{
+		weapon_skill:[2,1,"max"],
+		ballistic_skill :[2,1,"max"],
+		constitution :[2,1, "max"],
+		dexterity:2,
+		strength:1,
+		luck:1,
+		intelligence:1,
+		wisdom:1,
+		charisma:3,
+		display_name:"Lead by Example",
+		flavour_text :"In his many years of service, {0} has rissen through the ranks and has always lead by example and from the front, he has the respect of all of his brothers",
+	},
+	"still_standing":{
+		weapon_skill:[6,2,"max"],
+		ballistic_skill :[6,2,"max"],
+		constitution :[3,1, "max"],
+		dexterity:5,
+		luck:3,
+		wisdom:[3,3,1],
+		charisma:1,
+		display_name:"Still Standing",
+		flavour_text :"{0} survived inmessurable odds, either through killing a warboss, killing a nid queen, or other incredible deed, while all his brothers were injured",
+
+	},
+	"lone_survivor":{
+		weapon_skill:[8,2,"max"],
+		ballistic_skill :[8,2,"max"],
+		constitution :[8,1, "max"],
+		dexterity:[4,2, "max"],
+		strength:[4,2, "max"],
+		luck:5,
+		wisdom:[2,1,"max"],
+		intelligence:[3,3,"max"],
+		charisma:[-3, 1, "min"],
+		display_name:"Lone Survivor",
+		flavour_text :"{0} survived a battle where all his deployed brothers died. He is more reclusive, but gained immeasurable combat capabilities and is harder to kill.",
+	},
+	"beast_slayer":{
+		weapon_skill:[3,2,"max"],
+		ballistic_skill :[4,2,"max"],
+		constitution :[2,1, "max"],
+		dexterity:1,
+		strength:4,
+		wisdom:3,
+		charisma:1,
+		display_name:"Lone Survivor",
+		flavour_text :"{0} has defeated a huge beast in single combat, this proves his toughness and his great ability to overcome powerful enemies of the imperium",
+
+	},	
+	"mars_trained":{
+		technology:[10,5,"max"],
+		intelligence:[5,5,"max"],
+		display_name:"Trained On Mars",
+		flavour_text:"{0} Has had the best instruction in the imperium on technology from the Tech Priests of Mars"
+	},
+	"flesh_is_weak":{
+		technology:[2,1,"max"],
+		constitution:[1,1,"max"],
+		piety:[3,1,"max"],
+		display_name:"Weakness of Flesh",
+		flavour_text:"{0} tries to cast aside all perceived weaknesses of the flesh",
+		effect:"faith boosts from bionic replacements"
+	},
+	"zealous_faith":{
+		strength:[1,1,"max"],
+		texhnology:-2,
+		wisdom:3,
+		intelligence:-2,
+		piety:[5,2,"max"],
+		display_name:"Zealous Faith",
+		flavour_text:"{0} puts great emphasis on his faith, able to draw strength from it in crisis"
+	},
+	"feet_floor":{
+		wisdom:1,
+		dexterity:-2,
+		display_name:"Feet On the Ground",
+		flavour_text:"{0} prefers to keep both feet on the ground",
+		effect:"reduction in combat effectiveness when using Bikes or Jump Packs"
+	}
 }
 global.base_stats = { //tempory stats subject to change by anyone that wishes to try their luck
 	"chapter_master":{
@@ -291,11 +380,12 @@ global.base_stats = { //tempory stats subject to change by anyone that wishes to
 }
 function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 	constitution=0; strength=0;luck=0;dexterity=0;wisdom=0;piety=0;charisma=0;technology=0;intelligence=0;weapon_skill=0;ballistic_skill=0;size = 0;
+	religion="none";
+	religion_sub_cult = "none";
 	base_group = "none";
 	role_history = [];
 	company = comp;			//marine company
 	marine_number = mar;			//marine number in company
-	obj_ini.bio[company,marine_number] = 0;   //need to rework init of 2d arrays( and eventually remove)
 	squad = "none";
 	static bionics = function(){return obj_ini.bio[company,marine_number];}// get marine bionics count	
 	static experience =  function(){return obj_ini.experience[company,marine_number];}//get exp
@@ -376,34 +466,38 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 	static add_trait = function(trait){
 			var balance_value;
 			if struct_exists(global.trait_list, trait){
-				var selec_trait = global.trait_list[$ trait];
-				var edits = variable_struct_get_names(selec_trait);
-				var edit_stat,random_stat,stat_mod;
-			
-				//loop over stats and add stats where needed
-				stats = global.stat_list;
-				for (var stat_iter =0; stat_iter <array_length(stats);stat_iter++){
-					if (array_contains(edits ,stats[stat_iter])){
-						edit_stat = variable_struct_get(selec_trait, stats[stat_iter]);
-						if (is_array(edit_stat)){
-							stat_mod = gauss(edit_stat[0], edit_stat[1]);
-							if (array_length(edit_stat) > 2){
-								if (edit_stat[2] == "max"){
-									stat_mod = max(stat_mod, edit_stat[0]);
+				if (!array_contains(traits, trait)){
+					var selec_trait = global.trait_list[$ trait];
+					var edits = variable_struct_get_names(selec_trait);
+					var edit_stat,random_stat,stat_mod;
+				
+					//loop over stats and add stats where needed
+					stats = global.stat_list;
+					for (var stat_iter =0; stat_iter <array_length(stats);stat_iter++){
+						if (array_contains(edits ,stats[stat_iter])){
+							edit_stat = variable_struct_get(selec_trait, stats[stat_iter]);
+							if (is_array(edit_stat)){
+								stat_mod = gauss(edit_stat[0], edit_stat[1]);
+								if (array_length(edit_stat) > 2){
+									if (edit_stat[2] == "max"){
+										stat_mod = floor(max(stat_mod, edit_stat[0]));
+									} else if(edit_stat[2] == "min") {
+										stat_mod = floor(min(stat_mod, edit_stat[0]));
+									}
 								}
+							} else{stat_mod = edit_stat}
+							if (stats[stat_iter] == "constitution"){
+								balance_value = (hp()/max_health());
 							}
-						} else{stat_mod = edit_stat}
-						if (stats[stat_iter] == "constitution"){
-							balance_value = (hp()/max_health());
-						}
-						variable_struct_set(self,stats[stat_iter],  (variable_struct_get(self, stats[stat_iter])+  stat_mod));
-						if (stats[stat_iter] == "constitution"){
-							update_health(max_health()*balance_value)
+							variable_struct_set(self,stats[stat_iter],  (variable_struct_get(self, stats[stat_iter])+  stat_mod));
+							if (stats[stat_iter] == "constitution"){
+								update_health(max_health()*balance_value)
+							}
 						}
 					}
+					//max_health() = 100 * (1+((constitution - 20)*0.05));
+					array_push(traits, trait);
 				}
-				//max_health() = 100 * (1+((constitution - 20)*0.05));
-				array_push(traits, trait);
 			}
 	}
 	
@@ -419,7 +513,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 			if (is_array(variable_struct_get(self, stats[stat_iter]))){
 				//show_debug_message("is array");
 				edit_stat = variable_struct_get(self, stats[stat_iter]);
-				stat_mod =  gauss(edit_stat[0], edit_stat[1]);
+				stat_mod =  floor(gauss(edit_stat[0], edit_stat[1]));
 
 				variable_struct_set(self, stats[stat_iter],  stat_mod);			
 			}
@@ -433,16 +527,16 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 			}
 		   gene_Seed_mutations = {
 		   			"preomnor":obj_ini.preomnor,
-			    	"lyman":obj_ini.preomnor,
-			    	"omophagea":obj_ini.preomnor,
-			    	"ossmodula":obj_ini.preomnor,
-			    	"zygote":obj_ini.preomnor,
-			    	"betchers":obj_ini.preomnor,
-			    	"catalepsean":obj_ini.preomnor,
-			    	"occulobe":obj_ini.preomnor,
-			    	"mucranoid":obj_ini.preomnor,
-			    	"membran":obj_ini.preomnor,
-			    	"voice":obj_ini.preomnor,
+			    	"lyman":obj_ini.lyman,
+			    	"omophagea":obj_ini.omophagea,
+			    	"ossmodula":obj_ini.ossmodula,
+			    	"zygote":obj_ini.zygote,
+			    	"betchers":obj_ini.betchers,
+			    	"catalepsean":obj_ini.catalepsean,
+			    	"occulobe":obj_ini.occulobe,
+			    	"mucranoid":obj_ini.mucranoid,
+			    	"membran":obj_ini.membrane,
+			    	"voice":obj_ini.voice,
 			};			
 			if (instance_exists(obj_controller)){
 				role_history = [[obj_ini.role[company,marine_number], obj_controller.turn]]; //marines_promotion and demotion history
@@ -452,12 +546,14 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 				marine_ascension = "pre_game"; // on what day did turn did this marine begin to exist
 
 			}
-			if ((allegiance="Iron Hands") or (obj_ini.progenitor=6)) and (bionics() == 0){ obj_ini.bio[company,marine_number]=choose(2,3,4,5);}
 			
 			//need a niftier way of doing this as it's a lot of bulk and hard coding
 			if (irandom(99)>98){
 				 add_trait("very_hard_to_kill");	 //chance for marine to be exceedingly tough
 			};
+			if (irandom(199)>198){
+				add_trait("feet_floor");		
+			}
 			if (irandom(999)>998){
 				 add_trait("paragon");				//paragon chance just like cm
 			};
@@ -508,16 +604,40 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 					add_trait("lightning_warriors");
 				};
 			};
+			if (global.chapter_name=="Black Templars"){
+				if (irandom(3)==0){
+					add_trait("zealous_faith");
+				}
+			}else{
+				if (irandom(99)>98){
+					add_trait("zealous_faith");
+				};
+			}
+			if ((global.chapter_name=="Iron Hands") or (obj_ini.progenitor=6)){
+				religion="cult_mechanicus";
+				if (irandom(10)==1){
+					add_trait("flesh_is_weak");
+				}
+				if (irandom(49)>47){
+					add_trait("tinkerer");
+				};
+			} else{
+				if (irandom(99)>98){
+					add_trait("tinkerer");
+				};
+			}
+			if (global.chapter_name=="Space Wolves"){
+				religion_sub_cult = "The Allfather"
+			}
 			break;
 		/*case "skitarii":
 			break;*/	
 	}
-		body = {"left_leg":{}, "right_leg":{}, "torso":{}, "left_arm":{}, "right_arm":{}, "left_eye":{}, "right_eye":{}}; //body parts list can be extended as much as people want
+		body = {"left_leg":{}, "right_leg":{}, "torso":{}, "left_arm":{}, "right_arm":{}, "left_eye":{}, "right_eye":{},"throat":{}, "jaw":{}}; //body parts list can be extended as much as people want
 		static race = function(){return obj_ini.race[company,marine_number];}		//get race
-		static add_bionics = function(){
-			var new_bionic_pos, part, new_bionic = {quality :"standard"};
+		static add_bionics = function(area="none", bionic_quality="standard"){
+			var new_bionic_pos, part, new_bionic = {quality :bionic_quality};
 			if (obj_ini.bio[company,marine_number] < 10){
-				obj_ini.bio[company,marine_number]++;
 				update_health(hp()+30);
 				var bionic_possible = [];
 				for (var body_part = 0; body_part < array_length(global.body_parts);body_part++){
@@ -527,36 +647,42 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 					}
 				}
 				if (array_length(bionic_possible) > 0){
-					new_bionic_pos = bionic_possible[irandom(array_length(bionic_possible)-1)]
+					if (area!="none"){
+						if (array_contains(bionic_possible, area)){
+							new_bionic_pos = area;
+						} else {
+							return 0;
+						}
+					} else {
+						new_bionic_pos = bionic_possible[irandom(array_length(bionic_possible)-1)];
+					}
+					obj_ini.bio[company,marine_number]++;
 					variable_struct_set(body[$ new_bionic_pos], "bionic", new_bionic);
 					if (array_contains(["left_leg", "right_leg"], new_bionic_pos)){
 						constitution += 2;
 						strength++;
 						dexterity -= 2;
-					}
-					if (array_contains(["left_eye", "right_eye"], new_bionic_pos)){
+					}else if (array_contains(["left_eye", "right_eye"], new_bionic_pos)){
 						constitution += 1;
 						wisdom += 1;
 						dexterity++;
-					}
-					if (array_contains(["left_arm", "right_arm"], new_bionic_pos)){
+					} else if (array_contains(["left_arm", "right_arm"], new_bionic_pos)){
 						constitution += 2;
 						strength += 2;
 						weapon_skill--;
-					}	
-					if (new_bionic_pos == "torso"){
+					}	else if (new_bionic_pos == "torso"){
 						constitution += 4;
 						strength++;
 						dexterity--;						
+					}else{ 
+						constitution++;
 					}
-				} else{ constitution++;}
+					if (array_contains(traits, "flesh_is_weak")){
+						piety++;
+					}
+				}
 				if (hp()>max_health()){update_health(max_health())}
 			}
-		}
-		var needed_bionics = obj_ini.bio[company,marine_number];
-		obj_ini.bio[company,marine_number] = 0;
-		for (var bionic_allocate = 0;bionic_allocate < needed_bionics;bionic_allocate++){
-			add_bionics();
 		}
 		static age = function(){return obj_ini.age[company,marine_number];}// age
 		static update_age = function(new_val){obj_ini.age[company,marine_number] = new_val;}		
@@ -642,7 +768,16 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 
 		//quick way of getting name and role combined in string
 		static name_role = function (){
-			return string("{0} {1}", role(), name())
+			var temp_role = role();
+			if (squad != "none"){
+				if (struct_exists(obj_ini.squad_types[$ obj_ini.squads[squad].type], temp_role)){
+					var role_info = obj_ini.squad_types[$ obj_ini.squads[squad].type][$ temp_role]
+					if (struct_exists(role_info, "role")){
+						temp_role = role_info[$ "role"];
+					}
+				}
+			}
+			return string("{0} {1}", temp_role, name())
 		}
 		
 		static load_marine = function(ship){
@@ -672,11 +807,11 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 	static spawn_exp =function(){
 		var spawn_ex = 0;
 		if (obj_ini.company_spawn_buffs[company] != 0){
-			spawn_ex += gauss(obj_ini.company_spawn_buffs[company][0], obj_ini.company_spawn_buffs[company][1]);	//finds the on game spwan buff a marine should get from being spawned at game start
+			spawn_ex += floor(gauss(obj_ini.company_spawn_buffs[company][0], obj_ini.company_spawn_buffs[company][1]));	//finds the on game spwan buff a marine should get from being spawned at game start
 		}
 		if (struct_exists(obj_ini.role_spawn_buffs, role())){ //adds exp buffs based on marine's role
 			if (obj_ini.role_spawn_buffs[$ role()] != 0){
-				spawn_ex += gauss(obj_ini.role_spawn_buffs[$ role()][0], obj_ini.role_spawn_buffs[$ role()][1]);
+				spawn_ex += floor(gauss(obj_ini.role_spawn_buffs[$ role()][0], obj_ini.role_spawn_buffs[$ role()][1]));
 			}
 		}
 		if (spawn_ex != 0){update_exp(spawn_ex)}  //update the marines exp with updated guass value
@@ -685,6 +820,10 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 	static spawn_old_guard =function(){
 		var old_guard=irandom(100);
 		var age = (obj_ini.millenium*1000)+obj_ini.year;
+		var bionic_count = choose(0,0,0,0,1,2,3);
+		if (global.chapter_name=="Iron Hands"){
+			bionic_count = choose(2,3,4,5);
+		}
 		switch(role()){
 			case obj_ini.role[100,5]:  //captain
 				if(old_guard>=75){
@@ -692,18 +831,25 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 					update_age(age - gauss(400, 200))
 					add_trait("old_guard");
 					add_exp(50);
+					bionic_count = choose(0,0,1,2,3)
 				} // 25% of iron within
 				else{
-					update_armour("MK8 Errant");
+					update_armour(choose("MK5 Heresy","MK6 Corvus","MK7 Aquila", "MK4 Maximus","MK8 Errant"));
 					update_age(age - gauss(400, 25));
 					add_trait("seasoned");
 					add_exp(25);
-				};
+				}
 				break;
 			case  obj_ini.role[100,15]:  //apothecary
 				update_armour("MK7 Aquila");
-				if (company<=2) then update_armour(choose("MK8 Errant","MK6 Corvus"));
+				if (company<=2){update_armour(choose("MK8 Errant","MK6 Corvus"))
+				}else{
+					update_armour(choose("MK5 Heresy","MK6 Corvus","MK7 Aquila", "MK4 Maximus","MK8 Errant"));
+				}
 				update_age(age - gauss(400, 250));
+				if (intelligence<40){
+					intelligence=40;
+				}
 				break;
 			case "Standard Bearer":
 				 update_armour("MK5 Heresy");
@@ -770,7 +916,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 				};
 				break;	
 			case  obj_ini.role[100,9]: 		//devastators	
-				if (old_guard>=99 and old_guard<=97){
+				if ((old_guard>=99) and (old_guard<=97)){
 					update_armour("MK4 Maximus");
 					update_age(age - gauss(300, 100));
 					add_trait(choose("ancient","old_guard"));
@@ -787,13 +933,89 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 				} // company 1 and 2 taccies get beakies by default
 				else{update_armour("MK7 Aquila")};
 				break;
+			case  obj_ini.role[100,3]: //veterans
+				if ((old_guard>=80)and (old_guard>=95)){
+					update_armour(choose("MK4 Maximus","MK8 Errant"));
+					update_age(age - gauss(150, 30));
+					add_trait(choose("old_guard"));
+					add_exp(choose(50, 75));					
+				} else if (old_guard>95){
+					update_armour(choose("MK4 Maximus","MK3 Iron Armour"));
+					update_age(age - gauss(300, 100));
+					add_trait(choose("old_guard"));
+					add_exp(choose(125, 100));
+				} else if (old_guard<35){
+					update_armour(choose("MK4 Maximus","MK3 Iron Armour"));
+					update_age(age - gauss(150, 30));
+					add_trait(choose("old_guard"));
+					add_exp(choose(25, 50));					
+				}
+				break;
+			case obj_ini.role[100,16]: //techmarines
+				update_armour(choose("MK8 Errant","MK6 Corvus","MK4 Maximus","MK3 Iron Armour"))
+				if ((global.chapter_name="Iron Hands") or (obj_ini.progenitor=6)){
+					add_bionics("right_arm");
+					bionic_count = choose(6,6,7,7,7,8,9);
+					add_trait("flesh_is_weak");
+				}else {
+			    bionic_count = irandom(5)
+				  if (irandom(2) ==0){
+				    add_trait("flesh_is_weak");
+				  }
+			  }
+				if (technology<35){
+					technology=35;
+				}
+			  add_trait("mars_trained");
+			  if (irandom(1) ==0){
+			    add_trait("tinkerer");
+			  }
+			  religion = "cult_mechanicus"	
+				break;
+			case  obj_ini.role[100,12]: //scouts
+				bionic_count = choose(0,0,0,0,0,0,0,0,0,0,0,1)
+				break;
+			case  obj_ini.role[100,14]:  //chaplain
+				update_armour(choose("MK5 Heresy","MK6 Corvus","MK7 Aquila", "MK4 Maximus","MK8 Errant"));
+				update_age(age - gauss(400, 250));
+				if (piety<35){
+					piety=35;
+				}
+				if(irandom(1) ==0){
+					add_trait("zealous_faith")
+				}
+				break;
+			case "Codiciery":
+				update_armour(choose("MK5 Heresy","MK6 Corvus","MK7 Aquila", "MK4 Maximus","MK8 Errant"));
+				update_age(age - gauss(150, 20));
+				break;
+			case "Lexicanum":
+				update_armour(choose("MK5 Heresy","MK6 Corvus","MK7 Aquila", "MK4 Maximus","MK8 Errant"));
+				update_age(age - gauss(200, 30));
+				add_trait("seasoned");
+				break;
+			case obj_ini.role[100,17]:
+				update_armour(choose("MK5 Heresy","MK6 Corvus","MK7 Aquila", "MK4 Maximus","MK8 Errant"));
+				update_age(age - gauss(400, 250));
+				add_trait("seasoned");
+				break;		
+		}
+		for(var i=0;i<bionic_count;i++){
+				add_bionics();
+		}
+		if (irandom(399-experience()) == 0){
+			add_trait("still_standing");
+		};
+		if (irandom(399-experience()) == 0){
+			add_trait("beast_slayer");
+		};		
+		if (irandom(499-experience())==0){
+			add_trait("lone_survivor");
 		}
 	}
 	static alter_equipment = function(update_equipment){
-		show_debug_message("{0}",update_equipment)
 		var equip_areas = struct_get_names(update_equipment);
 		for (var i=0;i<array_length(equip_areas);i++){
-			show_debug_message("{0}",equip_areas[i])
 			switch(equip_areas[i]){
 				case "wep1":
 					update_weapon_one(update_equipment[$ equip_areas[i]]);
@@ -803,7 +1025,13 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 					break;
 				case "mobi":
 					update_mobility_item(update_equipment[$ equip_areas[i]]);
-					break;					
+					break;
+				case "armour":
+					update_armour(update_equipment[$ equip_areas[i]]);
+					break;
+				case "gear":
+					update_gear(update_equipment[$ equip_areas[i]]);
+					break;								
 			}
 		}
 	}

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -30,6 +30,8 @@ enum location_types {
 	ancient_ruins,
 	warp
 }
+
+global.phy_levels =["Rho","Pi","Omicron","Xi","Nu","Mu","Lambda","Kappa","Iota","Theta","Eta","Zeta","Epsilon","Delta","Gamma","Beta","Alpha","Alpha Plus","Beta","Gamma Plus"]
 global.trait_list = {
 	"champion":{
 		weapon_skill : [10,5,"max"],      
@@ -381,6 +383,7 @@ global.base_stats = { //tempory stats subject to change by anyone that wishes to
 function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 	constitution=0; strength=0;luck=0;dexterity=0;wisdom=0;piety=0;charisma=0;technology=0;intelligence=0;weapon_skill=0;ballistic_skill=0;size = 0;
 	religion="none";
+	psionic=0;
 	religion_sub_cult = "none";
 	base_group = "none";
 	role_history = [];
@@ -525,7 +528,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 			if (faction ="chapter"){
 				allegiance = global.chapter_name;
 			}
-		   gene_Seed_mutations = {
+		   gene_seed_mutations = {
 		   			"preomnor":obj_ini.preomnor,
 			    	"lyman":obj_ini.lyman,
 			    	"omophagea":obj_ini.omophagea,
@@ -535,9 +538,20 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 			    	"catalepsean":obj_ini.catalepsean,
 			    	"occulobe":obj_ini.occulobe,
 			    	"mucranoid":obj_ini.mucranoid,
-			    	"membran":obj_ini.membrane,
+			    	"membrane":obj_ini.membrane,
 			    	"voice":obj_ini.voice,
-			};			
+			};
+			var mutation_names = struct_get_names(gene_seed_mutations)
+			for (var mute =0; mute <array_length(mutation_names); mute++){
+				if (gene_seed_mutations[$ mutation_names[mute]] == 0){
+					if(irandom(999)-10<obj_ini.stability){
+						gene_seed_mutations[$ mutation_names[mute]] = 1;
+					}
+				}
+			}
+			if (gene_seed_mutations[$ "voice"] == 0){
+				charisma-=2;
+			}
 			if (instance_exists(obj_controller)){
 				role_history = [[obj_ini.role[company,marine_number], obj_controller.turn]]; //marines_promotion and demotion history
 				marine_ascension = obj_controller.turn; // on what day did turn did this marine begin to exist
@@ -557,6 +571,26 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 			if (irandom(999)>998){
 				 add_trait("paragon");				//paragon chance just like cm
 			};
+			psionic = 0
+			var warp_level = irandom(299)+1{
+				if (warp_level<=190){
+					psionic=choose(0,1);
+				} else if(warp_level<=294){
+					psionic=choose(2,3,4,5,6,7);
+				}else if(warp_level<=297){
+					psionic=choose(8,9,10);
+				} else if(warp_level<=298){
+					psionic=choose(11,12);
+				} else if(warp_level<=299){
+					psionic=choose(11,12,13,14);
+				} else if warp_level<=300{
+					if(irandom(4)==4){
+						psionic=choose(15,16);
+					} else{
+						psionic=choose(13,14);
+					}
+				}
+			}
 			if (irandom(49)>48){
 				 add_trait("warp_touched");			//has phychic potential
 			};		
@@ -674,6 +708,8 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 						constitution += 4;
 						strength++;
 						dexterity--;						
+					}	else if (new_bionic_pos == "throat"){
+						charisma--;					
 					}else{ 
 						constitution++;
 					}

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -412,9 +412,9 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 	static hp = function(){ 
 		return obj_ini.hp[company,marine_number]; //return current health
 	};
-    static update_health = function(new_health){
-      obj_ini.hp[company,marine_number] = new_health;
-   };	
+  static update_health = function(new_health){
+    obj_ini.hp[company,marine_number] = new_health;
+  };	
 	static get_unit_size = function(){
 		var unit_role = role();
 		var arm = armour();

--- a/scripts/scr_save/scr_save.gml
+++ b/scripts/scr_save/scr_save.gml
@@ -76,6 +76,8 @@ function scr_save(save_slot,save_id) {
 	    ini_write_real("Controller","tau_messenger",obj_controller.tau_messenger);
 	    ini_write_real("Controller","fleet_all",obj_controller.fleet_all);
 	    ini_write_real("Controller","tolerant",obj_ini.tolerant);
+	    ini_write_real("Controller","stability",obj_ini.stability);
+	    ini_write_real("Controller","purity",obj_ini.purity);
 	    ini_write_real("Controller","unload",obj_controller.unload);
 	    ini_write_real("Controller","diplomacy",obj_controller.diplomacy);
 	    ini_write_real("Controller","trading",obj_controller.trading);

--- a/scripts/scr_save/scr_save.gml
+++ b/scripts/scr_save/scr_save.gml
@@ -862,7 +862,7 @@ function scr_save(save_slot,save_id) {
 	                ini_write_string("Mar","spe"+string(coh)+"."+string(mah),obj_ini.spe[coh,mah]);
 	                ini_write_real("Mar","god"+string(coh)+"."+string(mah),obj_ini.god[coh,mah]);
 					if (!is_struct(obj_ini.TTRPG[coh,mah])){
-						TTRPG[coh,mah]= {};
+						TTRPG[coh,mah]= new TTRPG_stats("chapter", company,i, "blank");
 					}
 					ini_write_string("Mar","Struct"+string(coh)+"."+string(mah),base64_encode(jsonify_marine_struct(coh,mah)));					
 	            }

--- a/scripts/scr_save/scr_save.gml
+++ b/scripts/scr_save/scr_save.gml
@@ -837,12 +837,9 @@ function scr_save(save_slot,save_id) {
 	            ini_write_string("Mar","mb"+string(coh)+"."+string(mah),obj_ini.mobi[coh,mah]);	
 	        }
 	    }
-	    good=0;coh=10;mah=400;
-	    repeat(4400){
-	        if (good=0){
-	            mah-=1;
-	            if (mah=0){mah=400;coh-=1;}
-	            if (obj_ini.name[coh,mah]!=""){
+	    for (coh=0;coh<=10;coh++){
+	        for (mah=0;mah<=500;mah++){
+	        	if (obj_ini.name[coh,mah] != "none"){
 	                ini_write_real("Mar","co"+string(coh)+"."+string(mah),obj_ini.race[coh,mah]);
 	                ini_write_string("Mar","lo"+string(coh)+"."+string(mah),obj_ini.loc[coh,mah]);
 	                ini_write_string("Mar","num"+string(coh)+"."+string(mah),obj_ini.name[coh,mah]);
@@ -857,18 +854,17 @@ function scr_save(save_slot,save_id) {
 	                ini_write_string("Mar","ge"+string(coh)+"."+string(mah),obj_ini.gear[coh,mah]);
 	                ini_write_string("Mar","mb"+string(coh)+"."+string(mah),obj_ini.mobi[coh,mah]);
 
-	                ini_write_real("Mar","hp"+string(coh)+"."+string(mah),obj_ini.hp[coh,mah]);
+	                ini_write_real("Mar","hp"+string(coh)+"."+string(mah),obj_ini.TTRPG[coh,mah].hp());
 	                ini_write_real("Mar","cha"+string(coh)+"."+string(mah),obj_ini.chaos[coh,mah]);
 	                ini_write_real("Mar","exp"+string(coh)+"."+string(mah),obj_ini.experience[coh,mah]);
 	                ini_write_real("Mar","ag"+string(coh)+"."+string(mah),obj_ini.age[coh,mah]);
 	                ini_write_string("Mar","spe"+string(coh)+"."+string(mah),obj_ini.spe[coh,mah]);
 	                ini_write_real("Mar","god"+string(coh)+"."+string(mah),obj_ini.god[coh,mah]);
 					if (!is_struct(obj_ini.TTRPG[coh,mah])){
-						TTRPG[coh,mah]= new TTRPG_stats("chapter", company,i, "blank");
+						TTRPG[coh,mah]= new TTRPG_stats("chapter", coh,mah, "blank");
 					}
-					ini_write_string("Mar","Struct"+string(coh)+"."+string(mah),base64_encode(jsonify_marine_struct(coh,mah)));					
-	            }
-	            if (coh=0) and (mah=1) then good=1;
+					ini_write_string("Mar","Struct"+string(coh)+"."+string(mah),base64_encode(jsonify_marine_struct(coh,mah)));
+				}	
 	        }
 	    }
 	    var squad_copies = [];

--- a/scripts/scr_squad_names/scr_squad_names.gml
+++ b/scripts/scr_squad_names/scr_squad_names.gml
@@ -1,0 +1,5 @@
+// Script assets have changed for v2.3.0 see
+// https://help.yoyogames.com/hc/en-us/articles/360005277377 for more information
+function scr_squad_names(){
+
+}

--- a/scripts/scr_squad_names/scr_squad_names.yy
+++ b/scripts/scr_squad_names/scr_squad_names.yy
@@ -1,0 +1,11 @@
+{
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "scr_squad_names",
+  "isCompatibility": false,
+  "isDnD": false,
+  "parent": {
+    "name": "Scripts",
+    "path": "folders/Scripts.yy",
+  },
+}

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -1,5 +1,5 @@
 
-/* okay so basically htis functions loops through a given company and attempts to sort the units in the company not in a squad already into 
+/* okay so basically this function loops through a given company and attempts to sort the units in the company not in a squad already into 
 the requested squad type , if the squad is not possible it will  not be made*/
 // squad_type: the type of squad to be created as a string to access the correct key in obj_ini.squad_types
 // company : the company you wish to create the squad in (int)
@@ -8,14 +8,22 @@ the requested squad type , if the squad is not possible it will  not be made*/
 
 function create_squad(squad_type, company, squad_loadout = true){
 	var squad_unit_types, fulfilled,unit, squad, squad_unit;
-
+	show_debug_message("1")
 	var squad_count = array_length(obj_ini.squads);
 	var fill_squad =  obj_ini.squad_types[$ squad_type];			//grab all the squad struct info from the squad_types struct
 	var squad_fulfilment = {};		
 	squad_unit_types = struct_get_names(fill_squad);		//find out what type of units squad consists of
-	for (var i = 0;i < array_length(squad_unit_types);i++){
+	var unit_type_count = array_length(squad_unit_types);		
+	for (var i = 0;i < unit_type_count;i++){
+		if (squad_unit_types[i] == "display_name"){
+			array_delete(squad_unit_types, i, 1);
+			unit_type_count--;
+			i--;
+			continue;
+		}	
 		squad_fulfilment[$ squad_unit_types[i]] =0;	//create a fulfilment structure to log members of squad
 	}
+	show_debug_message("2")
 	squad = new unit_squad(squad_type);
 	squad.base_company = company;
 	var sergeant_found = false;
@@ -24,8 +32,10 @@ function create_squad(squad_type, company, squad_loadout = true){
 	for (var s = 0; s< 2;s++){
 		if (struct_exists(squad_fulfilment ,sgt_types[s])){
 			sergeant_found = false;
-			for (i = 0; i < array_length(obj_ini.TTRPG[company]);i++){	
+			for (i = 0; i < array_length(obj_ini.TTRPG[company]);i++){
+				if(!is_struct(obj_ini.TTRPG[company,i])){obj_ini.TTRPG[company,i]= new TTRPG_stats("chapter", company,i,"blank");}
 				unit = obj_ini.TTRPG[company,i];
+				if ((obj_ini.name[company,i] =="") or (unit.base_group=="none"))then continue;
 				if (unit.squad== "none"){
 					if (unit.role() == sgt_types[s]){
 						squad_fulfilment[$ sgt_types[s]] += 1;
@@ -37,8 +47,11 @@ function create_squad(squad_type, company, squad_loadout = true){
 			}
 		}
 	}
-	for (i = 0; i < array_length( obj_ini.TTRPG[company]);i++){								//fill squad roles
+	show_debug_message("3")
+	for (i = 0; i < array_length( obj_ini.TTRPG[company]);i++){							//fill squad roles
+		if(!is_struct(obj_ini.TTRPG[company,i])){obj_ini.TTRPG[company,i]= new TTRPG_stats("chapter", company,i,"blank");}
 		unit = obj_ini.TTRPG[company,i];
+		if ((obj_ini.name[company,i] =="") or (unit.base_group=="none")) then continue;
 		if (unit.squad== "none") and (array_contains(squad_unit_types, unit.role())){
 			//if no sergeant found add one marine to standard marine selection so that a marine can be promoted
 			if ((struct_exists(squad_fulfilment ,obj_ini.role[100,18])) or (struct_exists(squad_fulfilment ,obj_ini.role[100,19]))) and (sergeant_found == false){
@@ -53,6 +66,7 @@ function create_squad(squad_type, company, squad_loadout = true){
 			}
 		}
 	}
+	show_debug_message("4")
 	//if a new sergeant is needed find the marine with the highest experience in the squad 
 	//(which if everything works right should be a marine with the old_guard, seasoned, or ancient trait)
 	/*and ((squad_fulfilment[$ obj_ini.role[100,8]] > 4)or (squad_fulfilment[$ obj_ini.role[100,10]] > 4) or (squad_fulfilment[$ obj_ini.role[100,9]] > 4)or (squad_fulfilment[$ obj_ini.role[100,3]] > 4) )*/
@@ -69,6 +83,7 @@ function create_squad(squad_type, company, squad_loadout = true){
 			squad_fulfilment[$ sgt_types[s]]++;
 		}
 	}
+	show_debug_message("5")
 	//evaluate if the minimum unit type requirements have been met to create a new squad
 	fulfilled = true;
 	for (i = 0;i < array_length(squad_unit_types);i++){
@@ -81,6 +96,9 @@ function create_squad(squad_type, company, squad_loadout = true){
 		for (var s = 0; s< 2;s++){
 			if (struct_exists(squad_fulfilment ,sgt_types[s])) and (sergeant_found == false){
 				exp_unit.update_role(sgt_types[s]); //if squad is viable promote marine to sergeant
+				if (irandom(1) == 0){
+					exp_unit.add_trait("lead_example");
+				}
 			}
 		}			
 		//update units squad marker
@@ -223,6 +241,7 @@ function unit_squad(squad_type) constructor{
 	members = [];
 	squad_fulfilment ={};
 	base_company = -1;
+	//nickname = scr_squad_names();
 
 	// for creating a new sergeant from existing squad members
 	static new_sergeant = function(veteran=false){
@@ -252,6 +271,9 @@ function unit_squad(squad_type) constructor{
 					new_role= obj_ini.role[100,18];
 				}
 				exp_unit.update_role(new_role);
+				if (irandom(1) == 0){
+					exp_unit.add_trait("lead_example");
+				}
 			}
 		}
 	}
@@ -262,9 +284,16 @@ function unit_squad(squad_type) constructor{
 		var unit;
 		squad_fulfilment ={};
 		var fill_squad =  obj_ini.squad_types[$ type];			//grab all the squad struct info from the squad_types struct
-		var squad_fulfilment = {};		
-		squad_unit_types = struct_get_names(fill_squad);		//find out what type of units squad consists of
-		for (var i = 0;i < array_length(squad_unit_types);i++){
+		var squad_fulfilment = {};
+		var squad_unit_types = struct_get_names(fill_squad);		//find out what type of units squad consists of
+		var unit_type_count = array_length(squad_unit_types);		
+		for (var i = 0;i < unit_type_count;i++){
+			if (squad_unit_types[i] == "display_name"){
+				array_delete(squad_unit_types, i, 1);
+				unit_type_count--;
+				i--;
+				continue;				
+			}
 			squad_fulfilment[$ squad_unit_types[i]] =0;	//create a fulfilment structure to log members of squad
 		}
 		var member_length = array_length(members);

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -8,7 +8,6 @@ the requested squad type , if the squad is not possible it will  not be made*/
 
 function create_squad(squad_type, company, squad_loadout = true){
 	var squad_unit_types, fulfilled,unit, squad, squad_unit;
-	show_debug_message("1")
 	var squad_count = array_length(obj_ini.squads);
 	var fill_squad =  obj_ini.squad_types[$ squad_type];			//grab all the squad struct info from the squad_types struct
 	var squad_fulfilment = {};		
@@ -23,7 +22,6 @@ function create_squad(squad_type, company, squad_loadout = true){
 		}	
 		squad_fulfilment[$ squad_unit_types[i]] =0;	//create a fulfilment structure to log members of squad
 	}
-	show_debug_message("2")
 	squad = new unit_squad(squad_type);
 	squad.base_company = company;
 	var sergeant_found = false;
@@ -47,7 +45,6 @@ function create_squad(squad_type, company, squad_loadout = true){
 			}
 		}
 	}
-	show_debug_message("3")
 	for (i = 0; i < array_length( obj_ini.TTRPG[company]);i++){							//fill squad roles
 		if(!is_struct(obj_ini.TTRPG[company,i])){obj_ini.TTRPG[company,i]= new TTRPG_stats("chapter", company,i,"blank");}
 		unit = obj_ini.TTRPG[company,i];
@@ -66,7 +63,6 @@ function create_squad(squad_type, company, squad_loadout = true){
 			}
 		}
 	}
-	show_debug_message("4")
 	//if a new sergeant is needed find the marine with the highest experience in the squad 
 	//(which if everything works right should be a marine with the old_guard, seasoned, or ancient trait)
 	/*and ((squad_fulfilment[$ obj_ini.role[100,8]] > 4)or (squad_fulfilment[$ obj_ini.role[100,10]] > 4) or (squad_fulfilment[$ obj_ini.role[100,9]] > 4)or (squad_fulfilment[$ obj_ini.role[100,3]] > 4) )*/
@@ -83,7 +79,6 @@ function create_squad(squad_type, company, squad_loadout = true){
 			squad_fulfilment[$ sgt_types[s]]++;
 		}
 	}
-	show_debug_message("5")
 	//evaluate if the minimum unit type requirements have been met to create a new squad
 	fulfilled = true;
 	for (i = 0;i < array_length(squad_unit_types);i++){

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -1,7 +1,8 @@
 function scr_ui_manage() {
-	var unit,i;
+	var unit,i, tool_tip_text,x1,x2,y1,y2, var_text;
 	var romanNumerals=scr_roman_numerals();	
-	var normal_hp=true;
+	var normal_hp=true, bionic_tooltip="",tool_tip_drawing=[];
+	var body_augmentations = {mutations:[], bionics:[]}
 	
 	// Declare non marine roles here
 	var non_marine_roles=[
@@ -94,6 +95,7 @@ function scr_ui_manage() {
 	    var cn=obj_controller;
 		
 	    if (instance_exists(cn)){
+	    	var selected_unit =  temp[120];				//unit struct
 	        if (cn.temp[101]!="") and (cn.temp[100]="1"){
 	            ui_arm[1]=true;
 				ui_arm[2]=true;
@@ -115,7 +117,6 @@ function scr_ui_manage() {
             
 	            var terg,armour_sprite,show1,show2;terg=0;armour_sprite=spr_weapon_blank;
 	            var jump,dev,hood,skull,arm,halo,braz,slow,brothers,body_part;jump=0;dev=0;hood=0;skull=0;arm=0;halo=0;braz=0;slow=0;brothers=-5;
-				var selected_unit =  temp[120];				//unit struct
             
 	            var show_wep1,show_wep2,show_arm,show_gear,show_mobi;
 	            /*show_wep1=string_pos("&",cn.temp[108]);
@@ -595,10 +596,12 @@ function scr_ui_manage() {
 					
 					// bionics
 					
-					if (!array_contains(["Dreadnought", "Terminator Armour", "Tartaros"], selected_unit.armour())){
-						for (body_part = 0; body_part<array_length(global.body_parts);body_part++){
-							if (struct_exists(selected_unit.body[$ global.body_parts[body_part]], "bionic")){
-
+					
+					for (body_part = 0; body_part<array_length(global.body_parts);body_part++){
+						if (struct_exists(selected_unit.body[$ global.body_parts[body_part]], "bionic")){
+							bionic_tooltip+=string("standard bionic {0}#",global.body_parts_display[body_part])
+							array_push(body_augmentations.bionics, body_part);
+							if (!array_contains(["Dreadnought", "Terminator Armour", "Tartaros"], selected_unit.armour())){
 								if (global.body_parts[body_part] == "left_eye") {
 									if (selected_unit.armour() == "MK3 Iron Armour"){
 										draw_sprite(spr_bionics_eye,0,xx+1203,yy+178)
@@ -615,8 +618,8 @@ function scr_ui_manage() {
 								};
 								if (global.body_parts[body_part] == "left_leg") {draw_sprite(spr_bionics_leg,1,xx+1208,yy+178)};
 								if (global.body_parts[body_part] == "right_leg") {draw_sprite(spr_bionics_leg,0,xx+1208,yy+178)};
-								if (global.body_parts[body_part] == "left_arm") {draw_sprite(spr_bionics_arm,0,xx+1208,yy+178)};
-								if (global.body_parts[body_part] == "right_arm") {draw_sprite(spr_bionics_arm,1,xx+1208,yy+178)};
+								if (global.body_parts[body_part] == "left_arm") {draw_sprite(spr_bionics_arm,1,xx+1208,yy+178)};
+								if (global.body_parts[body_part] == "right_arm") {draw_sprite(spr_bionics_arm,0,xx+1208,yy+178)};
 							}
 						}
 					}
@@ -750,20 +753,72 @@ function scr_ui_manage() {
         
 	        if (cn.temp[110]!="") then draw_text_ext(xx+1387,yy+345,string_hash_to_newline(string(cn.temp[110])+"#"+string(cn.temp[111])),-1,187);
 	        if (cn.temp[110]!="") then draw_text_ext(xx+1388,yy+346,string_hash_to_newline(string(cn.temp[110])),-1,187);
-        
 			// Display information on the marine
-	        if (cn.temp[112]!="") then draw_text(xx+1015,yy+420,string_hash_to_newline("Health: "+string(cn.temp[112])));
 	        if (cn.temp[113]!="") then draw_text(xx+1190,yy+420,string_hash_to_newline("Experience: "+string(cn.temp[113])));
-	        if (cn.temp[114]!="") then draw_text(xx+1365,yy+420,string_hash_to_newline("Bionics: "+string(cn.temp[114])));
-        
-	        draw_set_color(c_gray);if (ui_melee_penalty>0) then draw_set_color(c_red);
-	        if (cn.temp[116]!="") then draw_text(xx+1015,yy+442,string_hash_to_newline("Melee Attack: "+string(cn.temp[116])));
-        
-	        draw_set_color(c_gray);if (ui_ranged_penalty>0) then draw_set_color(c_red);
-	        if (cn.temp[117]!="") then draw_text(xx+1190,yy+442,string_hash_to_newline("Ranged Attack: "+string(cn.temp[117])));
-        
-	        draw_set_color(c_gray);
-	        if (cn.temp[118]!="") then draw_text(xx+1365,yy+442,string_hash_to_newline("Damage Resistance: "+string(cn.temp[118])));
+	      	if (cn.temp[114]!=""){
+        		var_text = string_hash_to_newline(string("Bionics: {0}",selected_unit.bionics()))
+	        	x1 = xx+1365;
+	        	y1 = yy+420;
+	        	x2 = x1+string_width(var_text);
+	        	y2 = y1+string_height(var_text);
+		        draw_set_color(c_gray);
+		        draw_text(x1,y1,var_text);
+		        if (bionic_tooltip !=""){
+		        	array_push(tool_tip_drawing, [bionic_tooltip, [x1,y1,x2,y2]]);
+		    	} else{
+		    		array_push(tool_tip_drawing, ["No bionic Augmentations", [x1,y1,x2,y2]]);
+		    	}
+	    	}
+
+        	if (cn.temp[112]!=""){
+        		var_text = string_hash_to_newline(string("Health: {0}",cn.temp[112]))
+	        	tool_tip_text = string_hash_to_newline(string("CON : {0}", selected_unit.constitution));
+	        	x1 = xx+1015;
+	        	y1 = yy+420;
+	        	x2 = x1+string_width(var_text);
+	        	y2 = y1+string_height(var_text);
+		        draw_set_color(c_gray);
+		        draw_text(x1,y1,var_text);
+		        array_push(tool_tip_drawing, [tool_tip_text, [x1,y1,x2,y2]]);
+	    	}	        
+        	
+        	if (cn.temp[116]!=""){
+        		var_text = string_hash_to_newline(string("Melee Attack: {0}",cn.temp[116]))
+	        	tool_tip_text = string_hash_to_newline(string("WS : {0}#STR : {1}", selected_unit.weapon_skill, selected_unit.strength));
+	        	x1 = xx+1015;
+	        	y1 = yy+442;
+	        	x2 = x1+string_width(var_text);
+	        	y2 = y1+string_height(var_text);
+		        draw_set_color(c_gray);
+		        if (ui_melee_penalty>0) then draw_set_color(c_red);
+		        draw_text(x1,y1,var_text);
+		        array_push(tool_tip_drawing, [tool_tip_text, [x1,y1,x2,y2]]);
+	    	}
+
+        	if (cn.temp[117]!=""){
+        		var_text = string_hash_to_newline(string("Ranged Attack: {0}",cn.temp[117]))
+	        	tool_tip_text = string_hash_to_newline(string("BS : {0}#DEX : {1}", selected_unit.ballistic_skill, selected_unit.dexterity));
+	        	x1 = xx+1190;
+	        	y1 = yy+442;
+	        	x2 = x1+string_width(var_text);
+	        	y2 = y1+string_height(var_text);
+		        draw_set_color(c_gray);
+		        if (ui_ranged_penalty>0) then draw_set_color(c_red);
+		        draw_text(x1,y1,var_text);
+		        array_push(tool_tip_drawing, [tool_tip_text, [x1,y1,x2,y2]]);
+	    	}	 
+
+        	if (cn.temp[118]!=""){
+        		var_text = string_hash_to_newline(string("Damage Resistance: {0}",cn.temp[118]))
+	        	tool_tip_text = string_hash_to_newline(string("CON : {0}", selected_unit.constitution));
+	        	x1 = xx+1365;
+	        	y1 = yy+442;
+	        	x2 = x1+string_width(var_text);
+	        	y2 = y1+string_height(var_text);
+		        draw_set_color(c_gray);
+		        draw_text(x1,y1,var_text);
+		        array_push(tool_tip_drawing, [tool_tip_text, [x1,y1,x2,y2]]);
+	    	}
         
 	        draw_set_font(fnt_40k_14i);
 	        if (cn.temp[119]!="") then draw_text(xx+1020,yy+468,string_hash_to_newline(string(cn.temp[119])));
@@ -780,7 +835,7 @@ function scr_ui_manage() {
 	        
 	    yy+=77;
 		
-
+	    var unit_specialism_option=false, spec_tip="", tool_tip_set=[];
 		var repetitions=min(man_max,man_see)
 	    for(var i=0; i<repetitions;i++){
 
@@ -793,7 +848,8 @@ function scr_ui_manage() {
 	        if (man[sel]="man"){
 				unit = display_unit[sel];
 				var unit_location = unit.marine_location();
-	            temp1=$"{unit.role()} {unit.name()}";
+	            temp1=unit.name_role();
+	            unit_specialism_option=false;
 	            // temp1=string(managing)+"."+string(ide[sel]);
             
 	            temp2=string(ma_loc[sel]);
@@ -968,8 +1024,26 @@ function scr_ui_manage() {
 	        if (man_sel[sel]==0) then draw_set_color(c_black);
 	        if (man_sel[sel]!=0) then draw_set_color(6052956);// was gray
 	        draw_rectangle(xx+25,yy+64,xx+974,yy+85,0);
-	        draw_set_color(c_gray);
-			draw_rectangle(xx+25,yy+64,xx+974,yy+85,1);
+
+	        //if unit has techmarine potential
+	        if (unit.technology>=35){
+	        	draw_set_color(c_red);
+	        	unit_specialism_option=true;
+	        	spec_tip = "Techmarine Potential";
+	        //if unit has librarian potential
+	    	} else if(array_contains(unit.traits, "warp_touched")){
+	    		spec_tip = "Librarium potential";
+	    		unit_specialism_option=true;
+	    		draw_set_color(c_blue);
+	    	}else{
+	    		draw_set_color(c_gray);
+	    	}
+	    	if (unit_specialism_option){
+	    		array_push(tool_tip_set, [spec_tip, [xx+25,yy+64,xx+974,yy+85]]);
+	    		draw_rectangle(xx+25+2,yy+64+2,xx+974-2,yy+85-2,1);
+	    	} else{
+				draw_rectangle(xx+25,yy+64,xx+974,yy+85,1);
+	    	}
 
 	        // Squads
 	        var sqi="";
@@ -1387,6 +1461,12 @@ function scr_ui_manage() {
 	            }
 	        }
 	    }
+	    //draws hover overs for specialist potential
+	    for (var i=0;i<array_length(tool_tip_set);i++){
+	    	if (point_in_rectangle(mouse_x, mouse_y, tool_tip_set[i][1][0],tool_tip_set[i][1][1],tool_tip_set[i][1][2],tool_tip_set[i][1][3])){
+	    		tool_tip_draw(mouse_x, mouse_y, tool_tip_set[i][0])
+	    	}
+	    }
     
 	    yy-=8;
     
@@ -1527,6 +1607,164 @@ function scr_ui_manage() {
     
     
 	    scr_scrollbar(974,172,1005,790,34,man_max,man_current);
+	    var tip, coords;
+		for (i=0;i < array_length(tool_tip_drawing); i++){
+			tip = tool_tip_drawing[i];
+			coords=tip[1];
+			if (point_in_rectangle(mouse_x, mouse_y, coords[0],coords[1],coords[2],coords[3])){
+		        	tool_tip_draw(coords[0],coords[3]+4, tip[0]);
+			}
+		}
+		if instance_exists(cn){
+			if (cn.temp[101]!="") and (cn.temp[100]="1"){
+		        if ((point_in_rectangle(mouse_x, mouse_y, xx+1208, yy+168, xx+1374, yy+409)) and (!instance_exists(obj_temp3)) and(!instance_exists(obj_popup))){
+		        	draw_set_color(0);
+		    		draw_rectangle(xx+1004,yy+519,xx+1576,yy+957,0);
+		    		var stat_x = xx+1004;
+		    		var stat_y = yy+519;
+		    		var stat_display = string_hash_to_newline($"DEX#{selected_unit.dexterity}");
+		    		tool_tip_draw(stat_x,stat_y, stat_display,2);
+		    		stat_x += string_width(stat_display)+3;
+
+		    		stat_display = string_hash_to_newline($"STR#{selected_unit.strength}");
+		    		tool_tip_draw(stat_x,stat_y, stat_display,2);
+		    		stat_x += string_width(stat_display)+3;
+
+		    		stat_display = string_hash_to_newline($"CON#{selected_unit.constitution}");
+		    		tool_tip_draw(stat_x,stat_y, stat_display,1);
+		    		stat_x += string_width(stat_display)+2;	    		
+
+		    		stat_display = string_hash_to_newline($"INT#{selected_unit.intelligence}");
+		    		tool_tip_draw(stat_x,stat_y, stat_display,2);
+		    		stat_x += string_width(stat_display)+3;
+
+		    		stat_display = string_hash_to_newline($"WIS#{selected_unit.wisdom}");
+		    		tool_tip_draw(stat_x,stat_y, stat_display,2);
+		    		stat_x += string_width(stat_display)+3;
+
+		    		stat_display = string_hash_to_newline($"FAI#{selected_unit.piety}");
+		    		tool_tip_draw(stat_x,stat_y, stat_display,2);
+		    		stat_x += string_width(stat_display)+3;
+
+		    		stat_display = string_hash_to_newline($"WS#{selected_unit.weapon_skill}");
+		    		tool_tip_draw(stat_x,stat_y, stat_display, 5);
+		    		stat_x += string_width(stat_display)+6;
+
+		    		stat_display = string_hash_to_newline($"BS#{selected_unit.ballistic_skill}");
+		    		tool_tip_draw(stat_x,stat_y, stat_display, 6);
+		    		stat_x += string_width(stat_display)+7;
+
+		    		stat_display = string_hash_to_newline($"LU#{selected_unit.luck}");
+		    		tool_tip_draw(stat_x,stat_y, stat_display, 5);
+		    		stat_x += string_width(stat_display)+6;
+
+		    		stat_display = string_hash_to_newline($"TEC#{selected_unit.technology}");
+		    		tool_tip_draw(stat_x,stat_y, stat_display,2);
+		    		stat_x += string_width(stat_display)+3;
+
+		    		stat_display = string_hash_to_newline($"CHA#{selected_unit.charisma}");
+		    		tool_tip_draw(stat_x,stat_y, stat_display,2);
+		    		stat_x += string_width(stat_display)+5;
+		    		draw_line(stat_x, yy+519, stat_x, yy+957);
+
+		    		draw_set_alpha(0)
+		    		draw_set_color(c_gray);
+
+		        	unit_data_string = selected_unit.name_role();
+		        	if (selected_unit.squad != "none"){
+		        		var chapter_role = ""
+		        		chapter_role += " of the ";
+		        		if (selected_unit.company > 0){
+		        			chapter_role += scr_convert_company_to_string(selected_unit.company);
+		        		} //else{chapter_role = "Command"}
+		        		chapter_role += string(" {0} {1}", selected_unit.squad, obj_ini.squad_types[$ obj_ini.squads[selected_unit.squad].type][$ "display_name"]) + "#";
+		        		unit_data_string += chapter_role
+
+		        		if (selected_unit.base_group == "astartes"){
+		        			unit_data_string += $"He is {selected_unit.age()}, first becoming a marine in {selected_unit.marine_ascension}#"
+		        		}
+
+		        		if (array_contains([obj_ini.role[100,18], obj_ini.role[100,19]], selected_unit.role())){
+		        			unit_data_string +="#";
+		        			if (selected_unit.charisma < 25){
+		        				unit_data_string+= "He is generally disliked by the members of his squad.";
+		        			}else if(selected_unit.charisma >39){
+		        				unit_data_string+= "He is liked grealty by the members of his squad.";
+		        			}
+		        			if (selected_unit.wisdom < 30){
+		        				unit_data_string+= "His squad generally are disatisfied with his tactical decisions";
+		        			} else if ((selected_unit.wisdom < 35) and (selected_unit.wisdom >=30)){
+		        				unit_data_string+= "His squad do not always have a positive veiw his tactical abilities.";
+		        			} else if (selected_unit.wisdom < 45){
+		        				unit_data_string+= "He is considered a good tactician.";
+		        			}
+		        			if (selected_unit.ballistic_skill+selected_unit.weapon_skill>80){
+		        				unit_data_string+= "He is respected by those under his command for his skill at arms.";
+		        			} else if (selected_unit.ballistic_skill+selected_unit.weapon_skill>100){
+		        				unit_data_string+= "He is revered by those under his command and many look to him fo inspiration.";
+		        			} else if(selected_unit.ballistic_skill+selected_unit.weapon_skill<70){
+		        				unit_data_string+= "His men tend to find his skills as a warrior lacking considereing his position";
+		        			}
+		        			else if (selected_unit.wisdom >= 45){
+		        				unit_data_string+= "His military mind has saved his squad many times.";
+		        			}
+		        			unit_data_string +="#";
+		        		}
+		       		} else {unit_data_string+="#"}
+		       		var unit_name = selected_unit.name();
+		       		if (selected_unit.religion != "none"){
+		       			unit_data_string += unit_name+string(" is a follower of the {0}",global.religions[$ selected_unit.religion][$ "name"])
+		       			if (selected_unit.religion_sub_cult != "none"){
+		       				unit_data_string += $", in particular a sub cult known as {selected_unit.religion_sub_cult}"
+		       			}
+		       			if ((selected_unit.piety > 25)and (selected_unit.piety <40)){
+		       				unit_data_string += " and is a close follower of the faith"
+		       			}else if(selected_unit.piety <= 25){
+		       				unit_data_string += " however does not put much stock in religion"
+		       			}else if(selected_unit.piety >= 40){
+		       				unit_data_string += " and is zealous in his worship"
+		       			}else if(selected_unit.piety >= 50){
+		       				unit_data_string += " and is fanatical in his worship"
+		       			}
+		       			unit_data_string+="#";
+		       		}
+		       		if (selected_unit.base_group == "astartes"){
+		       			var bionic_count = selected_unit.bionics();
+		       			if (bionic_count ==0){
+		       				unit_data_string+= unit_name + " has no bodily augmentations besides his astartes gene seed and organs #"
+		       			}else if(bionic_count ==1){
+		       				unit_data_string+= unit_name + string(" Has a bionic {0}#", global.body_parts_display[body_augmentations.bionics[0]])
+		       			}else if((bionic_count >1) and (bionic_count <4)){
+		       				unit_data_string+= unit_name + " Has some bionic replacements #"
+		       			}else if((bionic_count >5) and (bionic_count <8)){
+		       				unit_data_string+= unit_name + " Has many bionic replacements #"
+		       			}else if (bionic_count >8){
+		       				unit_data_string+= unit_name + " Is mostly machine having replaced most of his flesh with bionic repacements.#"
+		       			}
+			       		if (selected_unit.strength > 49){
+			       			unit_data_string+= unit_name + "s strength greatly exceeds that of the standard astartes allowing him to wield weapons that normally require two hands in one.#"
+			       		} 
+			       		if ((selected_unit.technology >=35) and (!array_contains(selected_unit.traits, "mars_trained"))){
+			       			unit_data_string +="displays a talent with technology that might make him suited to a role within the armentarium.#";
+			       		}		
+		       		}
+		       		unit_data_string += "#";
+
+		       		tool_tip_text = "Traits##";
+		       		for (i=0;i<array_length(selected_unit.traits);i++){
+		       			unit_data_string += string(global.trait_list[$ selected_unit.traits[i]].flavour_text, unit_name) +"#";
+		       			tool_tip_text += global.trait_list[$ selected_unit.traits[i]].display_name;
+		       			if (struct_exists(global.trait_list[$ selected_unit.traits[i]], "effect")){
+		       				tool_tip_text += global.trait_list[$ selected_unit.traits[i]].effect;
+		       			}
+		       			tool_tip_text +="#";
+		       		}
+		       		tool_tip_text = string_hash_to_newline(tool_tip_text);
+		       		tool_tip_draw(stat_x+2,stat_y, tool_tip_text);
+		       		tool_tip_draw(xx+25,yy+65, string_hash_to_newline(unit_data_string), 3, 0, 985, 17);
+		        }
+			}
+		}    
 	}
 	
 
@@ -1606,4 +1844,5 @@ function scr_ui_manage() {
 	    // draw_text_transformed(xx+488,yy+426,"Selection Size: "+string(man_size),0.4,0.4,0);
 	    scr_scrollbar(974,172,1005,790,34,ship_max,ship_current);
 	}
+
 }

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -2,7 +2,7 @@ function scr_ui_manage() {
 	var unit,i, tool_tip_text,x1,x2,y1,y2, var_text;
 	var romanNumerals=scr_roman_numerals();	
 	var normal_hp=true, bionic_tooltip="",tool_tip_drawing=[];
-	var body_augmentations = {mutations:[], bionics:[]}
+	var body_augmentations = {mutations:[], bionics:[[],[]]}
 	
 	// Declare non marine roles here
 	var non_marine_roles=[
@@ -20,7 +20,7 @@ function scr_ui_manage() {
 
 	// This is the draw script for showing the main management screen or individual company screens
 
-	if (menu=1) and (managing>0){
+	if (menu==1) and (managing>0){
 	    var xx=__view_get( e__VW.XView, 0 )+0, yy=__view_get( e__VW.YView, 0 )+0, bb="", img=0;
 
 	    // Draw BG
@@ -34,38 +34,53 @@ function scr_ui_manage() {
 	    var c=0,fx="",skin=obj_ini.skin_color;
 		
 		
-	    if (managing<=10) then c=managing;
-	    if (managing>20) then c=managing-10;
-		
-		if (managing >= 1) and (managing <=10) {
+	    if (managing>20){
+	    	c=managing-10;
+	    }else if (managing >= 1) and (managing <=10) {
 			fx= romanNumerals[managing - 1] + " Company";
+			c=managing;
+		} else {
+			switch(managing){
+				case 11:
+					fx="Headquarters"
+					break;
+				case 12:
+					fx="Apothecarion";
+					break;
+				case 13:
+					fx="Librarium";
+					break;
+				case 14:
+					fx="Reclusium";
+					break;
+				case 15:
+					fx="Armamentarium";
+					break;
+			}
 		}
-
-	    if (managing=11) then fx="Headquarters";
-	    if (managing=12) then fx="Apothecarion";
-	    if (managing=13) then fx="Librarium";
-	    if (managing=14) then fx="Reclusium";
-	    if (managing=15) then fx="Armamentarium";
 
 		// Draw the company followed by chapters name
 	    draw_text(xx+800,yy+74,string_hash_to_newline(string(fx)+", "+string(global.chapter_name)));
 
 		
 	    if (managing<=10){
-	        var bar_wid=0;
+	        var bar_wid=0,click_check, string_h;
 	        draw_set_alpha(0.25);
 	        if (obj_ini.company_title[managing]!="") then bar_wid=max(400,string_width(string_hash_to_newline(obj_ini.company_title[managing])));
 	        if (obj_ini.company_title[managing]="") then bar_wid=400;
-        
-	        draw_rectangle(xx+800-(bar_wid/2),yy+108,xx+800+(bar_wid/2),yy+100+string_height(string_hash_to_newline("LOL")),1);
+        	string_h = string_height(string_hash_to_newline("LOL"));
+	        draw_rectangle(xx+800-(bar_wid/2),yy+108,xx+800+(bar_wid/2),yy+100+string_h,1);
+	        click_check = scr_hit(xx+800-(bar_wid/2),yy+108,xx+800+(bar_wid/2),yy+100+string_h);
 	        obj_cursor.image_index=0;
-        
-	        if (scr_hit(xx+800-(bar_wid/2),yy+108,xx+800+(bar_wid/2),yy+100+string_height(string_hash_to_newline("LOL")))=false) and (mouse_left=1) and (cooldown<=0) then text_bar=0;
-	        if (scr_hit(xx+800-(bar_wid/2),yy+108,xx+800+(bar_wid/2),yy+100+string_height(string_hash_to_newline("LOL")))=true){
+	        if (!click_check) and (mouse_left==1) and (cooldown<=0){
+	         text_bar=0;
+	        }else if(click_check){
 	            obj_cursor.image_index=2;
             
-	            if (cooldown<=0) and (mouse_left=1) and (text_bar=0){
-	                cooldown=8000;text_bar=1;keyboard_string=obj_ini.company_title[managing];
+	            if (cooldown<=0) and (mouse_left==1) and (text_bar=0){
+	                cooldown=8000;
+	                text_bar=1;
+	                keyboard_string=obj_ini.company_title[managing];
 	            }
             
 	        }
@@ -95,8 +110,8 @@ function scr_ui_manage() {
 	    var cn=obj_controller;
 		
 	    if (instance_exists(cn)){
-	    	var selected_unit =  temp[120];				//unit struct
-	        if (cn.temp[101]!="") and (cn.temp[100]="1"){
+	    	var selected_unit = temp[120];				//unit struct
+	        if (cn.temp[101]!="") and (cn.temp[100]=="1"){
 	            ui_arm[1]=true;
 				ui_arm[2]=true;
 				
@@ -115,8 +130,8 @@ function scr_ui_manage() {
 	            var cpec;
 				cspec=obj_ini.col_special;
             
-	            var terg,armour_sprite,show1,show2;terg=0;armour_sprite=spr_weapon_blank;
-	            var jump,dev,hood,skull,arm,halo,braz,slow,brothers,body_part;jump=0;dev=0;hood=0;skull=0;arm=0;halo=0;braz=0;slow=0;brothers=-5;
+	            var terg=0,armour_sprite=spr_weapon_blank,show1,show2;
+	            var jump=0,dev=0,hood=0,skull=0,arm=0,halo=0,braz=0,slow=0,brothers=-5,body_part;
             
 	            var show_wep1,show_wep2,show_arm,show_gear,show_mobi;
 	            /*show_wep1=string_pos("&",cn.temp[108]);
@@ -147,10 +162,21 @@ function scr_ui_manage() {
 	                if (show_gear="Master Servo Arms") then mas=1;
                 
 	                if (mas=0){
-	                    if (cspec=0) or (cspec>1) then arm=1;if (cspec=1) then arm=0;
+	                    if (cspec=0) or (cspec>1) then arm=1;
+	                    if (cspec=1) then arm=0;
 	                }
 	                if (mas>0){
-	                    if (cspec=0) then arm=10;if (cspec=1) then arm=11;if (cspec>=2) then arm=12;
+	                	switch(cspec){
+	                		case 0:
+	                			arm=10;
+	                			break;
+	                		case 1:
+	                			arm=11;
+	                			break;
+	                		case 2:
+	                			arm=12;
+	                			break;	                				                			
+	                	}
 	                }
 	            }
             
@@ -219,7 +245,7 @@ function scr_ui_manage() {
 	                ui_specialist=0;
 	                if (ma_role[sel]=obj_ini.role[100,14]) then ui_specialist=1;// Chaplain
 	                if (ma_role[sel]=obj_ini.role[100,15]) then ui_specialist=3;// Apothecary
-	                if (ma_role[sel]=obj_ini.role[100,15]) and ((global.chapter_name="Blood Angels") or (obj_ini.progenitor=5)) then ui_specialist=4;// Sanguinary
+	                if (ma_role[sel]=obj_ini.role[100,15]) and ((global.chapter_name="Blood Angels") or (obj_ini.progenitor==5)) then ui_specialist=4;// Sanguinary
 	                if (ma_role[sel]=obj_ini.role[100,16]) then ui_specialist=5;// Techmarine
 	                if (ma_role[sel]=obj_ini.role[100,17]) then ui_specialist=7;// Librarian
 	                */
@@ -298,15 +324,15 @@ function scr_ui_manage() {
 	                //Rejoice!
 	                // draw_sprite(spr_marine_base,img,xx+1208,yy+178);
                 
-	                var clothing_style;clothing_style=3;
-	                if (global.chapter_name="Dark Angels") or (obj_ini.progenitor=1) then clothing_style=0;
-	                if (global.chapter_name="White Scars") or (obj_ini.progenitor=2) then clothing_style=1; 
-	                if (global.chapter_name="Space Wolves") or (obj_ini.progenitor=3) then clothing_style=2;
-	                if (global.chapter_name="Imperial Fists") or (obj_ini.progenitor=4) then clothing_style=0;
-	                if (global.chapter_name="Iron Hands") or (obj_ini.progenitor=6) then clothing_style=0;
-	                if (global.chapter_name="Salamanders") or (obj_ini.progenitor=8) then clothing_style=4;
-	                if (global.chapter_name="Raven Guard") or (obj_ini.progenitor=9) then clothing_style=0;
-	                if (global.chapter_name="Doom Benefactors") then clothing_style=4;
+	                var clothing_style=3;
+	                if (global.chapter_name=="Dark Angels") or (obj_ini.progenitor==1) then clothing_style=0;
+	                if (global.chapter_name=="White Scars") or (obj_ini.progenitor==2) then clothing_style=1; 
+	                if (global.chapter_name=="Space Wolves") or (obj_ini.progenitor==3) then clothing_style=2;
+	                if (global.chapter_name=="Imperial Fists") or (obj_ini.progenitor==4) then clothing_style=0;
+	                if (global.chapter_name=="Iron Hands") or (obj_ini.progenitor==6) then clothing_style=0;
+	                if (global.chapter_name=="Salamanders") or (obj_ini.progenitor==8) then clothing_style=4;
+	                if (global.chapter_name=="Raven Guard") or (obj_ini.progenitor==9) then clothing_style=0;
+	                if (global.chapter_name=="Doom Benefactors") then clothing_style=4;
                 
 	                // Determine Sprite
 	                if (skull=-50) then skull=1;
@@ -374,13 +400,13 @@ function scr_ui_manage() {
 						armour_sprite=spr_tartaros2_colors;
 						if (brothers>-5) then brothers=4;
 						if (hood=-50) then hood=8;
-						if (skull=1) then skull=3;
+						if (skull==1) then skull=3;
 					}
 	                if (show_arm="Terminator Armour"){
 						armour_sprite=spr_terminator2_colors;
 						if (brothers>-5) then brothers=5;
 						if (hood=-50) then hood=9;
-						if (skull=1) then skull=2;
+						if (skull==1) then skull=2;
 					}
 	                if (show_arm="Dreadnought") then armour_sprite=spr_dread_colors;
                 
@@ -401,7 +427,7 @@ function scr_ui_manage() {
 							if (brothers>-5) then brothers=5;
 							armour_sprite=spr_terminator2_colors;
 							if (hood=-50) then hood=9;
-							if (skull=1) then skull=2;
+							if (skull==1) then skull=2;
 						}
 	                    if (string_count("Dread",temp[102])>0) then armour_sprite=spr_dread_colors;
 	                }
@@ -441,56 +467,56 @@ function scr_ui_manage() {
                 
 	                // Draw the backpack
 	                if (ui_back=true) and (terg<5) and (temp[102]!=""){
-	                    if (cspec=0) then draw_sprite(armour_sprite,10,xx+1208,yy+178);
-	                    if (cspec=1) then draw_sprite(armour_sprite,11,xx+1208,yy+178);
+	                    if (cspec==0) then draw_sprite(armour_sprite,10,xx+1208,yy+178);
+	                    if (cspec==1) then draw_sprite(armour_sprite,11,xx+1208,yy+178);
 	                    if (cspec>=2) then draw_sprite(armour_sprite,12,xx+1208,yy+178);
 	                }
 	                if (ui_back=false) and (terg<5) and (temp[102]!=""){
-	                    if (jump=1){
-	                        if (cspec=0) then draw_sprite(spr_pack_jump,0,xx+1208,yy+178);
-	                        if (cspec=1) then draw_sprite(spr_pack_jump,1,xx+1208,yy+178);
+	                    if (jump==1){
+	                        if (cspec==0) then draw_sprite(spr_pack_jump,0,xx+1208,yy+178);
+	                        if (cspec==1) then draw_sprite(spr_pack_jump,1,xx+1208,yy+178);
 	                        if (cspec>=2) then draw_sprite(spr_pack_jump,2,xx+1208,yy+178);
 	                    }
-	                    if (dev=1){
-	                        if (cspec=0) then draw_sprite(spr_pack_devastator,0,xx+1208,yy+178);
-	                        if (cspec=1) then draw_sprite(spr_pack_devastator,1,xx+1208,yy+178);
+	                    if (dev==1){
+	                        if (cspec==0) then draw_sprite(spr_pack_devastator,0,xx+1208,yy+178);
+	                        if (cspec==1) then draw_sprite(spr_pack_devastator,1,xx+1208,yy+178);
 	                        if (cspec>=2) then draw_sprite(spr_pack_devastator,2,xx+1208,yy+178);
 	                    }
 	                }
                 
 	                if (braz=1) and (cn.temp[102]!="") and (blandify=0){
-	                    if (terg=0) then draw_sprite(spr_pack_brazier,0,xx+1208,yy+178);
+	                    if (terg==0) then draw_sprite(spr_pack_brazier,0,xx+1208,yy+178);
 	                    if (terg>0) then draw_sprite(spr_pack_brazier,1,xx+1206,yy+178);
 	                }
                 
 	                // Draw the Iron Halo
 	                if (halo=1) and (temp[102]!=""){var st;st=false;
-	                    if (hood=0) and (terg<1) and (temp[102]!="") and (ui_specialist=14) and ((obj_ini.progenitor=5) or (global.chapter_name="Blood Angels")) then st=true;
-	                    if (st=false) then draw_sprite(spr_gear_halo,0,xx+1208,yy+178);
+	                    if (hood==0) and (terg<1) and (temp[102]!="") and (ui_specialist=14) and ((obj_ini.progenitor=5) or (global.chapter_name="Blood Angels")) then st=true;
+	                    if (st==false) then draw_sprite(spr_gear_halo,0,xx+1208,yy+178);
 	                }
                 
 	                // Weapons for below arms
-	                if (ui_weapon[1]!=0) and (sprite_exists(ui_weapon[1])) and (ui_above[1]=false) and (fix_left<8){
-	                    if (ui_twoh[1]=false) and (ui_twoh[2]=false) then draw_sprite(ui_weapon[1],0,xx+1208+ui_xmod[1],yy+178+ui_ymod[1]);
-	                    if (ui_twoh[1]=true){
+	                if (ui_weapon[1]!=0) and (sprite_exists(ui_weapon[1])) and (ui_above[1]==false) and (fix_left<8){
+	                    if (ui_twoh[1]==false) and (ui_twoh[2]==false) then draw_sprite(ui_weapon[1],0,xx+1208+ui_xmod[1],yy+178+ui_ymod[1]);
+	                    if (ui_twoh[1]==true){
 	                        if (cspec<=1) then draw_sprite(ui_weapon[1],0,xx+1208+ui_xmod[1],yy+178+ui_ymod[1]);
 	                        if (cspec>=2) then draw_sprite(ui_weapon[1],3,xx+1208+ui_xmod[1],yy+178+ui_ymod[1]);
-	                        if (ui_force_both=true){
+	                        if (ui_force_both==true){
 	                            if (cspec<=1) then draw_sprite(ui_weapon[1],0,xx+1208+ui_xmod[1],yy+178+ui_ymod[1]);
 	                            if (cspec>=2) then draw_sprite(ui_weapon[1],1,xx+1208+ui_xmod[1],yy+178+ui_ymod[1]);
 	                        }
 	                    }
 	                }
-	                if (ui_weapon[2]!=0) and (ui_above[2]=false) and (sprite_exists(ui_weapon[2])) and ((ui_twoh[1]=false) or (ui_force_both=true)) and (fix_right<8){
-	                    if (ui_spec[2]=false) then draw_sprite(ui_weapon[2],1,xx+1208+ui_xmod[2],yy+178+ui_ymod[2]);
-	                    if (ui_spec[2]=true){
+	                if (ui_weapon[2]!=0) and (ui_above[2]==false) and (sprite_exists(ui_weapon[2])) and ((ui_twoh[1]==false) or (ui_force_both==true)) and (fix_right<8){
+	                    if (ui_spec[2]==false) then draw_sprite(ui_weapon[2],1,xx+1208+ui_xmod[2],yy+178+ui_ymod[2]);
+	                    if (ui_spec[2]==true){
 	                        if (cspec<=1) then draw_sprite(ui_weapon[2],2,xx+1208+ui_xmod[2],yy+178+ui_ymod[2]);
 	                        if (cspec>=2) then draw_sprite(ui_weapon[2],3,xx+1208+ui_xmod[2],yy+178+ui_ymod[2]);
 	                    }
 	                }
                 
-	                if (temp[102]="") or (temp[102]="None") or (temp[102]="(None)"){
-	                    if (ui_specialist=111) and (global.chapter_name="Doom Benefactors") then skin=6;
+	                if (temp[102]=="") or (temp[102]=="None") or (temp[102]=="(None)"){
+	                    if (ui_specialist==111) and (global.chapter_name=="Doom Benefactors") then skin=6;
                     
 	                    draw_sprite(spr_marine_base,skin,xx+1208,yy+178);
                     
@@ -504,48 +530,48 @@ function scr_ui_manage() {
 	                }
 	                if (temp[102]="MK3 Iron Armour"){
 	                    draw_sprite(armour_sprite,col_special,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec<=1) then draw_sprite(spr_iron2_colors,4,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec>=2) then draw_sprite(spr_iron2_colors,5,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec<=1) then draw_sprite(spr_iron2_colors,4,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec>=2) then draw_sprite(spr_iron2_colors,5,xx+1208,yy+178);
 	                }
 	                if (temp[102]="MK4 Maximus"){
 	                    draw_sprite(armour_sprite,cspec,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec<=1) then draw_sprite(spr_maximus_colors,4,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec>=2) then draw_sprite(spr_maximus_colors,5,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec<=1) then draw_sprite(spr_maximus_colors,4,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec>=2) then draw_sprite(spr_maximus_colors,5,xx+1208,yy+178);
 	                }
 	                if (temp[102]="MK5 Heresy"){
 	                    draw_sprite(armour_sprite,cspec,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec<=1) then draw_sprite(spr_heresy_colors,4,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec>=2) then draw_sprite(spr_heresy_colors,5,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec<=1) then draw_sprite(spr_heresy_colors,4,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec>=2) then draw_sprite(spr_heresy_colors,5,xx+1208,yy+178);
 	                }
 	                if (temp[102]="MK6 Corvus"){
 	                    draw_sprite(armour_sprite,cspec,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec<=1) then draw_sprite(spr_beakie_colors,4,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec>=2) then draw_sprite(spr_beakie_colors,5,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec<=1) then draw_sprite(spr_beakie_colors,4,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec>=2) then draw_sprite(spr_beakie_colors,5,xx+1208,yy+178);
 	                }
 	                if (temp[102]="MK7 Aquila") or (show_arm="Power Armour"){
 	                    draw_sprite(armour_sprite,cspec,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec<=1) then draw_sprite(spr_aquila_colors,4,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec>=2) then draw_sprite(spr_aquila_colors,5,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec<=1) then draw_sprite(spr_aquila_colors,4,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec>=2) then draw_sprite(spr_aquila_colors,5,xx+1208,yy+178);
 	                }
 	                if (temp[102]="MK8 Errant"){
 	                    draw_sprite(armour_sprite,cspec,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec<=1) then draw_sprite(spr_errant_colors,4,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec>=2) then draw_sprite(spr_errant_colors,5,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec<=1) then draw_sprite(spr_errant_colors,4,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec>=2) then draw_sprite(spr_errant_colors,5,xx+1208,yy+178);
 	                }
 	                if (show_arm="Artificer Armour"){
 	                    draw_sprite(armour_sprite,cspec,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec<=1) then draw_sprite(spr_artificer_colors,4,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec>=2) then draw_sprite(spr_artificer_colors,5,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec<=1) then draw_sprite(spr_artificer_colors,4,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec>=2) then draw_sprite(spr_artificer_colors,5,xx+1208,yy+178);
 	                }
 	                if (terg=2){
 	                    draw_sprite(armour_sprite,cspec,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec<=1) then draw_sprite(spr_tartaros2_colors,4,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec>=2) then draw_sprite(spr_tartaros2_colors,5,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec<=1) then draw_sprite(spr_tartaros2_colors,4,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec>=2) then draw_sprite(spr_tartaros2_colors,5,xx+1208,yy+178);
 	                }
 	                if (terg=1){
 	                    draw_sprite(armour_sprite,cspec,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec<=1) then draw_sprite(spr_terminator2_colors,4,xx+1208,yy+178);
-	                    if (ttrim=0) and (cspec>=2) then draw_sprite(spr_terminator2_colors,5,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec<=1) then draw_sprite(spr_terminator2_colors,4,xx+1208,yy+178);
+	                    if (ttrim==0) and (cspec>=2) then draw_sprite(spr_terminator2_colors,5,xx+1208,yy+178);
 	                }
 	                if (terg=5){
 	                    draw_sprite(spr_dread_colors,cspec,xx+1208,yy+178);
@@ -581,7 +607,7 @@ function scr_ui_manage() {
 	                    }
 	                    if (yep=1) and (hood<7){
 	                        if (ttrim=1) then draw_sprite(spr_gear_hood2,0,xx+1206,yy+167);
-	                        if (ttrim=0) then draw_sprite(spr_gear_hood2,1,xx+1206,yy+167);
+	                        if (ttrim==0) then draw_sprite(spr_gear_hood2,1,xx+1206,yy+167);
 	                    }
 	                }
 					//Chaplain head and Terminator version
@@ -599,8 +625,9 @@ function scr_ui_manage() {
 					
 					for (body_part = 0; body_part<array_length(global.body_parts);body_part++){
 						if (struct_exists(selected_unit.body[$ global.body_parts[body_part]], "bionic")){
-							bionic_tooltip+=string("standard bionic {0}#",global.body_parts_display[body_part])
-							array_push(body_augmentations.bionics, body_part);
+							bionic_tooltip+=string("standard bionic {0}#",global.body_parts_display[body_part]);
+							array_push(body_augmentations.bionics[0], body_part);
+							array_push(body_augmentations.bionics[1], global.body_parts[body_part]);
 							if (!array_contains(["Dreadnought", "Terminator Armour", "Tartaros"], selected_unit.armour())){
 								if (global.body_parts[body_part] == "left_eye") {
 									if (selected_unit.armour() == "MK3 Iron Armour"){
@@ -625,7 +652,7 @@ function scr_ui_manage() {
 					}
                 
 	                // Honor Guard Helm
-	                if (hood=0) and (terg<1) and (temp[102]!="") and (ui_specialist=14){
+	                if (hood==0) and (terg<1) and (temp[102]!="") and (ui_specialist==14){
 	                    var helm_ii,o,yep;
                     	helm_ii=0;
 	                    if (obj_ini.progenitor=7) or (global.chapter_name="Ultramarines") then helm_ii=1;
@@ -640,7 +667,7 @@ function scr_ui_manage() {
 						for(var q=1; q<=4;q++){
 							if (obj_ini.dis[q]="Never Forgive") then yep=1;
 						}
-						if (yep=1) or (obj_ini.progenitor=1) then helm_ii=3;
+						if (yep=1) or (obj_ini.progenitor==1) then helm_ii=3;
 	                    yep=0;
 						for(var r=1; r<=4;r++){
 							if (obj_ini.adv[r]="Reverent Guardians") then yep=1;
@@ -845,7 +872,7 @@ function scr_ui_manage() {
 
 			eventing=false;
         
-	        if (man[sel]="man"){
+	        if (man[sel]=="man"){
 				unit = display_unit[sel];
 				var unit_location = unit.marine_location();
 	            temp1=unit.name_role();
@@ -1026,16 +1053,40 @@ function scr_ui_manage() {
 	        draw_rectangle(xx+25,yy+64,xx+974,yy+85,0);
 
 	        //if unit has techmarine potential
-	        if (unit.technology>=35){
-	        	draw_set_color(c_red);
-	        	unit_specialism_option=true;
-	        	spec_tip = "Techmarine Potential";
-	        //if unit has librarian potential
-	    	} else if(array_contains(unit.traits, "warp_touched")){
-	    		spec_tip = "Librarium potential";
-	    		unit_specialism_option=true;
-	    		draw_set_color(c_blue);
-	    	}else{
+	        unit_specialism_option=false;
+	        if (man[sel]="man"){
+	        	if (!is_specialist(unit.role())){
+			        if (unit.technology>=35){
+			        	draw_set_color(c_orange);
+			        	unit_specialism_option=true;
+			        	spec_tip = $"{obj_ini.role[100,16]} Potential";
+			        //if unit has librarian potential
+			    	} else if (unit.psionic>7){
+			    		spec_tip = "Librarium potential";
+			    		unit_specialism_option=true;
+			    		draw_set_color(c_aqua);
+			    	}else if (unit.piety>=35){
+			    		spec_tip = $"{obj_ini.role[100,15]} potential";
+			    		unit_specialism_option=true;
+			    		draw_set_color(c_olive);
+			    	}else if (unit.technology>=30) and (unit.intelligence>=45){
+			    		spec_tip = $"{obj_ini.role[100,14]} potential";
+			    		unit_specialism_option=true;
+			    		draw_set_color(c_fuchsia);
+			    	}
+		    	} else{
+		    		unit_specialism_option=true;
+		    		if (array_contains(["Lexicanum", "Codiciery",obj_ini.role[100,17], string("Chief {0}",obj_ini.role[100,17])], unit.role())){
+		    			draw_set_color(c_blue);
+		    		} else if(array_contains(["Forge Master",obj_ini.role[100,16]],unit.role())){
+		    			draw_set_color(c_maroon);
+		    		} else if(array_contains([obj_ini.role[100,15],"Master of the Apothecarion"],unit.role())){
+		    			draw_set_color(c_red);
+		    		} else if(array_contains([obj_ini.role[100,14],"Master of Sanctity"],unit.role())){
+		    			draw_set_color(c_teal);
+		    		}
+		    	}
+	    	} else {
 	    		draw_set_color(c_gray);
 	    	}
 	    	if (unit_specialism_option){
@@ -1616,7 +1667,7 @@ function scr_ui_manage() {
 			}
 		}
 		if instance_exists(cn){
-			if (cn.temp[101]!="") and (cn.temp[100]="1"){
+			if (cn.temp[101]!="") and (cn.temp[100]=="1"){
 		        if ((point_in_rectangle(mouse_x, mouse_y, xx+1208, yy+168, xx+1374, yy+409)) and (!instance_exists(obj_temp3)) and(!instance_exists(obj_popup))){
 		        	draw_set_color(0);
 		    		draw_rectangle(xx+1004,yy+519,xx+1576,yy+957,0);
@@ -1624,6 +1675,8 @@ function scr_ui_manage() {
 		    		var stat_y = yy+519;
 		    		var stat_display = string_hash_to_newline($"DEX#{selected_unit.dexterity}");
 		    		tool_tip_draw(stat_x,stat_y, stat_display,2);
+		    		tool_tip_draw(stat_x,stat_y+string_height(stat_display)+6,$"Warp Level:{selected_unit.psionic}");
+
 		    		stat_x += string_width(stat_display)+3;
 
 		    		stat_display = string_hash_to_newline($"STR#{selected_unit.strength}");
@@ -1671,6 +1724,10 @@ function scr_ui_manage() {
 		    		draw_set_color(c_gray);
 
 		        	unit_data_string = selected_unit.name_role();
+		        	var is_astartes = false;
+		        	if(selected_unit.base_group == "astartes"){
+		        		var is_astartes = true;
+		        	}
 		        	if (selected_unit.squad != "none"){
 		        		var chapter_role = ""
 		        		chapter_role += " of the ";
@@ -1726,27 +1783,130 @@ function scr_ui_manage() {
 		       			}else if(selected_unit.piety >= 50){
 		       				unit_data_string += " and is fanatical in his worship"
 		       			}
-		       			unit_data_string+="#";
+		       			unit_data_string+="##";
 		       		}
-		       		if (selected_unit.base_group == "astartes"){
+		       		unit_data_string += $"{unit_name} Has a Imperial Assignment: Positive Psionic Level value of {global.phy_levels[selected_unit.psionic]} ";
+		       		var is_lib = array_contains(["Lexicanum", "Codiciery",obj_ini.role[100,17]], selected_unit.role());
+		       		if (selected_unit.psionic<2){
+		       			unit_data_string += "as such has almost no presence in the warp";
+		       		} else if(selected_unit.psionic<8){
+		       			unit_data_string += "and has a limited presence in the warp causing them to be more prone to attacks from the immaterium";
+		       		} else if(selected_unit.psionic<11){
+		       			unit_data_string += "And is therefore considered a low level psyker with Conscious levels of psionic talent.";
+		       			if (is_astartes){
+			       			if (!is_lib){
+			       				unit_data_string += " He would be eligible for a role in the Librarium however is unlikely to ever exceed the role of Lexicanum";
+			       			}
+		       			}
+		       		}else if(selected_unit.psionic<13){
+		       			unit_data_string += "and has a very high level of mental psychic activity, making them a potent psyker, their presence in the warp is obvious to the daemons of the immaterium"
+		       			if (is_astartes){
+			       			if (!is_lib){
+			       				unit_data_string += " He would be eligible for a role in the Librarium capable of wielding his power to good effect";
+			       			}
+		       			}
+		       		}else if(selected_unit.psionic<15){
+		       			unit_data_string += "Occurring in approximately one-per-billion human births, they are a very potent psyker."
+		       			if (is_astartes){
+			       			if (!is_lib){
+			       				unit_data_string += " He would be eligible for a role in the Librarium And should be enrolled at once in order to train his abilities and stop his untrained mind causing damage to the chapter";
+			       			} else {
+			       				unit_data_string += " His rare talent is of great benefit to the chapter and could one day be a candidate for Chief of the librariam"
+			       			}
+		       			}		       				       			
+		       		} else if(selected_unit.psionic<15){
+		       			unit_data_string += "Exceedingly rare and dangerous but unfathomably powerful."
+		       			if (is_astartes){
+		       				unit_data_string += " Their Talents are both a great boon and huge risk to the chapter."
+			       			if (!is_lib){
+			       				unit_data_string += " He must brought into the guided sphere of the librarium immediately or else dealt with by other methods for the good of the chapter";
+			       			} else {
+			       				unit_data_string += " His rare talent is of great benefit to the chapter and will likely one day be a candidate for Chief of the librariam if he does not succumb to either the material or immaterium"
+			       			}
+		       			}
+		       		}
+		       		unit_data_string += "##"
+		       		if (is_astartes){
 		       			var bionic_count = selected_unit.bionics();
 		       			if (bionic_count ==0){
 		       				unit_data_string+= unit_name + " has no bodily augmentations besides his astartes gene seed and organs #"
 		       			}else if(bionic_count ==1){
-		       				unit_data_string+= unit_name + string(" Has a bionic {0}#", global.body_parts_display[body_augmentations.bionics[0]])
+		       				unit_data_string+= unit_name + string(" Has a bionic {0}#", global.body_parts_display[body_augmentations.bionics[0][0]])
 		       			}else if((bionic_count >1) and (bionic_count <4)){
 		       				unit_data_string+= unit_name + " Has some bionic replacements #"
 		       			}else if((bionic_count >5) and (bionic_count <8)){
 		       				unit_data_string+= unit_name + " Has many bionic replacements #"
 		       			}else if (bionic_count >8){
-		       				unit_data_string+= unit_name + " Is mostly machine having replaced most of his flesh with bionic repacements.#"
+		       				unit_data_string+= unit_name + " Is mostly machine having replaced most of his flesh with bionic replacements."
 		       			}
+		       			if (array_contains(body_augmentations.bionics[1], "throat")){
+		       				unit_data_string+="People tend to find the sound from his augmetic throat unnerving"
+		       			}
+
+		       			unit_data_string+="#";
+
+		       			var mutation_names = struct_get_names(selected_unit.gene_seed_mutations);
+		       			var pure_seed =true;
+		       			var mutation_string = unit_name + " has an impure gene seed."
+						for (var mute =0; mute <array_length(mutation_names); mute++){
+							if (selected_unit.gene_seed_mutations[$ mutation_names[mute]] == 1){
+								pure_seed = false;
+								switch(mutation_names[mute]){
+									case "preomnor":
+										mutation_string += "He lacks the detoxifying gland called the Preomnor- he is more susceptible to poisons and toxins,";
+										break;
+									case "lyman":
+										mutation_string += "Lacks a working Lyman's ear, And therefore struggles with deep strikes and certain other actions";
+										break;
+									case "omophagea":
+										mutation_string += "suffers from a faulty Omophagea,";
+										break;
+									case "ossmodula":
+										mutation_string += "suffers from a faulty Ossmodula, and takes longer to heal from injuries,";
+										break;
+									case "zygote":
+										mutation_string +="One of his Zygotes is faulty or missing.";
+										break;
+									case "betchers":
+										mutation_string +="He is missing his Betchers Gland and therefore cannot spit acid.";
+										break;
+									case "catalepsean":
+										mutation_string +="He has a faulty Catalepsean Node reducing his awareness when tired.";
+										break;
+									case "occulobe":
+										mutation_string += "He suffers from a faulty occulobe limiting his eyesight enhancements.";
+										break;
+									case "mucranoid":
+										mutation_string += "He suffers from a faulty mucranoid reducing his resistance to extreme heat and cold.";
+										break;
+									case "membrane":
+										mutation_string += "He cannot properly activate his Sus-an Membrane, this limits his ability to survive mortal wounds";
+										break;
+									case "voice":
+										mutation_string += "the marine implantation process caused his voice to warp and now produces a sound that the average member of the Imperium finds unnerving to hear.";
+								}
+							}
+						}
+						if (pure_seed){
+							unit_data_string += "Has a pure gene seed suffering no mutations";
+						} else{
+							unit_data_string += mutation_string;
+						}
+		       			unit_data_string+="#";
 			       		if (selected_unit.strength > 49){
 			       			unit_data_string+= unit_name + "s strength greatly exceeds that of the standard astartes allowing him to wield weapons that normally require two hands in one.#"
 			       		} 
-			       		if ((selected_unit.technology >=35) and (!array_contains(selected_unit.traits, "mars_trained"))){
-			       			unit_data_string +="displays a talent with technology that might make him suited to a role within the armentarium.#";
-			       		}		
+			       		if ((selected_unit.technology >=35) and (selected_unit.technology<45)){
+			       			if(!array_contains(selected_unit.traits, "mars_trained")){
+			       				unit_data_string +="displays a talent with technology that might make him suited to a role within the armentarium.#";
+			       			}
+			       		} else if(selected_unit.technology >= 45){
+			       			unit_data_string +="Is a technological prodigy able to understand and build most anything that takes his interest.#";
+			       		} else if (selected_unit.technology <25){
+			       			unit_data_string +="Is a technological luddite capable of little more than cleaning his own bolter.#";
+			       		} else if (selected_unit.technology <35){
+			       			unit_data_string +="Is capable enough with technical skills to carry out basic tasks in the field.#";
+			       		}
 		       		}
 		       		unit_data_string += "#";
 
@@ -1761,7 +1921,7 @@ function scr_ui_manage() {
 		       		}
 		       		tool_tip_text = string_hash_to_newline(tool_tip_text);
 		       		tool_tip_draw(stat_x+2,stat_y, tool_tip_text);
-		       		tool_tip_draw(xx+25,yy+65, string_hash_to_newline(unit_data_string), 3, 0, 985, 17);
+		       		tool_tip_draw(xx+25,yy+65, string_hash_to_newline(unit_data_string), 3, 0, 975, 17);
 		        }
 			}
 		}    

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -1,7 +1,7 @@
 function scr_ui_manage() {
-	var unit,i, tool_tip_text,x1,x2,y1,y2, var_text;
+	var unit,i, tooltip_text,x1,x2,y1,y2, var_text;
 	var romanNumerals=scr_roman_numerals();	
-	var normal_hp=true, bionic_tooltip="",tool_tip_drawing=[];
+	var normal_hp=true, bionic_tooltip="",tooltip_drawing=[];
 	var body_augmentations = {mutations:[], bionics:[[],[]]}
 	
 	// Declare non marine roles here
@@ -791,27 +791,27 @@ function scr_ui_manage() {
 		        draw_set_color(c_gray);
 		        draw_text(x1,y1,var_text);
 		        if (bionic_tooltip !=""){
-		        	array_push(tool_tip_drawing, [bionic_tooltip, [x1,y1,x2,y2]]);
+		        	array_push(tooltip_drawing, [bionic_tooltip, [x1,y1,x2,y2]]);
 		    	} else{
-		    		array_push(tool_tip_drawing, ["No bionic Augmentations", [x1,y1,x2,y2]]);
+		    		array_push(tooltip_drawing, ["No bionic Augmentations", [x1,y1,x2,y2]]);
 		    	}
 	    	}
 
         	if (cn.temp[112]!=""){
         		var_text = string_hash_to_newline(string("Health: {0}",cn.temp[112]))
-	        	tool_tip_text = string_hash_to_newline(string("CON : {0}", selected_unit.constitution));
+	        	tooltip_text = string_hash_to_newline(string("CON : {0}", selected_unit.constitution));
 	        	x1 = xx+1015;
 	        	y1 = yy+420;
 	        	x2 = x1+string_width(var_text);
 	        	y2 = y1+string_height(var_text);
 		        draw_set_color(c_gray);
 		        draw_text(x1,y1,var_text);
-		        array_push(tool_tip_drawing, [tool_tip_text, [x1,y1,x2,y2]]);
+		        array_push(tooltip_drawing, [tooltip_text, [x1,y1,x2,y2]]);
 	    	}	        
         	
         	if (cn.temp[116]!=""){
         		var_text = string_hash_to_newline(string("Melee Attack: {0}",cn.temp[116]))
-	        	tool_tip_text = string_hash_to_newline(string("WS : {0}#STR : {1}", selected_unit.weapon_skill, selected_unit.strength));
+	        	tooltip_text = string_hash_to_newline(string("WS : {0}#STR : {1}", selected_unit.weapon_skill, selected_unit.strength));
 	        	x1 = xx+1015;
 	        	y1 = yy+442;
 	        	x2 = x1+string_width(var_text);
@@ -819,12 +819,12 @@ function scr_ui_manage() {
 		        draw_set_color(c_gray);
 		        if (ui_melee_penalty>0) then draw_set_color(c_red);
 		        draw_text(x1,y1,var_text);
-		        array_push(tool_tip_drawing, [tool_tip_text, [x1,y1,x2,y2]]);
+		        array_push(tooltip_drawing, [tooltip_text, [x1,y1,x2,y2]]);
 	    	}
 
         	if (cn.temp[117]!=""){
         		var_text = string_hash_to_newline(string("Ranged Attack: {0}",cn.temp[117]))
-	        	tool_tip_text = string_hash_to_newline(string("BS : {0}#DEX : {1}", selected_unit.ballistic_skill, selected_unit.dexterity));
+	        	tooltip_text = string_hash_to_newline(string("BS : {0}#DEX : {1}", selected_unit.ballistic_skill, selected_unit.dexterity));
 	        	x1 = xx+1190;
 	        	y1 = yy+442;
 	        	x2 = x1+string_width(var_text);
@@ -832,19 +832,19 @@ function scr_ui_manage() {
 		        draw_set_color(c_gray);
 		        if (ui_ranged_penalty>0) then draw_set_color(c_red);
 		        draw_text(x1,y1,var_text);
-		        array_push(tool_tip_drawing, [tool_tip_text, [x1,y1,x2,y2]]);
+		        array_push(tooltip_drawing, [tooltip_text, [x1,y1,x2,y2]]);
 	    	}	 
 
         	if (cn.temp[118]!=""){
         		var_text = string_hash_to_newline(string("Damage Resistance: {0}",cn.temp[118]))
-	        	tool_tip_text = string_hash_to_newline(string("CON : {0}", selected_unit.constitution));
+	        	tooltip_text = string_hash_to_newline(string("CON : {0}", selected_unit.constitution));
 	        	x1 = xx+1365;
 	        	y1 = yy+442;
 	        	x2 = x1+string_width(var_text);
 	        	y2 = y1+string_height(var_text);
 		        draw_set_color(c_gray);
 		        draw_text(x1,y1,var_text);
-		        array_push(tool_tip_drawing, [tool_tip_text, [x1,y1,x2,y2]]);
+		        array_push(tooltip_drawing, [tooltip_text, [x1,y1,x2,y2]]);
 	    	}
         
 	        draw_set_font(fnt_40k_14i);
@@ -862,7 +862,7 @@ function scr_ui_manage() {
 	        
 	    yy+=77;
 		
-	    var unit_specialism_option=false, spec_tip="", tool_tip_set=[];
+	    var unit_specialism_option=false, spec_tip="", tooltip_set=[];
 		var repetitions=min(man_max,man_see)
 	    for(var i=0; i<repetitions;i++){
 
@@ -1090,7 +1090,7 @@ function scr_ui_manage() {
 	    		draw_set_color(c_gray);
 	    	}
 	    	if (unit_specialism_option){
-	    		array_push(tool_tip_set, [spec_tip, [xx+25,yy+64,xx+974,yy+85]]);
+	    		array_push(tooltip_set, [spec_tip, [xx+25,yy+64,xx+974,yy+85]]);
 	    		draw_rectangle(xx+25+2,yy+64+2,xx+974-2,yy+85-2,1);
 	    	} else{
 				draw_rectangle(xx+25,yy+64,xx+974,yy+85,1);
@@ -1513,9 +1513,9 @@ function scr_ui_manage() {
 	        }
 	    }
 	    //draws hover overs for specialist potential
-	    for (var i=0;i<array_length(tool_tip_set);i++){
-	    	if (point_in_rectangle(mouse_x, mouse_y, tool_tip_set[i][1][0],tool_tip_set[i][1][1],tool_tip_set[i][1][2],tool_tip_set[i][1][3])){
-	    		tool_tip_draw(mouse_x, mouse_y, tool_tip_set[i][0])
+	    for (var i=0;i<array_length(tooltip_set);i++){
+	    	if (point_in_rectangle(mouse_x, mouse_y, tooltip_set[i][1][0],tooltip_set[i][1][1],tooltip_set[i][1][2],tooltip_set[i][1][3])){
+	    		tooltip_draw(mouse_x, mouse_y, tooltip_set[i][0])
 	    	}
 	    }
     
@@ -1659,11 +1659,11 @@ function scr_ui_manage() {
     
 	    scr_scrollbar(974,172,1005,790,34,man_max,man_current);
 	    var tip, coords;
-		for (i=0;i < array_length(tool_tip_drawing); i++){
-			tip = tool_tip_drawing[i];
+		for (i=0;i < array_length(tooltip_drawing); i++){
+			tip = tooltip_drawing[i];
 			coords=tip[1];
 			if (point_in_rectangle(mouse_x, mouse_y, coords[0],coords[1],coords[2],coords[3])){
-		        	tool_tip_draw(coords[0],coords[3]+4, tip[0]);
+		        	tooltip_draw(coords[0],coords[3]+4, tip[0]);
 			}
 		}
 		if instance_exists(cn){
@@ -1674,49 +1674,49 @@ function scr_ui_manage() {
 		    		var stat_x = xx+1004;
 		    		var stat_y = yy+519;
 		    		var stat_display = string_hash_to_newline($"DEX#{selected_unit.dexterity}");
-		    		tool_tip_draw(stat_x,stat_y, stat_display,2);
-		    		tool_tip_draw(stat_x,stat_y+string_height(stat_display)+6,$"Warp Level:{selected_unit.psionic}");
+		    		tooltip_draw(stat_x,stat_y, stat_display,2);
+		    		tooltip_draw(stat_x,stat_y+string_height(stat_display)+6,$"Warp Level:{selected_unit.psionic}");
 
 		    		stat_x += string_width(stat_display)+3;
 
 		    		stat_display = string_hash_to_newline($"STR#{selected_unit.strength}");
-		    		tool_tip_draw(stat_x,stat_y, stat_display,2);
+		    		tooltip_draw(stat_x,stat_y, stat_display,2);
 		    		stat_x += string_width(stat_display)+3;
 
 		    		stat_display = string_hash_to_newline($"CON#{selected_unit.constitution}");
-		    		tool_tip_draw(stat_x,stat_y, stat_display,1);
+		    		tooltip_draw(stat_x,stat_y, stat_display,1);
 		    		stat_x += string_width(stat_display)+2;	    		
 
 		    		stat_display = string_hash_to_newline($"INT#{selected_unit.intelligence}");
-		    		tool_tip_draw(stat_x,stat_y, stat_display,2);
+		    		tooltip_draw(stat_x,stat_y, stat_display,2);
 		    		stat_x += string_width(stat_display)+3;
 
 		    		stat_display = string_hash_to_newline($"WIS#{selected_unit.wisdom}");
-		    		tool_tip_draw(stat_x,stat_y, stat_display,2);
+		    		tooltip_draw(stat_x,stat_y, stat_display,2);
 		    		stat_x += string_width(stat_display)+3;
 
 		    		stat_display = string_hash_to_newline($"FAI#{selected_unit.piety}");
-		    		tool_tip_draw(stat_x,stat_y, stat_display,2);
+		    		tooltip_draw(stat_x,stat_y, stat_display,2);
 		    		stat_x += string_width(stat_display)+3;
 
 		    		stat_display = string_hash_to_newline($"WS#{selected_unit.weapon_skill}");
-		    		tool_tip_draw(stat_x,stat_y, stat_display, 5);
+		    		tooltip_draw(stat_x,stat_y, stat_display, 5);
 		    		stat_x += string_width(stat_display)+6;
 
 		    		stat_display = string_hash_to_newline($"BS#{selected_unit.ballistic_skill}");
-		    		tool_tip_draw(stat_x,stat_y, stat_display, 6);
+		    		tooltip_draw(stat_x,stat_y, stat_display, 6);
 		    		stat_x += string_width(stat_display)+7;
 
 		    		stat_display = string_hash_to_newline($"LU#{selected_unit.luck}");
-		    		tool_tip_draw(stat_x,stat_y, stat_display, 5);
+		    		tooltip_draw(stat_x,stat_y, stat_display, 5);
 		    		stat_x += string_width(stat_display)+6;
 
 		    		stat_display = string_hash_to_newline($"TEC#{selected_unit.technology}");
-		    		tool_tip_draw(stat_x,stat_y, stat_display,2);
+		    		tooltip_draw(stat_x,stat_y, stat_display,2);
 		    		stat_x += string_width(stat_display)+3;
 
 		    		stat_display = string_hash_to_newline($"CHA#{selected_unit.charisma}");
-		    		tool_tip_draw(stat_x,stat_y, stat_display,2);
+		    		tooltip_draw(stat_x,stat_y, stat_display,2);
 		    		stat_x += string_width(stat_display)+5;
 		    		draw_line(stat_x, yy+519, stat_x, yy+957);
 
@@ -1910,18 +1910,18 @@ function scr_ui_manage() {
 		       		}
 		       		unit_data_string += "#";
 
-		       		tool_tip_text = "Traits##";
+		       		tooltip_text = "Traits##";
 		       		for (i=0;i<array_length(selected_unit.traits);i++){
 		       			unit_data_string += string(global.trait_list[$ selected_unit.traits[i]].flavour_text, unit_name) +"#";
-		       			tool_tip_text += global.trait_list[$ selected_unit.traits[i]].display_name;
+		       			tooltip_text += global.trait_list[$ selected_unit.traits[i]].display_name;
 		       			if (struct_exists(global.trait_list[$ selected_unit.traits[i]], "effect")){
-		       				tool_tip_text += global.trait_list[$ selected_unit.traits[i]].effect;
+		       				tooltip_text += global.trait_list[$ selected_unit.traits[i]].effect;
 		       			}
-		       			tool_tip_text +="#";
+		       			tooltip_text +="#";
 		       		}
-		       		tool_tip_text = string_hash_to_newline(tool_tip_text);
-		       		tool_tip_draw(stat_x+2,stat_y, tool_tip_text);
-		       		tool_tip_draw(xx+25,yy+65, string_hash_to_newline(unit_data_string), 3, 0, 975, 17);
+		       		tooltip_text = string_hash_to_newline(tooltip_text);
+		       		tooltip_draw(stat_x+2,stat_y, tooltip_text);
+		       		tooltip_draw(xx+25,yy+65, string_hash_to_newline(unit_data_string), 3, 0, 975, 17);
 		        }
 			}
 		}    

--- a/scripts/scr_ui_popup/scr_ui_popup.gml
+++ b/scripts/scr_ui_popup/scr_ui_popup.gml
@@ -1,10 +1,33 @@
+function tool_tip_draw(base_x, base_y, tool_tip, extra_x=0, extra_y=0, defined_width=false, line_gap=0){
+	var xx=__view_get( e__VW.XView, 0 )+0;
+	var yy=__view_get( e__VW.YView, 0 )+0;
+	var width,height;
+	if (defined_width != false){
+		width =defined_width+extra_x;
+	} else{
+		width = string_width(string_hash_to_newline(tool_tip)) + extra_x;
+	}
+	height = string_height(string_hash_to_newline(tool_tip))+extra_y;
+	draw_set_color(0);
+	draw_rectangle(base_x,base_y,width+base_x+6,height+base_y+6,0);
+	draw_set_color(c_gray);
+	draw_rectangle(base_x,base_y,width+base_x+6,height+base_y+6,1);
+	draw_set_alpha(0.5);
+	draw_rectangle(base_x+1,base_y+1,width+base_x+5,height+base_y+5,1);
+    draw_set_alpha(1);
+    if (defined_width == false){
+    	draw_text(base_x+2.5,base_y+2.5,string_hash_to_newline(string(tool_tip)));
+    } else{
+    	draw_text_ext(base_x+2.5,base_y+2.5, string_hash_to_newline(string(tool_tip)), line_gap, defined_width);
+    }
+}
+
 function scr_ui_popup() {
-  
-  
-  
+
 	// 48,48      over like 256, down to 480-128
 
-	if (obj_controller.menu=60){var xx,yy;
+	if (obj_controller.menu=60){
+		var xx,yy;
 	    xx=__view_get( e__VW.XView, 0 )+25;yy=__view_get( e__VW.YView, 0 )+165;
     
 	    draw_sprite(spr_popup_large,1,xx,yy);
@@ -412,9 +435,9 @@ function scr_ui_popup() {
     
 	    robj=instance_nearest(obj_fleet_select.x,obj_fleet_select.y,obj_p_fleet);
     
-	    if (es>0) then ty+=1;
-	    if (fr>0) then ty+=1;
-	    if (ca>0) then ty+=1;
+	    if (es>0) then ty++;
+	    if (fr>0) then ty++;
+	    if (ca>0) then ty++;
     
 	    for(var j=0; j<(es+fr+ca+ty); j++){
 	        y3+=20;
@@ -445,7 +468,7 @@ function scr_ui_popup() {
 	            y3=142;
 	            x3+=223;
 	            posi++;
-	            colu+=1;
+	            colu++;
 	        }
         
 	        if (posi<=ca){
@@ -532,10 +555,15 @@ function scr_ui_popup() {
 	            draw_set_color(c_gray);
 	        }
 	        if (posi>ca+fr) and (posi<=ca+fr+es){
-	            shit=posi-(ca+fr);nem=robj.escort[shit];
-	            if (string_width(string_hash_to_newline(nem))*scale>179) then repeat(9){if (string_width(string_hash_to_newline(nem))*scale>179) then scale-=0.05;}
+	            shit=posi-(ca+fr);
+	            nem=robj.escort[shit];
+	            if (string_width(string_hash_to_newline(nem))*scale>179){
+	            	for (i=0;i<10;i++){if (string_width(string_hash_to_newline(nem))*scale>179) then scale-=0.05;}
+	            }
 	            if (mouse_x>=__view_get( e__VW.XView, 0 )+x3) and (mouse_x<__view_get( e__VW.XView, 0 )+x3+209) and (mouse_y>=__view_get( e__VW.YView, 0 )+y3) and (mouse_y<=__view_get( e__VW.YView, 0 )+y3+18){
-	                if (string_width(string_hash_to_newline(nem))*scale>135) then repeat(9){if (string_width(string_hash_to_newline(nem))*scale>135) then scale-=0.05;}shew=2;
+	                if (string_width(string_hash_to_newline(nem))*scale>135){for (i=0;i<10;i++){
+	                	if (string_width(string_hash_to_newline(nem))*scale>135) then scale-=0.05;}shew=2
+	                }
 	            }
 	            if (mouse_check_button_pressed(mb_left)) and (obj_controller.cooldown<=0){
 	                if (mouse_x>=__view_get( e__VW.XView, 0 )+x3) and (mouse_x<__view_get( e__VW.XView, 0 )+x3+25) and (mouse_y>=__view_get( e__VW.YView, 0 )+y3) and (mouse_y<=__view_get( e__VW.YView, 0 )+y3+18){
@@ -616,21 +644,6 @@ function scr_ui_popup() {
 	    // draw_set_color(c_red);
 	    // draw_rectangle(view_xview[0]+obj_fleet_select.void_x,view_yview[0]+obj_fleet_select.void_y,view_xview[0]+obj_fleet_select.void_x+obj_fleet_select.void_wid,view_yview[0]+obj_fleet_select.void_y+obj_fleet_select.void_hei,1);
 	}
-
-	function tool_tip_draw(base_x, base_y, tool_tip){
-		var xx=__view_get( e__VW.XView, 0 )+0;
-		var yy=__view_get( e__VW.YView, 0 )+0;
-		draw_set_color(0);
-		draw_rectangle(base_x,base_y,string_width(string_hash_to_newline(tool_tip))+base_x+6,string_height(string_hash_to_newline(tool_tip))+base_y+6,0);
-		draw_set_color(c_gray);
-		draw_rectangle(base_x,base_y,string_width(string_hash_to_newline(tool_tip))+base_x+6,string_height(string_hash_to_newline(tool_tip))+base_y+6,1);
-		draw_set_alpha(0.5);
-		draw_rectangle(base_x+1,base_y+1,string_width(string_hash_to_newline(tool_tip))+base_x+5,string_height(string_hash_to_newline(tool_tip))+base_y+5,1);
-	    draw_set_alpha(1);
-	    draw_text(base_x+2.5,base_y+2.5,string_hash_to_newline(string(tool_tip)));
-	    draw_text(base_x+3.5,base_y+3.5,string_hash_to_newline(string(tool_tip)));	    
-	}
-
 	var xx=__view_get( e__VW.XView, 0 )+0;
 	var yy=__view_get( e__VW.YView, 0 )+0;
 	if (zoomed == 0){
@@ -700,12 +713,12 @@ function scr_ui_popup() {
 		        if (loyal_num[d]>1) and (lines=0){
 		            tool1+=string(loyal[d])+": -"+string(loyal_num[d])+"#";
 		            tool2+=string(loyal[d])+": #";
-		            lines+=1;
+		            lines++;
 		        }
 		        if (loyal_num[d]>1) and (lines>0){
 		            tool1+=string(loyal[d])+": -"+string(loyal_num[d])+"#";
 		            tool2+=string(loyal[d])+": #";
-		            lines+=1;
+		            lines++;
 		        }
 		    }
 	    
@@ -733,13 +746,15 @@ function scr_ui_popup() {
 		        tool_tip_draw(xx+373, yy+42, tool1);
 		    }
 		}
-		if (scr_hit(xx+1435,yy+40,xx+1580,yy+267)){
-		    var tx=0,ty=0,tool1="",tool2="",plu="";
-		    tool1=$"Turn :{obj_controller.turn}";
-		    tool2="Astartes";
-		    if (tool1!=""){
-		    	tool_tip_draw(xx+1480, yy+265, tool1);
-		    }
+		if (menu == 0) and (diplomacy<=0){
+			if (scr_hit(xx+1435,yy+40,xx+1580,yy+267)){
+			    var tx=0,ty=0,tool1="",tool2="",plu="";
+			    tool1=$"Turn :{obj_controller.turn}";
+			    tool2="Astartes";
+			    if (tool1!=""){
+			    	tool_tip_draw(xx+1480, yy+265, tool1);
+			    }
+			}
 		}
 
 		if (scr_hit(xx+813,yy+10,xx+960,yy+38)) and (penitent==1) {
@@ -782,7 +797,7 @@ function scr_ui_popup() {
 	        i++;if (loyal_num[i]>1){
 	            blurp+=string(loyal[i])+": -"+string(loyal_num[i])+"#";
 	            blurp2+=string(loyal[i])+": #";
-	            lines+=1;
+	            lines++;
 	        }
 	    }
     

--- a/scripts/scr_ui_popup/scr_ui_popup.gml
+++ b/scripts/scr_ui_popup/scr_ui_popup.gml
@@ -1,13 +1,13 @@
-function tool_tip_draw(base_x, base_y, tool_tip, extra_x=0, extra_y=0, defined_width=false, line_gap=0){
+function tooltip_draw(base_x, base_y, tooltip, extra_x=0, extra_y=0, defined_width=false, line_gap=0){
 	var xx=__view_get( e__VW.XView, 0 )+0;
 	var yy=__view_get( e__VW.YView, 0 )+0;
 	var width,height;
 	if (defined_width != false){
 		width =defined_width+extra_x;
 	} else{
-		width = string_width(string_hash_to_newline(tool_tip)) + extra_x;
+		width = string_width(string_hash_to_newline(tooltip)) + extra_x;
 	}
-	height = string_height(string_hash_to_newline(tool_tip))+extra_y;
+	height = string_height(string_hash_to_newline(tooltip))+extra_y;
 	draw_set_color(0);
 	draw_rectangle(base_x,base_y,width+base_x+6,height+base_y+6,0);
 	draw_set_color(c_gray);
@@ -16,9 +16,9 @@ function tool_tip_draw(base_x, base_y, tool_tip, extra_x=0, extra_y=0, defined_w
 	draw_rectangle(base_x+1,base_y+1,width+base_x+5,height+base_y+5,1);
     draw_set_alpha(1);
     if (defined_width == false){
-    	draw_text(base_x+2.5,base_y+2.5,string_hash_to_newline(string(tool_tip)));
+    	draw_text(base_x+2.5,base_y+2.5,string_hash_to_newline(string(tooltip)));
     } else{
-    	draw_text_ext(base_x+2.5,base_y+2.5, string_hash_to_newline(string(tool_tip)), line_gap, defined_width);
+    	draw_text_ext(base_x+2.5,base_y+2.5, string_hash_to_newline(string(tooltip)), line_gap, defined_width);
     }
 }
 
@@ -700,7 +700,7 @@ function scr_ui_popup() {
 	        }		    
 	    
 		    if (tool1!=""){
-		    	tool_tip_draw(xx+10, yy+42, tool1);
+		    	tooltip_draw(xx+10, yy+42, tool1);
 		    }
 		}
 
@@ -725,7 +725,7 @@ function scr_ui_popup() {
 		    if (tool1="") then tool1="Loyalty";
 	    
 		    if (tool1!=""){
-		        tool_tip_draw(xx+150, yy+42, tool1);
+		        tooltip_draw(xx+150, yy+42, tool1);
 		    }
 		}
 
@@ -734,7 +734,7 @@ function scr_ui_popup() {
 		    var tx=0,ty=0,tool1="",tool2="",plu="";
 		    tool1="Gene-Seed";
 		    if (tool1!=""){
-		        tool_tip_draw(xx+249, yy+42, tool1);
+		        tooltip_draw(xx+249, yy+42, tool1);
 		    }
 		}
 
@@ -743,7 +743,7 @@ function scr_ui_popup() {
 		    tool1="Astartes#(Normal/Command)";
 		    tool2="Astartes";
 		    if (tool1!=""){
-		        tool_tip_draw(xx+373, yy+42, tool1);
+		        tooltip_draw(xx+373, yy+42, tool1);
 		    }
 		}
 		if (menu == 0) and (diplomacy<=0){
@@ -752,7 +752,7 @@ function scr_ui_popup() {
 			    tool1=$"Turn :{obj_controller.turn}";
 			    tool2="Astartes";
 			    if (tool1!=""){
-			    	tool_tip_draw(xx+1480, yy+265, tool1);
+			    	tooltip_draw(xx+1480, yy+265, tool1);
 			    }
 			}
 		}
@@ -782,7 +782,7 @@ function scr_ui_popup() {
 		    }
 	    
 		    if (tool1!=""){
-		        tool_tip_draw(xx+813, yy+42, tool1)
+		        tooltip_draw(xx+813, yy+42, tool1)
 		    }
 		}
 


### PR DESCRIPTION
- units now have a full ui viewable by hovering the cursor over the marines sprite
- fix hover over issue with turn counter appearing incorrectly
- hover overs over all the marines stat data with enhanced data,
- marines with tech or librarium potential are highlighted in company ui
- refactored much of initialise_custom (more will com later)
- refactored first company spawn
- made marines spawnable with bionics on game start
- added new traits (started implementing game mechanics with traits for example having the flesh_is_weak trait gives piety stat bonus' when adding a new bionic)
- refactored specialist spawning
- created custom squad specific names for roles (e.g tactical sergeant as opposed to sergeant)
- all marines now have a psionic or pysker value denoting their effect on the warp (if value is high enough can be trained into librarian)
- all marines now have markers for different gene seed mutations, any marine has a chance to spawn with gene seed mutations with the chance increased as a result of chapter creation gene seed stability(makes stability acctually do something)
- fix the CTD crashes from loading and saving (duke was not consistent with starting positions or numbers with arrays so something to look out for)

sorry for the size of this one and having so much different stuff i just kept noticing stuff and got carried away