### PR TITLE
crusade bug fix, and improvements

### DIFF
--- a/ChapterMaster.resource_order
+++ b/ChapterMaster.resource_order
@@ -590,6 +590,7 @@
     {"name":"fnt_menu","order":7,"path":"fonts/fnt_menu/fnt_menu.yy",},
     {"name":"fnt_info","order":9,"path":"fonts/fnt_info/fnt_info.yy",},
     {"name":"fnt_tiny","order":11,"path":"fonts/fnt_tiny/fnt_tiny.yy",},
+    {"name":"scr_necron_tombs","order":73,"path":"scripts/scr_necron_tombs/scr_necron_tombs.yy",},
     {"name":"fnt_small","order":13,"path":"fonts/fnt_small/fnt_small.yy",},
     {"name":"fnt_legal","order":15,"path":"fonts/fnt_legal/fnt_legal.yy",},
     {"name":"obj_fleet","order":1,"path":"objects/obj_fleet/obj_fleet.yy",},

--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -887,6 +887,7 @@
     {"id":{"name":"fnt_menu","path":"fonts/fnt_menu/fnt_menu.yy",},},
     {"id":{"name":"fnt_info","path":"fonts/fnt_info/fnt_info.yy",},},
     {"id":{"name":"fnt_tiny","path":"fonts/fnt_tiny/fnt_tiny.yy",},},
+    {"id":{"name":"scr_necron_tombs","path":"scripts/scr_necron_tombs/scr_necron_tombs.yy",},},
     {"id":{"name":"fnt_small","path":"fonts/fnt_small/fnt_small.yy",},},
     {"id":{"name":"fnt_legal","path":"fonts/fnt_legal/fnt_legal.yy",},},
     {"id":{"name":"obj_fleet","path":"objects/obj_fleet/obj_fleet.yy",},},

--- a/objects/obj_en_fleet/Alarm_1.gml
+++ b/objects/obj_en_fleet/Alarm_1.gml
@@ -461,8 +461,8 @@ if navy {
 	}
 
 	// Bombard the shit out of the player homeworld
-	if (obj_controller.faction_status[eFACTION.Imperium]="War") and (action="") and (trade_goods="") and (guardsmen_unloaded=0){
-	    if (instance_exists(orbiting)) {
+	if (obj_controller.faction_status[eFACTION.Imperium]="War") and (action="") and (trade_goods="") and (guardsmen_unloaded=0) and (instance_exists(orbiting)){
+	    if (orbiting!=noone){
 			var orbiting_guardsmen = array_reduce(orbiting.p_guardsman, function(prev, curr) {
 				return prev + curr
 			})
@@ -504,7 +504,8 @@ if navy {
 						
 	                    scare=(capital_number*3)+frigate_number;
 
-	                    if (scare>2) then scare=2;if (scare<1) then scare=0;
+	                    if (scare>2) then scare=2;
+                        if (scare<1) then scare=0;
 	                    //onceh=2;
 
 	                    if (orbiting.p_large[bombard]) {

--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -335,7 +335,9 @@ if (defeat=0) and (npowers=true){
         if (plasma_bomb>0){
             // scr_check_equip("Plasma Bomb",battle_loc,battle_id,1);
             // scr_check_equip("Plasma Bomb","","",1);
-            newline="Plasma Bomb used to seal the Necron Tomb.";newline_color="yellow";scr_newtext();
+            newline="Plasma Bomb used to seal the Necron Tomb.";
+            newline_color="yellow";
+            scr_newtext();
 			seal_tomb_world(battle_object.p_feature[battle_id])
         }
 

--- a/scripts/scr_apothecary_ground/scr_apothecary_ground.gml
+++ b/scripts/scr_apothecary_ground/scr_apothecary_ground.gml
@@ -53,22 +53,23 @@ function scr_apothecary_ground() {
 				if(planet_feature_bool(p_feature[run],P_features.Starship)==1) and (engineer_count>0){
 
 	                var starship = p_feature[run][search_planet_features(p_feature[run],P_features.Starship)[0]];
+	                var engineer_score_start = starship.engineer_score;
                 	if (starship.engineer_score<2000){
 	                	for (v=0;v<engineer_count;v++){
-	                		starship.engineer_score += engineers[v].technology;
-	                		scr_alert("green","owner",$"Ancient ship repairs {min((starship.engineer_score/2000)*100, 100)}% complete",x,y);
+	                		starship.engineer_score += (engineers[v].technology/2);
 	                	}
+	                	scr_alert("green","owner",$"Ancient ship repairs {min((starship.engineer_score/2000)*100, 100)}% complete",x,y);
                 	}
             
 	                var maxr=0,requisition_spend=0,target_spend=10000;
 
 	                maxr=floor(obj_controller.requisition/50);
-	                requisition_spend=min(maxr*50,engineers*50,target_spend-starship.funds_spent);
+	                requisition_spend=min(maxr*50,array_length(engineers)*50,target_spend-starship.funds_spent);
 	                obj_controller.requisition-=requisition_spend;
 	                starship.funds_spent+=requisition_spend;
                 
 	                if (requisition_spend>0) and (starship.funds_spent<target_spend){
-	                    scr_alert("green","owner",string(requisition_spend)+" Requision spent on Ancient Ship repairs in materials and outfitting",x,y);
+	                    scr_alert("green","owner",$"{requisition_spend} Requision spent on Ancient Ship repairs in materials and outfitting (outfitting {(starship.funds_spent/target_spend)*100}%)",x,y);
 	                }
 	                if (starship.funds_spent>=target_spend) and(starship.engineer_score>=2000){// u2=tar;
 	                    p_feature[run]="";

--- a/scripts/scr_cheatcode/scr_cheatcode.gml
+++ b/scripts/scr_cheatcode/scr_cheatcode.gml
@@ -22,6 +22,9 @@ function scr_cheatcode(argument0) {
         cheatcode_m_digits = (cheatcode_digits * -1)
 
     if (cheatcode_digits == "") {
+        if (cheatcode_string=="slaughtersong"){
+            create_starship_event();
+        }
         if (string_count("event", cheatcode_string) >0) {
             if (string_count("crusade", cheatcode_string) >0) {
                 show_debug_message("crusading");

--- a/scripts/scr_cheatcode/scr_cheatcode.gml
+++ b/scripts/scr_cheatcode/scr_cheatcode.gml
@@ -22,31 +22,43 @@ function scr_cheatcode(argument0) {
         cheatcode_m_digits = (cheatcode_digits * -1)
 
     if (cheatcode_digits == "") {
-
+        if (string_count("event", cheatcode_string) >0) {
+            if (string_count("crusade", cheatcode_string) >0) {
+                show_debug_message("crusading");
+                  with(obj_controller){
+                    launch_crusade();
+                }           
+            }else {
+                with(obj_controller){
+                    scr_random_event(1);
+                }
+            }
+        }
+        
         if (cheatcode_string == "infreq" && global.cheat_req == 0) {
-            global.cheat_req = 1
-            cheatyface = 1
+            global.cheat_req = 1;
+            cheatyface = 1;
             obj_controller.tempRequisition = obj_controller.requisition
             obj_controller.requisition = 51234
         } else if (cheatcode_string == "infreq" && global.cheat_req == 1) {
-            global.cheat_req = 0
-            cheatyface = 1
+            global.cheat_req = 0;
+            cheatyface = 1;
             obj_controller.requisition = obj_controller.tempRequisition
         } else if (cheatcode_string == "infseed" && global.cheat_gene == 0) {
-            global.cheat_gene = 1
-            cheatyface = 1
+            global.cheat_gene = 1;
+            cheatyface = 1;
             obj_controller.tempGene_seed = obj_controller.gene_seed
             obj_controller.gene_seed = 9999
         } else if (cheatcode_string == "infseed" && global.cheat_gene == 1) {
-            global.cheat_gene = 0
-            cheatyface = 1
+            global.cheat_gene = 0;
+            cheatyface = 1;
             obj_controller.gene_seed = obj_controller.tempGene_seed
         } else if (cheatcode_string == "debug" && global.cheat_debug == 0) {
-            global.cheat_debug = 1
-            cheatyface = 1
+            global.cheat_debug = 1;
+            cheatyface = 1;
         } else if (cheatcode_string == "debug" && global.cheat_debug == 1) {
-            global.cheat_debug = 0
-            cheatyface = 1
+            global.cheat_debug = 0;
+            cheatyface = 1;
         }
 
         if (cheatcode == "test") {
@@ -96,14 +108,10 @@ function scr_cheatcode(argument0) {
             obj_controller.disposition[9] = real(cheatcode_m_digits)
             obj_controller.disposition[10] = real(cheatcode_m_digits)
         }
-    }
-    else if (cheatcode_string == "stc") {
+    }else if (cheatcode_string == "stc") {
         cheatcode_digits = clamp(cheatcode_digits, 0, 100)
         repeat cheatcode_digits
         scr_add_stc_fragment()
-    } else if (string_count("event", cheatcode) == 1) {
-        with(obj_controller)
-        scr_random_event(1)
     } else if (cheatcode_string == "recruit") {
         var _start_pos = 0
         var length = (array_length(obj_controller.recruit_name) - 1)

--- a/scripts/scr_cheatcode/scr_cheatcode.gml
+++ b/scripts/scr_cheatcode/scr_cheatcode.gml
@@ -28,6 +28,11 @@ function scr_cheatcode(argument0) {
                   with(obj_controller){
                     launch_crusade();
                 }           
+            }else if (string_count("tomb", cheatcode_string) >0){
+                show_debug_message("necron_tomb_awaken");
+                with(obj_controller){
+                    awaken_tomb_event();
+                }  
             }else {
                 with(obj_controller){
                     scr_random_event(1);

--- a/scripts/scr_crusade/scr_crusade.gml
+++ b/scripts/scr_crusade/scr_crusade.gml
@@ -172,7 +172,7 @@ function launch_crusade(){
 			for(var j = 1; j <= 4 && !assigned_crusade;  j++){
 				if(star_id.p_problem[i][j] == ""){
 					star_id.p_problem[i][j] = "great_crusade";
-					star_id.p_timer[i][j] = 24;
+					star_id.p_timer[i][j] = 36;
 					assigned_crusade = true;
 					break;
 				}
@@ -184,11 +184,11 @@ function launch_crusade(){
 		}
 		else{
 			//TODO decide the target/purpose of the crusade to create more variety and to help with post crusade rewards
-			scr_popup("Crusade","Fellow Astartes legions are preparing to embark on a Crusade to a nearby sector.  Your forces are expected at "+string(star_id.name)+"; 24 turns from now your ships there shall begin their journey.","crusade","");
+			scr_popup("Crusade","Fellow Astartes legions are preparing to embark on a Crusade to a nearby sector.  Your forces are expected at "+string(star_id.name)+"; 36 turns from now your ships there shall begin their journey.","crusade","");
 			var star_alert = instance_create(star_id.x+16,star_id.y-24,obj_star_event);
 			star_alert.image_alpha=1;
 			star_alert.image_speed=1;
-			scr_event_log("","A Crusade is called; our forces are expected at "+string(star_id.name)+" in 24 months.");
+			scr_event_log("","A Crusade is called; our forces are expected at "+string(star_id.name)+" in 36 months.");
 			return true;	
 		}
 	}

--- a/scripts/scr_crusade/scr_crusade.gml
+++ b/scripts/scr_crusade/scr_crusade.gml
@@ -3,111 +3,109 @@ function scr_crusade() {
 	// Executed to kill the fuck out of the player's marines
 	// Think it is ran in the obj_p_fleet object when arriving back from crusade
 
-	var co, i, apoth, death_determination, death_determination_2, roll3, type, artifacts, shi, shipp, eff, clean, good, seed, marines_lost, command_lost, unit;
-	co=0;i=0;apoth=0;death_determination=0;death_determination_2=0;roll3=0;type="";artifacts=0;shi=0;shipp="";eff=0;clean=0;good=0;seed=0;marines_lost=0;command_lost=0;
+	var unit;
+	var co=0,i=0,apoth=0,death_determination=0,death_determination_2=0,roll3=0,type="",artifacts=0,clean=0;good=0;seed=0;marines_lost=0;
+	var heroics_strings=[];
+	
+	//index 1: death_determine 1 //index 2: death_determine 2 /index 3: apoth_recovery
+	//index 3 exp_gains irandom + static
+    var death_sets = {
+    	normal:[80,90,40,[5,10]],
+    	hard:[60,80,30,[20,20]],
+    	brutal:[20,65,20,[40,20]]
+    };
 
-	death_determination=floor(random(100))+1;roll3=floor(random(100))+1;
-	if (death_determination<=50){type="normal";artifacts=choose(0,0,0,0,0,1);}
-	if (death_determination>50){type="hard";artifacts=choose(0,0,1);}
-	if (death_determination>80){type="brutal";artifacts=choose(0,1,2);}
+	death_determination=floor(random(100))+1;
+	roll3=irandom(99)+1
 
-	i=-1;
-	repeat(11){i+=1;clean[i]=0;}
-
-	i=-1;co=-1;
-	repeat(11){
-	    co+=1;i=0;
-        
-    
-	    repeat(305){
-	        i+=1;// man_c[i]=0;man_i[i]=0;
-        
-	        /*show_message(string(co)+"."+string(i)+": "+string(obj_ini.name[co][i])+"
-	        "+string(co)+"."+string(i+1)+": "+string(obj_ini.name[co,i+1])+"
-	        "+string(co)+"."+string(i+2)+": "+string(obj_ini.name[co,i+2])+"
-	        "+string(co)+"."+string(i+3)+": "+string(obj_ini.name[co,i+3])+"
-	        "+string(co)+"."+string(i+4)+": "+string(obj_ini.name[co,i+4]));*/
-        
-	        shi=0;good=0;dead=false;
-        
-	        var command_lost;comand_lost=0;
-        
-	        repeat(capital_number+frigate_number+escort_number){
-	            shi+=1;
-            
-	            if (shi<=capital_number) and (capital_number>0){shipp="capital";eff=shi;}
-	            if (shi>capital_number) and (frigate_number>0){shipp="frigate";eff=shi-capital_number;}
-	            if (shi>capital_number+frigate_number) and (escort_number>0){shipp="escort";eff=shi-(capital_number+frigate_number);}
-            
-	            if (shipp="capital"){if (obj_ini.lid[co][i]=capital_num[eff]) then good=1;}
-	            if (shipp="frigate"){if (obj_ini.lid[co][i]=frigate_num[eff]) then good=1;}
-	            if (shipp="escort"){if (obj_ini.lid[co][i]=escort_num[eff]) then good=1;}
-            
-	            if (obj_ini.name[co][i]!="") and (good=1){
-	            	unit=obj_ini.TTRPG[co][i];
-	                death_determination=floor(random(100))+1;
-	                if (unit.has_trait("very_hard_to_kill")) then death_determination-=10;
-	                death_determination_2=death_determination;
-	                death_determination-=obj_ini.experience[co][i];
-	                if (string_count("Slow",obj_ini.strin)>0) then death_determination-=20;
-                
-	                var dead=false;
-	                if (type="normal") and ((death_determination>80) or (death_determination_2>90)) then dead=true;
-	                if (type="hard") and ((death_determination>60) or (death_determination_2>80)) then dead=true;
-	                if (type="brutal") and ((death_determination>20) or (death_determination_2>65)) then dead=true;
-                
-	                if (obj_ini.role[co][i]="Standard Bearer") then dead=false;
-	                if (obj_ini.role[co][i]="Chapter Master") then dead=false;
-                
-	                if (dead=true){
-	                    var man_size;man_size=0;
-	                    man_size=scr_unit_size(obj_ini.armour[co][i],obj_ini.role[co][i],true);
-                    
-	                    obj_ini.ship_carrying[obj_ini.lid[co][i]]-=man_size;
-                    	if (unit.IsSpecialist("standard",true)){
-                    		command_lost++;
-                    	}
-                    
-	                    clean[co]=1;
-	                    obj_controller.marines-=1;
-	                    marines_lost+=1;
-	                    scr_kill_unit(co,i);
-	                    seed+=2;
-	                }
-	                if (dead=false) and ((obj_ini.role[co][i]=obj_ini.role[100][15]) or (obj_ini.role[co][i]="Master of the Apothecarion")) and (obj_ini.gear[co][i]="Narthecium") then apoth+=1;
-	                if (dead=false){
-	                	var new_exp=0;
-	                	switch (type){
-	                		case "normal":
-	                			new_exp=irandom(2)+4;
-								break
-	                		case "hard":
-	                			new_exp=irandom(2)+10;
-	                		case "brutal":
-	                			new_exp=irandom(5)+15;	                				                			
-	                	}
-	                	unit.add_exp(new_exp);
-                    
-	                    if (unit.IsSpecialist("libs")) then unit.update_powers()
-	                }
-	            }
-        
-	        }
-        
-	    }
+	if (death_determination<=50){
+		type="normal";artifacts=choose(0,0,0,0,0,1);
+	}else if (death_determination>50){
+		type="hard";artifacts=choose(0,0,1);
+	}else if (death_determination>80){
+		type="brutal";
+		artifacts=choose(1,2,3);
 	}
 
-	obj_controller.marines+=command_lost;
-	obj_controller.command-=command_lost;
+    var  death_data = death_sets[$ type]
 
+	for (co=0;co<=10;co++){
+		clean[co]=0;
+	}
+	var total_ship_id=array_concat(capital_num,frigate_num,escort_num);
 
+	for (co=0;co<=10;co++){
+	    for (i=0;i<=500;i++){
+        	good=0;dead=false;
+        	if (obj_ini.name[co][i]=="" || obj_ini.lid==0) then continue;
+        
+            if (array_contains(total_ship_id,obj_ini.lid[co][i])){
+            	unit=obj_ini.TTRPG[co][i];
+                death_determination=floor(random(100))+1;
+                //specialist trait greatly reduces death risk
+                //TODO figure out how to quantify and present these risks so the player knows to protect dudes with trait
+                if (unit.has_trait("very_hard_to_kill")) then death_determination-=20;
+                death_determination_2=death_determination;
+                death_determination-=(unit.experience()/2);
 
+                //more generalised trait bonus mainly linked to chapter advantage of same name
+                if (unit.has_trait("slow_and_purposeful")) then death_determination-=10;
+            
+                var dead=false;
+                if (death_determination>death_data[0] || death_determination_2>death_data[1]){
+                	dead=true;
+	                if (unit.role()==obj_ini.role[100][5]){
+	                	if (irandom(20)<unit.luck){
+	                		dead=false;
+	                	} else {
+	                		if (irandom(100)<unit.weapon_skill){
+	                			var heroic_deed = choose(
+	                					"holding a breach in imperial defenses allowing allied forces to regroup,",
+	                					"slaying the enemy leader in glorious combat, while victorious he ultimately succumbed to his wounds,",
+	                					"leading an imortant boarding mission,",
+	                				);
+	                			//TODO figure out a blance in reward for captains or high rnaking death on crusade
+	                			//adds dynamacism as itt creates reward for the potential loss of men and talent during crusades 
+	                			//var consolations = ["ship", "req",""]
+	                			//var consolation_prize = irandom(2)
+	                			var heroic_death = $"{unit.full_title()} died {heroic_deed} {unit.name()} dies a hero of the {global.chapter_name}";
+	                			array_push(heroics_strings, heroic_death);
+	                		}
+	                	}
+	                }else if (unit.role()=="Standard Bearer" || unit.role()=="Chapter Master") then dead=false;
+	           	}
+                if (dead){               	
+                    var man_size=0;
+                    obj_ini.ship_carrying[obj_ini.lid[co][i]]-=unit.get_unit_size();
+                	if (unit.IsSpecialist("standard",true)){
+                		obj_controller.command--;
+                	} else {
+                		obj_controller.marines--;
+                	}
+                
+                    clean[co]=1;
+                    marines_lost++;
+                    scr_kill_unit(co,i);
+                    seed+=2;
+                } else {
+                	if (unit.IsSpecialist("apoth")) and (obj_ini.gear[co][i]="Narthecium") then apoth++;
+                	unit.add_exp(irandom(death_data[3][0])+death_data[3][1]);
+                
+                    if (unit.IsSpecialist("libs")) then unit.update_powers();
+                    if (irandom(99)==1 && irandom(20)<unit.luck){
+                    	var heroic_deed=choose("still_standing","lone_survivor","beast_slayer");
+                    	unit.add_trait(heroic_deed);
+                    	array_push(heroics_strings, string(global.trait_list[$ heroic_deed].flavour_text,unit.full_title()));
+                    }             	
+                }
+            }
+    
+        }        
+    }
 
 	if (obj_ini.doomed=0){
 	    if (apoth>0){
-	        if (type="normal") then seed=min(seed,apoth*40);
-	        if (type="hard") then seed=min(seed,apoth*30);
-	        if (type="brutal") then seed=min(seed,apoth*20);
+	    	seed=min(seed,apoth*death_data[2]);
 	    }
 	    if (apoth=0) then seed=floor(seed*0.2);
 	    obj_controller.gene_seed+=seed;
@@ -116,19 +114,11 @@ function scr_crusade() {
 	// i=-1;
 	// repeat(11){
 	    // i+=1;
-
-	if (clean[0]=1) then with(obj_ini){scr_company_order(0);}
-	if (clean[1]=1) then with(obj_ini){scr_company_order(1);}
-	if (clean[2]=1) then with(obj_ini){scr_company_order(2);}
-	if (clean[3]=1) then with(obj_ini){scr_company_order(3);}
-	if (clean[4]=1) then with(obj_ini){scr_company_order(4);}
-	if (clean[5]=1) then with(obj_ini){scr_company_order(5);}
-	if (clean[6]=1) then with(obj_ini){scr_company_order(6);}
-	if (clean[7]=1) then with(obj_ini){scr_company_order(7);}
-	if (clean[8]=1) then with(obj_ini){scr_company_order(8);}
-	if (clean[9]=1) then with(obj_ini){scr_company_order(9);}
-	if (clean[10]=1) then with(obj_ini){scr_company_order(10);}
-
+	with(obj_ini){
+		for (i=0;i<=10;i++){
+			scr_company_order(i);
+		}
+	}
 	// }
 
 	if (roll3<=10) then artifacts+=1;
@@ -138,7 +128,7 @@ function scr_crusade() {
 	}
 
 
-	var tixt;tixt="Your ships have returned from the Crusade.  ";
+	var tixt="Your ships have returned from the Crusade.  ";
 	if (type="normal") then tixt+="The combat was as could be expected- ";
 	if (type="hard") then tixt+="The combat was fairly grueling- ";
 	if (type="brutal") then tixt+="The combat was absolutely brutal- your marines were the first into the fray, and as a result ";
@@ -149,15 +139,57 @@ function scr_crusade() {
 	    if (apoth>0) and (seed>0) then tixt+="  The "+string(apoth)+" surviving "+string(obj_ini.role[100][15])+" were able to recover "+string(seed)+" Gene-Seed.";
 	    if (apoth=0) and (seed>0) then tixt+="  You had no able-bodied "+string(obj_ini.role[100][15])+", or all of them perished in the Crusade.  Foreign Apothecaries were able to recover "+string(seed)+" of your Gene-Seed.";
 	}
-	if (obj_ini.doomed=1){
+	if (obj_ini.doomed==1){
 	    tixt+="  Due to fatal mutations in your marines none of the fallen Gene-Seed was recoverable.";
 	}
 
 	if (artifacts>0) then tixt+="  "+string(artifacts)+" Artifacts were granted to your Chapter or looted.";
 	if (roll3<=10) and (artifacts>1) then tixt+="  One of them were given as a bonus for exceptional valor.";
 
+	if (array_length(heroics_strings)==1){
+		tixt += " A heroic deed was recorded"
+	} else if (array_length(heroics_strings)>1){
+		tixt += " Several deeds were recorded"
+	}
+// title / text / image / speshul
 	scr_popup("Crusade Results",tixt,"crusade","");
-	// title / text / image / speshul
+	for (i=0;i<array_length(heroics_strings);i++){
+		scr_popup("Heroic Deed",heroics_strings[i],"crusade","");
+	}
 
+}
 
+//TODO never place the star out of reach of a player fleet, eiter increase allowed response time or find nearer planet
+function launch_crusade(){
+	var star_id = scr_random_find(2,true,"","");
+	if(star_id == undefined){
+		debugl("RE: Crusade, couldn't find a star for the crusade");
+		return false;
+	}
+	else{
+		var assigned_crusade = false;
+		for(var i = 1; i <= star_id.planets && !assigned_crusade;i++){
+			for(var j = 1; j <= 4 && !assigned_crusade;  j++){
+				if(star_id.p_problem[i][j] == ""){
+					star_id.p_problem[i][j] = "great_crusade";
+					star_id.p_timer[i][j] = 24;
+					assigned_crusade = true;
+					break;
+				}
+			}
+		}
+		if(!assigned_crusade){
+			debugl("RE: Crusade, couldn't assign a crusade at the system");
+			return false;
+		}
+		else{
+			//TODO decide the target/purpose of the crusade to create more variety and to help with post crusade rewards
+			scr_popup("Crusade","Fellow Astartes legions are preparing to embark on a Crusade to a nearby sector.  Your forces are expected at "+string(star_id.name)+"; 24 turns from now your ships there shall begin their journey.","crusade","");
+			var star_alert = instance_create(star_id.x+16,star_id.y-24,obj_star_event);
+			star_alert.image_alpha=1;
+			star_alert.image_speed=1;
+			scr_event_log("","A Crusade is called; our forces are expected at "+string(star_id.name)+" in 24 months.");
+			return true;	
+		}
+	}
 }

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1732,6 +1732,10 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 			}
 			return string("{0} {1}", temp_role, name())
 		}
+
+		static full_title = function(){
+			return $"{name_role()} of the {scr_roman_numerals()[company-1]}co.";
+		}
 		
 		static load_marine = function(ship, star="none"){
 			 get_unit_size(); // make sure marines size given it's current equipment is correct

--- a/scripts/scr_necron_tombs/scr_necron_tombs.gml
+++ b/scripts/scr_necron_tombs/scr_necron_tombs.gml
@@ -1,0 +1,54 @@
+
+function awaken_tomb_event(){
+	debugl("RE: Necron Tomb Awakens");
+	var stars = scr_get_stars();
+	
+	var valid_stars = array_filter_ext(stars, 
+		function(star, index){
+			var tomb_world = scr_get_planet_with_feature(star,P_features.Necron_Tomb);
+			
+			if (tomb_world == -1) then return false;
+			else {
+				return awake_tomb_world(star.p_feature[tomb_world]) == 0;
+			}
+		});
+
+	if(valid_stars == 0){
+		debugl("RE: Necron Tomb Awakens, couldn't find a sleeping necron tomb");
+		return false;
+	}
+	
+	var star_index = irandom(valid_stars-1);
+	var star = stars[star_index];
+	var planet = -1;
+	for(var i = 1; i <= star.planets; i++) {
+		if (awake_tomb_world(star.p_feature[i])==0){
+			awaken_tomb_world(star.p_feature[i]);
+			planet = i;
+			break;
+		}
+	}
+	
+	if(planet == -1) {
+		debugl("RE: Necron Tomb Awakens, couldn't find a sleeping necron tomb planet");
+		return false;
+	}
+	
+    var text=string(star.name) + string(scr_roman(planet));
+    scr_event_log("red","The Necron Tomb on "+string(text)+" has surged into activity.");
+    scr_popup("Necron Awakening","The Necron Tomb on "+string(text)+" has surged into activity.  Rank upon rank of the abominations are pouring out from their tunnels.","necron_tomb","");
+    var star_alert=instance_create(star.x+16,star.y-24,obj_star_event);
+	star_alert.image_alpha=1;
+	star_alert.image_speed=1;
+	star_alert.col="red"; 
+    star.p_pdf[planet]=0;
+	star.p_necrons[planet]=6;
+	
+    if (star.p_guardsmen[planet]<2000000) {
+		star.p_guardsmen[planet]=0;
+	}
+	if (star.p_guardsmen[planet]>=2000000) {
+		star.p_guardsmen[planet]=round(star.p_guardsmen[planet]/2);
+	}
+	return true;
+}

--- a/scripts/scr_necron_tombs/scr_necron_tombs.yy
+++ b/scripts/scr_necron_tombs/scr_necron_tombs.yy
@@ -1,0 +1,11 @@
+{
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "scr_necron_tombs",
+  "isCompatibility": false,
+  "isDnD": false,
+  "parent": {
+    "name": "Scripts",
+    "path": "folders/Scripts.yy",
+  },
+}

--- a/scripts/scr_planetary_feature/scr_planetary_feature.gml
+++ b/scripts/scr_planetary_feature/scr_planetary_feature.gml
@@ -306,7 +306,7 @@ function awake_tomb_world(planet){
 //selas a tomb world and switche off awake so will no longer spawn necrons or necron fleets
 function seal_tomb_world(planet){
 	var awake_tomb = 0;
-	 var tombs = search_planet_features(planet, search_feature);
+	 var tombs = search_planet_features(planet, P_features.Necron_Tomb);
 	 if (array_length(tombs)>0){
 		 for (var tomb =0;tomb<array_length(tombs);tomb++){
 			 if (planet[tombs[tomb]].awake == 1){
@@ -324,7 +324,7 @@ function seal_tomb_world(planet){
 //awakens a tomb world so necrons and necron fleets will spawn
 function awaken_tomb_world(planet){
 	var awake_tomb = 0;
-	 var tombs = search_planet_features(planet, search_feature);
+	 var tombs = search_planet_features(planet, P_features.Necron_Tomb);
 	 if (array_length(tombs)>0){
 		 for (var tomb =0;tomb<array_length(tombs);tomb++){
 			if (planet[tombs[tomb]].awake == 0){

--- a/scripts/scr_planetary_feature/scr_planetary_feature.gml
+++ b/scripts/scr_planetary_feature/scr_planetary_feature.gml
@@ -77,7 +77,14 @@ function new_planet_feature(feature_type, other_data={}) constructor{
 		planet_display = "Arsenal";
 		player_hidden = 0;
 		built = obj_controller.turn+3;
-		break;		
+		break;
+	case P_features.Starship:
+		f_type = P_features.Starship;
+		planet_display = "Ancient Starship";
+		funds_spent = 0;
+		player_hidden = 0;
+		engineer_score = 0;
+	break;	
 	case P_features.Ancient_Ruins:
 		var ruin_data = choose(["tiny", 5], ["small", 15], ["medium", 55], ["large",110], ["sprawling", 0])
 		ruins_size =  ruin_data[0]
@@ -389,4 +396,15 @@ function scr_planetary_feature(planet_num) {
 		}
 	}
 }
-		
+
+function create_starship_event(){
+	var star = scr_random_find(2,true,"","");
+	if(star == undefined){
+		debugl("RE: couldn't find starship target");
+		return false;
+	}else {
+		var planet=irandom(star.planets-1)+1;
+		array_push(star.p_feature[planet], new new_planet_feature(P_features.Starship))
+		scr_event_log("","Ancient Starship discovered on "+string(star.name)+" "+scr_roman(planet)+".");
+	}
+}

--- a/scripts/scr_planetary_feature/scr_planetary_feature.gml
+++ b/scripts/scr_planetary_feature/scr_planetary_feature.gml
@@ -313,8 +313,9 @@ function seal_tomb_world(planet){
 				awake_tomb = 1;
 				planet[tombs[tomb]].awake = 0;
 				planet[tombs[tomb]].sealed = 1;
+				planet[tombs[tomb]].planet_display = "Sealed Necron Tomb";
 			 }
-			 if (awake_tomb = 1){break;}
+			 if (awake_tomb = 1) then break;
 		 }
 	 }
 }
@@ -326,11 +327,12 @@ function awaken_tomb_world(planet){
 	 var tombs = search_planet_features(planet, search_feature);
 	 if (array_length(tombs)>0){
 		 for (var tomb =0;tomb<array_length(tombs);tomb++){
-			 if (planet[tombs[tomb]].awake == 0){
+			if (planet[tombs[tomb]].awake == 0){
 				awake_tomb = 1;
 				planet[tombs[tomb]].awake = 1;
-			 }
-			 if (awake_tomb = 1){break;}
+				planet[tombs[tomb]].planet_display = "Active Necron Tomb";
+			}
+			if (awake_tomb = 1){break;}
 		 }
 		 
 	 }
@@ -355,30 +357,34 @@ function scr_planetary_feature(planet_num) {
 					break;
 				case P_features.Necron_Tomb:
 				    var lop="Necron Tomb discovered on "+string(name)+" "+scr_roman(planet_num)+"."debugl(lop);
-				    scr_alert("red","feature",lop,x,y);scr_event_log("red",lop);
+				    scr_alert("red","feature",lop,x,y);
+				    scr_event_log("red",lop);
 					break;
 				case P_features.Artifact:
 					var lop="Artifact discovered on "+string(name)+" "+scr_roman(planet_num)+"."debugl(lop);
-					scr_alert("green","feature",lop,x,y);scr_event_log("",lop);
+					scr_alert("green","feature",lop,x,y);
+					scr_event_log("",lop);
 					break;
 				case P_features.STC_Fragment:
 					var lop="STC Fragment located on "+string(name)+" "+scr_roman(planet_num)+"."debugl(lop);
-					 scr_alert("green","feature",lop,x,y);scr_event_log("",lop);
+					 scr_alert("green","feature",lop,x,y);
+					 scr_event_log("",lop);
 					 break;
 				case P_features.Ancient_Ruins:
 					var lop=$"A {feat.ruins_size} Ancient Ruins discovered on {string(name)} {scr_roman(planet_num)}."debugl(lop);
-					scr_alert("green","feature",lop,x,y);scr_event_log("",lop);
+					scr_alert("green","feature",lop,x,y);
+					scr_event_log("",lop);
 					break;
 				case P_features.Cave_Network:
 					var lop="Extensive Cave Network discovered on "+string(name)+" "+scr_roman(planet_num)+"."debugl(lop);
-			        scr_alert("green","feature",lop,x,y);scr_event_log("",lop);
+			        scr_alert("green","feature",lop,x,y);
+			        scr_event_log("",lop);
 					break;
 				case P_features.Warlord7:
 				    var lop="Ork Warboss discovered on "+string(name)+" "+scr_roman(planet_num)+"."debugl(lop);
-				    scr_alert("red","feature",lop,x,y);scr_event_log("red",lop);
-					break;
-		
-			
+				    scr_alert("red","feature",lop,x,y);
+				    scr_event_log("red",lop);
+					break;		
 			}
 		}
 	}

--- a/scripts/scr_random_event/scr_random_event.gml
+++ b/scripts/scr_random_event/scr_random_event.gml
@@ -22,8 +22,7 @@ function scr_random_event(execute_now) {
 	//        exit;
 	//    }
 	//}
-
-
+	var chosen_event;
 
 	var inquisition_mission_roll = irandom(100);
 	var force_inquisition_mission = false;
@@ -31,7 +30,6 @@ function scr_random_event(execute_now) {
 		force_inquisition_mission = true;
 	}
 
-	var chosen_event;
 	if (force_inquisition_mission && random_event_next == EVENT.none) {
 		chosen_event = EVENT.inquisition_mission;
 	}
@@ -67,38 +65,38 @@ function scr_random_event(execute_now) {
 				if(player_luck == luck.good){
 					events = 
 					[
-					EVENT.space_hulk,
-					EVENT.promotion,
-					EVENT.strange_building,
-					EVENT.sororitas,
-					EVENT.rogue_trader,
-					EVENT.inquisition_mission,
-					EVENT.inquisition_planet,
-					EVENT.mechanicus_mission
+						EVENT.space_hulk,
+						EVENT.promotion,
+						EVENT.strange_building,
+						EVENT.sororitas,
+						EVENT.rogue_trader,
+						EVENT.inquisition_mission,
+						EVENT.inquisition_planet,
+						EVENT.mechanicus_mission
 					];
 				}
 				else if(player_luck == luck.neutral){
 					events = 
 					[
-					EVENT.strange_behavior,
-					EVENT.fleet_delay,
-					EVENT.harlequins,
-					EVENT.succession_war,
-					EVENT.random_fun,
+						EVENT.strange_behavior,
+						EVENT.fleet_delay,
+						EVENT.harlequins,
+						EVENT.succession_war,
+						EVENT.random_fun,
 					];
 				}
 				else if(player_luck == luck.bad){
 					events = 
 					[
-					EVENT.warp_storms,
-					EVENT.enemy_forces,
-					EVENT.crusade,
-					EVENT.enemy,
-					EVENT.mutation,
-					EVENT.ship_lost,
-					EVENT.chaos_invasion,
-					EVENT.necron_awaken,
-					EVENT.fallen,
+						EVENT.warp_storms,
+						EVENT.enemy_forces,
+						EVENT.crusade,
+						EVENT.enemy,
+						EVENT.mutation,
+						EVENT.ship_lost,
+						EVENT.chaos_invasion,
+						EVENT.necron_awaken,
+						EVENT.fallen,
 					];
 				}
 	
@@ -223,9 +221,9 @@ function scr_random_event(execute_now) {
 		random_event_next = chosen_event;
 		exit;
 	}
-	
 
 	if (chosen_event == EVENT.strange_behavior){
+		//TODO this event currenlty dose'nt do anything but now we have marine structs there is lots of potential here
 		debugl("RE: Strange Behavior");
 	    var marine_and_company = scr_random_marine("",0);
 		if(marine_and_company == "none")
@@ -354,6 +352,7 @@ function scr_random_event(execute_now) {
 		var heritical_item = false;
         
 		//this bit should be improved, idk what duke was checking for here
+		//TODO make craft chance reflective of crafters skill, rewards players for having skilled tech area
         if (string_count("Shit",obj_ini.strin2)>0) {
 			craft_roll+=20;
 		}
@@ -1268,35 +1267,8 @@ function scr_random_event(execute_now) {
 	}
 
 	else if ((chosen_event == EVENT.crusade)){
-	    var star_id = scr_random_find(2,true,"","");
-		if(star_id == undefined){
-			debugl("RE: Crusade, couldn't find a star for the crusade");
-			exit;	
-		}
-		else{
-			var assigned_crusade = false;
-			for(var i = 1; i <= star_id.planets && !assigned_crusade;i++){
-				for(var j = 1; j <= 4 && !assigned_crusade;  j++){
-					if(star_id.p_problem[i,j] == ""){
-						star_id.p_problem[i,j] = "great_crusade";
-						star_id.p_timer[i,j] = 24;
-						assigned_crusade = true;
-					}
-				}
-			}
-			if(!assigned_crusade){
-				debugl("RE: Crusade, couldn't assign a crusade at the system");
-				exit;
-			}
-			else{
-				scr_popup("Crusade","Fellow Astartes legions are preparing to embark on a Crusade to a nearby sector.  Your forces are expected at "+string(star_id.name)+"; 24 turns from now your ships there shall begin their journey.","crusade","");
-				var star_alert = instance_create(star_id.x+16,star_id.y-24,obj_star_event);
-				star_alert.image_alpha=1;
-				star_alert.image_speed=1;
-				scr_event_log("","A Crusade is called; our forces are expected at "+string(star_id.name)+" in 24 months.");
-				evented = true;	
-			}
-		}
+		//i think all events should be hanlded like this then we have far more options on when to call them and how they work
+		evented = launch_crusade();
 	}
     
 	else if (chosen_event == EVENT.enemy) {
@@ -1369,6 +1341,7 @@ function scr_random_event(execute_now) {
 	}
     
 	else if ((chosen_event == EVENT.mutation)) {
+		//TODO make reprocussions to ignoring this
 		debugl("RE: Gene-Seed Mutation");
 	    var text = "The Chapter's gene-seed has mutated!  Apothecaries are scrambling to control the damage and prevent further contamination.  What is thy will?";
 	    scr_popup("Gene-Seed Mutated!",text,"gene_bad","");

--- a/scripts/scr_random_event/scr_random_event.gml
+++ b/scripts/scr_random_event/scr_random_event.gml
@@ -1510,56 +1510,7 @@ function scr_random_event(execute_now) {
 	}
     
 	else if (chosen_event == EVENT.necron_awaken){
-		debugl("RE: Necron Tomb Awakens");
-		var stars = scr_get_stars();
-		
-		var valid_stars = array_filter_ext(stars, 
-			function(star, index){
-				var tomb_world = scr_get_planet_with_feature(star,P_features.Necron_Tomb);
-				
-				if (tomb_world == -1) then return false;
-				else {
-					return awake_tomb_world(star.p_feature[tomb_world]) == 0;
-				}
-		});
-	
-		if(valid_stars == 0){
-			debugl("RE: Necron Tomb Awakens, couldn't find a sleeping necron tomb");
-			exit;
-		}
-		
-		var star_index = irandom(valid_stars-1);
-		var star = stars[star_index];
-		var planet = -1;
-		for(var i = 1; i <= star.planets; i++) {
-			if (awake_tomb_world(star.p_feature[i])!=1){
-				planet = i;
-				break;
-			}
-		}
-		
-		if(planet == -1) {
-			debugl("RE: Necron Tomb Awakens, couldn't find a sleeping necron tomb planet");
-			exit;
-		}
-		
-        var text=string(star.name) + string(scr_roman(planet));
-        scr_event_log("red","The Necron Tomb on "+string(text)+" has surged into activity.");
-        scr_popup("Necron Awakening","The Necron Tomb on "+string(text)+" has surged into activity.  Rank upon rank of the abominations are pouring out from their tunnels.","necron_tomb","");
-        var star_alert=instance_create(star.x+16,star.y-24,obj_star_event);
-		star_alert.image_alpha=1;
-		star_alert.image_speed=1;
-		star_alert.col="red"; 
-        star.p_pdf[planet]=0;
-		star.p_necrons[planet]=6;
-		
-        if (star.p_guardsmen[planet]<2000000) {
-			star.p_guardsmen[planet]=0;
-		}
-		if (star.p_guardsmen[planet]>=2000000) {
-			star.p_guardsmen[planet]=round(star.p_guardsmen[planet]/2);
-		}
-		evented = true;
+		evented = awaken_tomb_event();
 	}
 	
 	else if(chosen_event == EVENT.fallen){

--- a/scripts/scr_return_ship/scr_return_ship.gml
+++ b/scripts/scr_return_ship/scr_return_ship.gml
@@ -36,7 +36,8 @@ function scr_return_ship(ship_name, object, planet_number) {
     
 	    if (object.man_sel[i]>0){
 	        if (object.man[i]="man"){
-	            obj_ini.lid[comp][object.ide[i]]=object.man_sel[i];obj_ini.wid[comp][object.ide[i]]=0;
+	            obj_ini.lid[comp][object.ide[i]]=object.man_sel[i];
+	            obj_ini.wid[comp][object.ide[i]]=0;
 	        }
 	        // if (comp!=0) then show_message(comp);
 	        // show_message(string(i)+"] ide:"+string(object.ide[i])+" = "+string(obj_ini.role[comp][object.ide[i]]));


### PR DESCRIPTION
a few minor bug fixes
- in obj_en_fleet/Alarm1  a variable not being checked for noone value resulting in crash
- necron tombs not displaying the correct name after being sealed or awakening
- excess number of marines sometimes dying in crusades
- also a general refactor of crusades script
- refactored crusade event into a function so it can be activated more readily and cleans up event script
- minor feature in a report of heroic deeds from crusades (logs new traits added to marines)
- added cheat/debug for crusading

to test and to launch crusades at will enter "eventcrusade" into the cheat console and then check the event log to see where the crusade event launched send fleet and end turn until crusade fleet returns