### PR TITLE
refactor: zoom and remove redundant was_zoomed

### DIFF
--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -671,7 +671,6 @@ trade_gene=0;
 trade_chip=0;
 trade_info=0;
 zui=0;
-was_zoomed=1;
 // Variables for management
 for(var t=0; i<200; t++){
     temp[t]="";

--- a/objects/obj_controller/KeyPress_32.gml
+++ b/objects/obj_controller/KeyPress_32.gml
@@ -9,24 +9,7 @@ if (__b__){
                 if (instance_exists(obj_ncombat)){
                     if (obj_ncombat.start==7) then exit;
                 }
-                var onceh=0;
-
-                if (zoomed==0) and (onceh==0){
-                    zoomed=1;
-                    onceh=1;
-                    __view_set( e__VW.Visible, 0, false );
-                    __view_set( e__VW.Visible, 1, true );
-                    obj_cursor.image_xscale=2;
-                    obj_cursor.image_yscale=2;
-                }
-                if (zoomed==1) and (onceh==0){
-                    zoomed=0;
-                    onceh=1;
-                    __view_set( e__VW.Visible, 0, true );
-                    __view_set( e__VW.Visible, 1, false );
-                    obj_cursor.image_xscale=1;
-                    obj_cursor.image_yscale=1;
-                }
+                scr_zoom();
             }
         }
     }

--- a/objects/obj_popup/Mouse_51.gml
+++ b/objects/obj_popup/Mouse_51.gml
@@ -91,7 +91,7 @@ if (instance_exists(obj_controller)){
         obj_p_fleet.alarm[6]=1;
         with(obj_fleet_select){instance_destroy();}
         obj_controller.popup=0;
-        if (obj_controller.zoomed=1){with(obj_controller){scr_zoom();}obj_controller.was_zoomed=0;}
+        if (obj_controller.zoomed=1){with(obj_controller){scr_zoom();}}
         
         type=98;title="Fleet Retreating";
         cooldown=15;obj_controller.menu=0;

--- a/scripts/scr_load/scr_load.gml
+++ b/scripts/scr_load/scr_load.gml
@@ -73,7 +73,6 @@ function scr_load(argument0, argument1) {
 	    obj_controller.cheatyface=ini_read_real("Controller","cheatyface",0);
 	    obj_controller.x=ini_read_real("Controller","x",obj_controller.x);
 	    obj_controller.y=ini_read_real("Controller","y",obj_controller.y);
-	    obj_controller.was_zoomed=ini_read_real("Controller","was_zoomed",0);
 	    obj_controller.zoomed=ini_read_real("Controller","zoomed",0);
 	    obj_controller.chaos_rating=ini_read_real("Controller","chaos_rating",0);
 	    obj_controller.fleet_type=ini_read_string("Controller","fleet_type",""); //

--- a/scripts/scr_save/scr_save.gml
+++ b/scripts/scr_save/scr_save.gml
@@ -56,7 +56,6 @@ function scr_save(save_slot,save_id) {
 	    ini_write_real("Controller","x",obj_controller.x);
 	    ini_write_real("Controller","y",obj_controller.y);
 	    ini_write_real("Controller","alll",obj_controller.alll);
-	    ini_write_real("Controller","was_zoomed",obj_controller.was_zoomed);
 	    ini_write_real("Controller","zoomed",obj_controller.zoomed);
 	    ini_write_real("Controller","chaos_rating",obj_controller.chaos_rating);
 	    ini_write_string("Controller","fleet_type",obj_controller.fleet_type);

--- a/scripts/scr_zoom/scr_zoom.gml
+++ b/scripts/scr_zoom/scr_zoom.gml
@@ -2,28 +2,21 @@ function scr_zoom() {
 
 	// Zooms the view in or out when executed
 
-	var onceh;onceh=0;
-	if (zoomed=1) and (onceh=0) {
-		was_zoomed=1;
-		zoomed=0;
-		onceh=1;
-		__view_set( e__VW.Visible, 0, true );
-		__view_set( e__VW.Visible, 1, false );
-		if (instance_exists(obj_cursor)) {
-			obj_cursor.image_xscale=1;
-			obj_cursor.image_yscale=1;
-		}
-	}
-	if (was_zoomed=1) and (onceh=0) {
-		was_zoomed=0;
-		zoomed=1;
-		onceh=1;
-		__view_set( e__VW.Visible, 0, false );
-		__view_set( e__VW.Visible, 1, true );
-		if (instance_exists(obj_cursor)) {
-			obj_cursor.image_xscale=2;
-			obj_cursor.image_yscale=2;
-		}
-	}
-
+    if (zoomed) {
+        zoomed=0;
+        view_set_visible(0, true);
+        view_set_visible(1, false);
+        if (instance_exists(obj_cursor)) {
+            obj_cursor.image_xscale=1;
+            obj_cursor.image_yscale=1;
+        }
+    } else {
+        zoomed=1;
+        view_set_visible(0, false);
+        view_set_visible(1, true);
+        if (instance_exists(obj_cursor)) {
+            obj_cursor.image_xscale=2;
+            obj_cursor.image_yscale=2;
+        }
+    }
 }


### PR DESCRIPTION
Changes
1. zoom logic was duplicated and is now centralized in `src_zoom`, for maintainability.
2. refactor zoom logic to use `else`
3. `was_zoomed` was removed after the above refactor, as it was then never read.
4. replaced `__view_set` with the API `view_set_visible` for more direct view management.

The saves I made before removing `was_zoomed` still load after.