### PR TITLE
fix: removed duplicate assault cannon in shop for dreadnoughts.

### DIFF
--- a/objects/obj_shop/Create_0.gml
+++ b/objects/obj_shop/Create_0.gml
@@ -655,15 +655,6 @@ if (shop = "vehicles") {
     }
     i += 1;
     x_mod[i] = 9;
-    item[i] = "Assault Cannon";
-    item_stocked[i] = scr_item_count(item[i]);
-    item_cost[i] = 75;
-    if (rene = 1) {
-        nobuy[i] = 1;
-        item_cost[i] = 0;
-    }
-    i += 1;
-    x_mod[i] = 9;
     item[i] = "Flamestorm Cannon";
     item_stocked[i] = scr_item_count(item[i]);
     item_cost[i] = 135;
@@ -675,7 +666,7 @@ if (shop = "vehicles") {
     x_mod[i] = 9;
     item[i] = "Assault Cannon";
     item_stocked[i] = scr_item_count(item[i]);
-    item_cost[i] = 110;
+    item_cost[i] = 75;
     if (rene = 1) {
         nobuy[i] = 1;
         item_cost[i] = 0;


### PR DESCRIPTION
This pull request removes the duplicate assault cannon entry in the armamentarium.

![image](https://github.com/ZAB909/ChapterMaster/assets/48617/6a185518-12f6-4557-a477-1069cf1a5467)

I kept the lower price; the commit history wasn't clear to me which prices were intended.