### PR TITLE
Fix overspending stc fragments

### DIFF
--- a/objects/obj_controller/Mouse_50.gml
+++ b/objects/obj_controller/Mouse_50.gml
@@ -256,39 +256,41 @@ if (menu==14) and (cooldown<=0){
     }
     // Identify STC
     if (mouse_x>xx+621) and (mouse_y>yy+466) and (mouse_x<xx+720) and (mouse_y<yy+486){
-        if (stc_wargear_un+stc_vehicles_un+stc_ships_un>0){
-            var r1,r2=0;
+        if (stc_wargear_un + stc_vehicles_un + stc_ships_un > 0){
+				
             cooldown=8000;
             audio_play_sound(snd_stc,-500,0)
             audio_sound_gain(snd_stc,master_volume*effect_volume,0);
-            r1=irandom(stc_wargear_un+stc_vehicles_un+stc_ships_un)+1;
 
-            if (r1<stc_wargear_un) and (stc_wargear_un>0) then r2=1;
-            if (r1>stc_wargear_un) and (r1<=stc_wargear_un+stc_vehicles_un) and (stc_vehicles_un>0) then r2=2;
-            if (r1>stc_wargear_un+stc_vehicles_un) and (r2<=stc_wargear_un+stc_vehicles_un+stc_ships_un) and (stc_ships_un>0) then r2=3;
 
-            if (stc_wargear_un>0) and (stc_vehicles_un+stc_ships_un==0) then r2=1;
-            if (stc_vehicles_un>0) and (stc_wargear_un+stc_ships_un==0) then r2=2;
-            if (stc_ships_un>0) and (stc_vehicles_un+stc_wargear_un==0) then r2=3;
-
-            if (r2==1){
-                stc_wargear_un-=1;
-                stc_wargear+=1;
+			if(stc_wargear_un > 0 && 
+			stc_wargear < MAX_STC_PER_SUBCATEGORY &&
+			stc_wargear <= min(stc_vehicles, stc_ships)) {
+					
+				stc_wargear_un--;
+                stc_wargear++;
                 if (stc_wargear==2) then stc_bonus[1]=choose(1,2,3,4,5);
                 if (stc_wargear==4) then stc_bonus[2]=choose(1,2,3);
-            }
-            if (r2==2){
-                stc_vehicles_un-=1;
-                stc_vehicles+=1;
+			}
+			else if(stc_vehicles_un > 0 && 
+			stc_vehicles < MAX_STC_PER_SUBCATEGORY &&
+			stc_vehicles <= min(stc_wargear, stc_ships)) {
+					
+				stc_vehicles_un--;
+                stc_vehicles++;
                 if (stc_vehicles==2) then stc_bonus[3]=choose(1,2,3,4,5);
                 if (stc_vehicles==4) then stc_bonus[4]=choose(1,2,3);
-            }
-            if (r2==3){
-                stc_ships_un-=1;
-                stc_ships+=1;
+			}
+			else if(stc_ships_un > 0 && 
+			stc_ships < MAX_STC_PER_SUBCATEGORY &&
+			stc_ships <= min(stc_vehicles, stc_wargear)) {
+				
+				stc_ships_un--;
+                stc_ships++;
                 if (stc_ships==2) then stc_bonus[5]=choose(1,2,3,4,5);
                 if (stc_ships==4) then stc_bonus[6]=choose(1,2,3);
-            }
+			}
+			
             // Refresh the shop
             instance_create(1000,1000,obj_shop);
         }

--- a/scripts/macros/macros.gml
+++ b/scripts/macros/macros.gml
@@ -13,6 +13,8 @@ function macros() {
 		artifact
 	}
 
+	#macro MAX_STC_PER_SUBCATEGORY 6
+
 	enum INQUISITION_MISSION {
 		purge,
 		inquisitor,

--- a/scripts/scr_add_stc_fragment/scr_add_stc_fragment.gml
+++ b/scripts/scr_add_stc_fragment/scr_add_stc_fragment.gml
@@ -13,9 +13,10 @@ function scr_add_stc_fragment() {
 	            wik=3;onk=0;
 	        }
 	    }
-	    if (wik=1) and (obj_controller.stc_wargear_un+obj_controller.stc_wargear=6) then wik=2;
-	    if (wik=2) and (obj_controller.stc_vehicles_un+obj_controller.stc_vehicles=6) then wik=3;
-	    if (wik=3) and (obj_controller.stc_ships_un+obj_controller.stc_ships=6) then wik=1;
+
+	    if (wik=1) and (obj_controller.stc_wargear_un+obj_controller.stc_wargear=MAX_STC_PER_SUBCATEGORY) then wik=2;
+	    if (wik=2) and (obj_controller.stc_vehicles_un+obj_controller.stc_vehicles=MAX_STC_PER_SUBCATEGORY) then wik=3;
+	    if (wik=3) and (obj_controller.stc_ships_un+obj_controller.stc_ships=MAX_STC_PER_SUBCATEGORY) then wik=1;
     
 	    if (wik=1) and (onk<=0){obj_controller.stc_wargear_un+=1;onk=1;}
 	    if (wik=2) and (onk<=0){obj_controller.stc_vehicles_un+=1;onk=1;}


### PR DESCRIPTION
fixes #219 
Cause: STC Identification code missing limit check.
Fix: Implement bounds check - 6 per category (wargear/vehicles/ships) at present. As defined by MAX_STC_PER_SUBCATEGORY
Does not fix: 'Identify' button remaining highlighted if limit has been reached

Additional changes/Side effects: STC in the category with least identified STCs (wargear/vehicles/ships) will be identified first.
Was: Purely random before