### PR TITLE
corruption change and emissary bug

### DIFF
--- a/objects/obj_controller/Alarm_5.gml
+++ b/objects/obj_controller/Alarm_5.gml
@@ -896,19 +896,20 @@ if (gene_xeno>0){
         }
     }
 }
-var p=0,penitorium=0;
+var p=0,penitorium=0, unit;
 for(var c=0; c<11; c++){
     for(var e=1; e<=250; e++){
         if (obj_ini.god[c,e]>=10){
+            unit=obj_ini.TTRPG[c][e];
             p+=1;
             penit_co[p]=c;
             penit_id[p]=e;
             penitorium+=1;
-            if (obj_ini.chaos[c,e]<90) and (obj_ini.chaos[c,e]>0){
+            if (unit.corruption<90) and (unit.corruption>0){
                 var heresy_old=0,heresy_new=0;
-                heresy_old=round((obj_ini.chaos[c,e]*obj_ini.chaos[c,e])/50)-0.5;
-                heresy_new=(heresy_old*50)/obj_ini.chaos[c,e];
-                obj_ini.chaos[c,e]=max(0,heresy_new);
+                heresy_old=round((unit.corruption*unit.corruption)/50)-0.5;
+                heresy_new=(heresy_old*50)/unit.corruption;
+                unit.corruption=max(0,heresy_new);
             }
         }
     }
@@ -1559,12 +1560,13 @@ for(var i=1; i<=99; i++){
             }
 
             if (string_count("strange_building",event[i])>0){
-                var b_event="",marine_name="",comp=0,marine_num=0,item="";
+                var b_event="",marine_name="",comp=0,marine_num=0,item="",unit;
                 explode_script(event[i],"|");
                 b_event=string(explode[0]);
                 marine_name=string(explode[1]);
                 comp=real(explode[2]);
                 marine_num=real(explode[3]);
+                unit=obj_ini.TTRPG[comp][marine_num];
                 item=string(explode[4]);
 
                 var killy=0,tixt=string(obj_ini.role[100][16])+" "+string(marine_name)+" has finished his work- ";
@@ -1596,38 +1598,24 @@ for(var i=1; i<=99; i++){
                     tixt+="some form of divine inspiration has seemed to have taken hold of him.  An artifact "+string(obj_ini.artifact[k])+" has been crafted.";
                 }
                 if (item=="baby"){
-                    obj_ini.chaos[comp,marine_num]+=choose(8,12,16,20);
+                    unit.corruption+=choose(8,12,16,20);
                     tixt+="some form of horrendous statue.  A weird amalgram of limbs and tentacles, the sheer atrocity of it is made worse by the tiny, baby-like form, the once natural shape of a human child twisted nearly beyond recognition.";
                 }
                 if (item=="robot"){
-                    obj_ini.chaos[comp,marine_num]+=choose(2,4,6,8,10);
+                    unit.corruption+=choose(2,4,6,8,10);
                     tixt+="some form of small, box-like robot.  It seems to teeter around haphazardly, nearly falling over with each step.  "+string(marine_name)+" maintains that it has no AI, though the other "+string(obj_ini.role[100][16])+" express skepticism.";
                 }
                 if (item=="demon"){
-                    obj_ini.chaos[comp,marine_num]+=choose(8,12,16,20);
+                    unit.corruption+=choose(8,12,16,20);
                     tixt+="some form of horrendous statue.  What was meant to be some sort of angel, or primarch, instead has a mishappen face that is hardly human in nature.  Between the fetid, ragged feathers and empty sockets it is truly blasphemous.";
                 }
                 if (item=="fusion"){
-                    // obj_ini.chaos[comp,marine_num]+=choose(70);
+                    // unit.corruption+=choose(70);
                     tixt+="some kind of ill-mannered ascension.  One of your battle-brothers enters the armamentarium to find "+string(marine_name)+" fused to a vehicle, his flesh twisted and submerged into the frame.  Mechendrites and weapons fire upon the marine without warning, a windy scream eminating from the abomination.  It takes several battle-brothers to take out what was once a "+string(obj_ini.role[100][16])+".";
 
                     // This is causing the problem
 
-                    obj_ini.race[comp,marine_num]=0;
-                    obj_ini.loc[comp,marine_num]="";
-                    obj_ini.name[comp,marine_num]="";
-                    obj_ini.role[comp,marine_num]="";
-                    obj_ini.wep1[comp,marine_num]="";
-                    obj_ini.lid[comp,marine_num]=0;
-                    obj_ini.wep2[comp,marine_num]="";
-                    obj_ini.armour[comp,marine_num]="";
-                    obj_ini.gear[comp,marine_num]="";
-                    obj_ini.hp[comp,marine_num]=100;
-                    obj_ini.chaos[comp,marine_num]=0;
-                    obj_ini.experience[comp,marine_num]=0;
-                    obj_ini.mobi[comp,marine_num]="";
-                    obj_ini.age[comp,marine_num]=0;
-					obj_ini.TTRPG[comp,marine_num]=new TTRPG_stats("chapter",comp,marine_num, "blank");
+                    scr_kill_unit(comp,marine_num)
                     with(obj_ini){scr_company_order(0);}
                 }
                 scr_popup("He Built It",tixt,"tech_build","target_marine|"+string(marine_name)+"|"+string(comp)+"|"+string(marine_num)+"|");

--- a/objects/obj_controller/Mouse_50.gml
+++ b/objects/obj_controller/Mouse_50.gml
@@ -534,7 +534,7 @@ if (menu==20) and (diplomacy==10.1){
                 //TODO make this into a real dual with consequences
                 pop_up = instance_create(0,0,obj_popup);
                 pop_up.title = "Skull for the Skull Throne";
-                pop_up.text = $"You summon {dead_champ.name_role()} to your personal chambers. Darting from the shadows {dead_champ.name()} is a cunning warrior and reacts with precision gowever eventually you previal and strike him down. With the flesh removed from his skull you place the skull upon a hastily erected shrine."
+                pop_up.text = $"You summon {dead_champ.name_role()} to your personal chambers. Darting from the shadows towards {dead_champ.name()} who is a cunning warrior and reacts with precision to your attack, however eventually you prevail and strike him down. With the flesh removed from his skull you place it upon a hastily erected shrine."
                 pop_up.type=98;
                 pop_up.image = "chaos";                
                // obj_duel = instance_create(0,0,obj_duel);

--- a/objects/obj_controller/Mouse_50.gml
+++ b/objects/obj_controller/Mouse_50.gml
@@ -507,6 +507,7 @@ if (menu==20) and (diplomacy==10.1){
             //grab a random librarian
             var lib = scr_random_marine("lib",0);
             if (lib!="none"){
+                var chapter_master = obj_ini.TTRPG[0][1];
                 var dead_lib = obj_ini.TTRPG[lib[0],lib[1]];
                 pop_up = instance_create(0,0,obj_popup);
                 pop_up.title = "Skull for the Skull Throne";
@@ -514,6 +515,7 @@ if (menu==20) and (diplomacy==10.1){
                 pop_up.type=98;
                 pop_up.image = "chaos";
                 scr_kill_unit(lib[0],lib[1]);
+                chapter_master.add_trait("blood_for_blood");
             } else {
                 diplomacy_pathway = "daemon_scorn";
             }
@@ -526,7 +528,15 @@ if (menu==20) and (diplomacy==10.1){
 			diplomacy_pathway = "sacrifice_champ";
             var champ = scr_random_marine(obj_ini.role[100,7],0);
             if (champ!="none"){
-                var dead_champ = obj_ini.TTRPG[champ[0],champ[1]];
+                var chapter_master = obj_ini.TTRPG[0][1];
+                 chapter_master.add_trait("blood_for_blood");
+                var dead_champ = obj_ini.TTRPG[champ[0]][champ[1]];
+                //TODO make this into a real dual with consequences
+                pop_up = instance_create(0,0,obj_popup);
+                pop_up.title = "Skull for the Skull Throne";
+                pop_up.text = $"You summon {dead_champ.name_role()} to your personal chambers. Darting from the shadows {dead_champ.name()} is a cunning warrior and reacts with precision gowever eventually you previal and strike him down. With the flesh removed from his skull you place the skull upon a hastily erected shrine."
+                pop_up.type=98;
+                pop_up.image = "chaos";                
                // obj_duel = instance_create(0,0,obj_duel);
                // obj_duel.title = "Ambush Champion";
                // pop.type="duel";
@@ -540,13 +550,22 @@ if (menu==20) and (diplomacy==10.1){
         if (point_in_rectangle(mouse_x, mouse_y, option_selections[2].lh, option_selections[2].top, option_selections[2].rh, option_selections[2].base)){
 			cooldown=8000;
 			diplomacy_pathway = "sacrifice_squad";
-            var kill_squad;
+            var kill_squad, squad_found=false;
             for(var i=0;i<array_length(obj_ini.squads);i++){
                 kill_squad = obj_ini.squads[i];
-                if (kill_squad.type == "tactical_squad"){
+                if (kill_squad.type == "tactical_squad" && array_length(kill_squad.members)>4){
+                    var chapter_master = obj_ini.TTRPG[0][1];
+                    chapter_master.add_trait("blood_for_blood");                    
                     kill_squad.kill_members();
+                    with(obj_ini){
+                        scr_company_order(kill_squad.base_company);
+                    }
+                    squad_found=true
                     break;
                 }
+            }
+            if (!squad_found){
+                diplomacy_pathway = "daemon_scorn";
             }
 			scr_dialogue(diplomacy_pathway);
 			force_goodbye = 1;

--- a/objects/obj_event/Step_0.gml
+++ b/objects/obj_event/Step_0.gml
@@ -12,14 +12,15 @@ if (closing=true) and (fading=-1) and (fade_alpha<=0){
         if (obj_controller.fest_feature3=1) then obj_controller.fest_drugses+=1;
     }
     
-    var ide;ide=0;
+    var ide=0, unit;
     repeat(700){ide+=1;
+        unit = obj_ini.TTRPG[attend_co[ide]][attend_id[ide]];
         if (attend_corrupted[ide]=0) and (attend_id[ide]>0){
             if (array_contains(obj_ini.artifact_tags[obj_controller.fest_display],"Chaos")){
-                obj_ini.chaos[attend_co[ide],attend_id[ide]]+=choose(1,2,3,4);
+                unit.corruption+=choose(1,2,3,4);
             }
             if (array_contains(obj_ini.artifact_tags[obj_controller.fest_display],"Daemon")){
-                obj_ini.chaos[attend_co[ide],attend_id[ide]]+=choose(6,7,8,9);
+                unit.corruption+=choose(6,7,8,9);
             }            
             attend_corrupted[ide]=1;
         }
@@ -82,15 +83,12 @@ if (ticked=1){// Select a random marine and have them perform an action
     dice1=floor(random(100))+1;
     dice2=floor(random(100))+1;
     dice3=floor(random(100))+1;
+    var unit = obj_ini.TTRPG[attend_co[ide]][attend_id[ide]];
     
     repeat(20){
         if (good=false){
             good=true;ide=floor(random(attendants))+1;
-            if (obj_ini.role[attend_co[ide],attend_id[ide]]="Chapter Master") then good=false;
-            if (obj_ini.role[attend_co[ide],attend_id[ide]]="Master of Sanctity") then good=false;
-            if (obj_ini.role[attend_co[ide],attend_id[ide]]="Master of the Apothecarion") then good=false;
-            if (obj_ini.role[attend_co[ide],attend_id[ide]]="Forge Master") then good=false;
-            if (obj_ini.role[attend_co[ide],attend_id[ide]]="Chief "+string(obj_ini.role[100,17])) then good=false;
+            if (unit.IsSpecialist("heads")) then good=false;
         }
     }
     if (good=false) then good=true;
@@ -140,7 +138,7 @@ if (ticked=1){// Select a random marine and have them perform an action
         if (dice1>70) then doso=true;
     }
     if (attend_confused[ide]<=0) and (activity="") then doso=true;
-    
+    var unit = obj_ini.TTRPG[attend_co[ide]][attend_id[ide]];
     if (doso=true){
         dice1=floor(random(100))+1;
         dice2=floor(random(100))+1;
@@ -155,8 +153,8 @@ if (ticked=1){// Select a random marine and have them perform an action
             rep2=attend_drunk[ide]+1;
             rep3=attend_high[ide]+1;
             
-            mod2=obj_ini.chaos[attend_co[ide],attend_id[ide]]/5;
-            mod3=obj_ini.chaos[attend_co[ide],attend_id[ide]]/10;
+            mod2=unit.corruption/5;
+            mod3=unit.corruption/10;
             
             activity="talk";
             
@@ -179,52 +177,52 @@ if (ticked=1){// Select a random marine and have them perform an action
     
     if (activity="confused"){
         rando=choose(1,2,2,3);
-        if (rando=1) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" is unsure of what to do.  He sits at the table silently, doing nothing.";
-        if (rando=2) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" is confused.  He sits at the table and does nothing, wishing he were "+choose("killing xenos","praying","training","training","studying")+" instead.";
+        if (rando=1) then textt=unit.name_role()+" is unsure of what to do.  He sits at the table silently, doing nothing.";
+        if (rando=2) then textt=unit.name_role()+" is confused.  He sits at the table and does nothing, wishing he were "+choose("killing xenos","praying","training","training","studying")+" instead.";
         
         // Special CONFUS for the various event types
         if (rando=3){
-            if (obj_controller.fest_type="Great Feast") and (obj_controller.fest_feature1>0) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" picks up silverwear to begin to feast, but then has second thoughts and puts them back down.";
-            if (obj_controller.fest_type="Great Feast") and (obj_controller.fest_feature1<=0) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" is unsure of what to do.  He sits at the table silently, doing nothing.";
+            if (obj_controller.fest_type="Great Feast") and (obj_controller.fest_feature1>0) then textt=unit.name_role()+" picks up silverwear to begin to feast, but then has second thoughts and puts them back down.";
+            if (obj_controller.fest_type="Great Feast") and (obj_controller.fest_feature1<=0) then textt=unit.name_role()+" is unsure of what to do.  He sits at the table silently, doing nothing.";
         }
         
     }
     if (activity="eat"){
-        var eater_type;eater_type=1;
+        var eater_type=1;
         if (global.chapter_name="Space Wolves") or (obj_ini.progenitor=3) then eater_type=2;
         
         if (stage=5) and (eater_type=1){rando=choose(1,2,3);
-            if (rando=1) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" digs into the food and begins to eat.";
-            if (rando=2) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" begins to feast, eating the food slowly to enjoy the taste.";
-            if (rando=3) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" grabs a portion of food for himself and begins to eat.";
+            if (rando=1) then textt=unit.name_role()+" digs into the food and begins to eat.";
+            if (rando=2) then textt=unit.name_role()+" begins to feast, eating the food slowly to enjoy the taste.";
+            if (rando=3) then textt=unit.name_role()+" grabs a portion of food for himself and begins to eat.";
         }
         if (stage=5) and (eater_type=2){rando=choose(1,2,3);
-            if (rando=1) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" digs into the food and begins to eat.";
-            if (rando=2) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" makes a show out of eating, consuming the food as loudly and dramaticaly as possible.";
-            if (rando=3) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" begins to stuff their face full of food, hardly bothering to chew.";
+            if (rando=1) then textt=unit.name_role()+" digs into the food and begins to eat.";
+            if (rando=2) then textt=unit.name_role()+" makes a show out of eating, consuming the food as loudly and dramaticaly as possible.";
+            if (rando=3) then textt=unit.name_role()+" begins to stuff their face full of food, hardly bothering to chew.";
         }
         if (stage=6){
             if (part2="fish"){rando=choose(1,2,3,3,3);
-                if (rando=1) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" selects some of the sushi rolls and begins to pop them into his mouth.";
-                if (rando=2) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" chooses a bit of each dish, chapter serfs setting up quite the variety of foods on his plate.";
-                if (rando=3) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" grabs a portion of the broadbill and begins to eat it slowly, savoring the taste.";
+                if (rando=1) then textt=unit.name_role()+" selects some of the sushi rolls and begins to pop them into his mouth.";
+                if (rando=2) then textt=unit.name_role()+" chooses a bit of each dish, chapter serfs setting up quite the variety of foods on his plate.";
+                if (rando=3) then textt=unit.name_role()+" grabs a portion of the broadbill and begins to eat it slowly, savoring the taste.";
             }
             if (part2="fruit"){rando=choose(1,2,3,3,3);
-                if (rando=1) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" selects an assortment of fruit and begins to eat.";
-                if (rando=2) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" finishes up the rest of his plate, and hails a serf to bring him some "+choose("pineapple","strawberries","grapes","apples","oranges","of each fruit")+".";
-                if (rando=3) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" hails a chapter serf, and orders a variety of different fruits.  He then eats them slowly, enjoying the taste.";
+                if (rando=1) then textt=unit.name_role()+" selects an assortment of fruit and begins to eat.";
+                if (rando=2) then textt=unit.name_role()+" finishes up the rest of his plate, and hails a serf to bring him some "+choose("pineapple","strawberries","grapes","apples","oranges","of each fruit")+".";
+                if (rando=3) then textt=unit.name_role()+" hails a chapter serf, and orders a variety of different fruits.  He then eats them slowly, enjoying the taste.";
             }
         }
         if (stage=7){
             if (part3="lobster"){
                 rando=choose(1,2,2,3,3);
                 if (eater_type=2) then rando=choose(1,2,2,3,3,4);
-                if (rando=1) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" helps break open one of the massive legs of the Deathcoleri, then scoops out some of the meat within.";
-                if (rando=2) and (eater_type=1) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" tears some of the tendrils free from the crustacean and begins to eat them.";
-                if (rando=3) and (eater_type=1) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" rips some of the delectable meat free from the Deathcoleri's leg, and then eats it slowly, enjoying the treat.";
-                if (rando=2) and (eater_type=2) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" begins to shovel Deathcoleri meat down his throat, boasting that he will eat more than anyone else.";
-                if (rando=3) and (eater_type=2) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" rips tendrils free from the crustaceans face and begins to eat them, loudly.";
-                if (rando=4) then text=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" wants the good parts.  He shoves his arm through the beast's shell and scoops out the innards, taking some for himself and sharing other bits.";
+                if (rando=1) then textt=unit.name_role()+" helps break open one of the massive legs of the Deathcoleri, then scoops out some of the meat within.";
+                if (rando=2) and (eater_type=1) then textt=unit.name_role()+" tears some of the tendrils free from the crustacean and begins to eat them.";
+                if (rando=3) and (eater_type=1) then textt=unit.name_role()+" rips some of the delectable meat free from the Deathcoleri's leg, and then eats it slowly, enjoying the treat.";
+                if (rando=2) and (eater_type=2) then textt=unit.name_role()+" begins to shovel Deathcoleri meat down his throat, boasting that he will eat more than anyone else.";
+                if (rando=3) and (eater_type=2) then textt=unit.name_role()+" rips tendrils free from the crustaceans face and begins to eat them, loudly.";
+                if (rando=4) then text=unit.name_role()+" wants the good parts.  He shoves his arm through the beast's shell and scoops out the innards, taking some for himself and sharing other bits.";
             }
         }
         
@@ -236,30 +234,30 @@ if (ticked=1){// Select a random marine and have them perform an action
         if (global.chapter_name="Blood Angels") or (obj_ini.progenitor=5) then eater_type=3;
         
         if (eater_type=1){
-            if (attend_drunk[ide]<=0) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" hails a serf and has "+choose("him","her")+" pour some Amasec.";
-            if (attend_drunk[ide]>0) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" sips at his Amasec, "+choose("enjoying the taste","judging the quality","savoring the treat")+".";
+            if (attend_drunk[ide]<=0) then textt=unit.name_role()+" hails a serf and has "+choose("him","her")+" pour some Amasec.";
+            if (attend_drunk[ide]>0) then textt=unit.name_role()+" sips at his Amasec, "+choose("enjoying the taste","judging the quality","savoring the treat")+".";
         }
         if (eater_type=2){
-            // if (attend_drunk[ide]<=0) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" hails a serf and has "+choose("him","her")+" bring him a tankard of Mjod.";
+            // if (attend_drunk[ide]<=0) then textt=unit.name_role()+" hails a serf and has "+choose("him","her")+" bring him a tankard of Mjod.";
             // if (attend_drunk[ide]>0){
                 rando=choose(1,2,3);
-                if (rando=1) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" pounds down Mjod, the concoction already beginning to inebriate the astartes.";
-                if (rando=2) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" boasts that he will outdrink anyone, and then pounds down his tankard.  Nearby battlebrothers laugh and begin to meet his challenge.";
-                if (rando=3) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" begins to drink down Mjod, a large frothing glass of the substance in each hand.  He alternates between the two.";
+                if (rando=1) then textt=unit.name_role()+" pounds down Mjod, the concoction already beginning to inebriate the astartes.";
+                if (rando=2) then textt=unit.name_role()+" boasts that he will outdrink anyone, and then pounds down his tankard.  Nearby battlebrothers laugh and begin to meet his challenge.";
+                if (rando=3) then textt=unit.name_role()+" begins to drink down Mjod, a large frothing glass of the substance in each hand.  He alternates between the two.";
             // }
         }
         if (eater_type=3){
-            if (attend_drunk[ide]<=0) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" hails a serf and has "+choose("him","her")+" pour him a glass of "+choose("red wine","Amasec","Dammassine")+".";
-            if (attend_drunk[ide]>0) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" sips at his drink slowly, "+choose("enjoying the taste","judging the quality","analyzing the components")+".";
+            if (attend_drunk[ide]<=0) then textt=unit.name_role()+" hails a serf and has "+choose("him","her")+" pour him a glass of "+choose("red wine","Amasec","Dammassine")+".";
+            if (attend_drunk[ide]>0) then textt=unit.name_role()+" sips at his drink slowly, "+choose("enjoying the taste","judging the quality","analyzing the components")+".";
         }
         
         attend_drunk[ide]+=1;
     }
     if (activity="drugs"){
         attend_high[ide]+=1;
-        obj_ini.chaos[attend_co[ide],attend_id[ide]]=min(100,obj_ini.chaos[attend_co[ide],attend_id[ide]]+10);
-        if (attend_high[ide]<=1) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" snorts up a line of powder through a straw.  Why not?";
-        if (attend_high[ide]>1) then textt=string(obj_ini.role[attend_co[ide],attend_id[ide]])+" "+string(obj_ini.name[attend_co[ide],attend_id[ide]])+" snorts another line of powder.";
+        unit.corruption=min(100,unit.corruption+10);
+        if (attend_high[ide]<=1) then textt=unit.name_role()+" snorts up a line of powder through a straw.  Why not?";
+        if (attend_high[ide]>1) then textt=unit.name_role()+" snorts another line of powder.";
     }
     
     
@@ -312,10 +310,10 @@ if (ticked=1){// Select a random marine and have them perform an action
         
         if (attend_corrupted[ide]=0){
             if (array_contains(obj_ini.artifact_tags[obj_controller.fest_display], "Chaos")){
-                obj_ini.chaos[attend_co[ide]][attend_id[ide]]+=choose(1,2,3,4);
+                unit.corruption+=choose(1,2,3,4);
             }
             if (array_contains(obj_ini.artifact_tags[obj_controller.fest_display], "Daemon")){
-                obj_ini.chaos[attend_co[ide],attend_id[ide]]+=choose(6,7,8,9);
+                unit.corruption+=choose(6,7,8,9);
             }
             attend_corrupted[ide]=1;
         }

--- a/objects/obj_ncombat/Alarm_7.gml
+++ b/objects/obj_ncombat/Alarm_7.gml
@@ -49,10 +49,7 @@ if (obj_ncombat.enemy=1){
                 
                 obj_ncombat.world_size+=scr_unit_size(obj_ini.armour[nco,nid],obj_ini.role[nco,nid],true, obj_ini.mobi[nco,nid]);
                 
-                obj_ini.race[nco,nid]=0;obj_ini.loc[nco,nid]="";obj_ini.name[nco,nid]="";obj_ini.role[nco,nid]="";obj_ini.wep1[nco,nid]="";
-                obj_ini.lid[nco,nid]=0;obj_ini.wep2[nco,nid]="";obj_ini.armour[nco,nid]="";obj_ini.gear[nco,nid]="";obj_ini.hp[nco,nid]=100;
-                obj_ini.chaos[nco,nid]=0;obj_ini.experience[nco,nid]=0;obj_ini.mobi[nco,nid]="";obj_ini.age[nco,nid]=0;
-                obj_ini.spe[nco,nid]="";obj_ini.god[nco,nid]=0;obj_ini.bio[nco,nid]=0;
+                scr_kill_unit(nco,nid);
             }
         }
     }

--- a/objects/obj_p_assra/Alarm_0.gml
+++ b/objects/obj_p_assra/Alarm_0.gml
@@ -41,9 +41,7 @@ o=0;repeat(20){o+=1;
             if (obj_ini.wep1[co][i]="Company Standard") then scr_loyalty("Lost Standard","+");
             if (obj_ini.wep2[co][i]="Company Standard") then scr_loyalty("Lost Standard","+");
             
-            obj_ini.race[co][i]=0;obj_ini.loc[co][i]="";obj_ini.name[co][i]="";obj_ini.role[co][i]="";obj_ini.wep1[co][i]="";obj_ini.lid[co][i]=0;
-            obj_ini.wep2[co][i]="";obj_ini.armour[co][i]="";obj_ini.gear[co][i]="";obj_ini.hp[co][i]=100;obj_ini.chaos[co][i]=0;obj_ini.experience[co][i]=0;
-            obj_ini.mobi[co][i]="";obj_ini.age[co][i]=0;obj_ini.spe[co][i]="";obj_ini.god[co][i]=0;obj_ini.bio[co][i]=0;
+            scr_kill_unit(co,i)
             
             if (obj_fleet.capital+obj_fleet.frigate+obj_fleet.escort>0) then obj_controller.gene_seed+=seed_max;
         }

--- a/objects/obj_pnunit/Alarm_6.gml
+++ b/objects/obj_pnunit/Alarm_6.gml
@@ -23,12 +23,7 @@ repeat(600){i+=1;
         if (obj_ini.wid[marine_co[i],marine_id[i]]>0) then obj_ncombat.world_size+=man_size;
         if (obj_ini.lid[marine_co[i],marine_id[i]]>0) then obj_ini.ship_carrying[obj_ini.lid[marine_co[i],marine_id[i]]]-=man_size;
         //
-        obj_ini.race[marine_co[i],marine_id[i]]=0;obj_ini.loc[marine_co[i],marine_id[i]]="";obj_ini.name[marine_co[i],marine_id[i]]="";
-        obj_ini.role[marine_co[i],marine_id[i]]="";obj_ini.wep1[marine_co[i],marine_id[i]]="";obj_ini.lid[marine_co[i],marine_id[i]]=0;
-        obj_ini.wid[marine_co[i],marine_id[i]]=2;obj_ini.wep2[marine_co[i],marine_id[i]]="";obj_ini.armour[marine_co[i],marine_id[i]]="";
-        obj_ini.gear[marine_co[i],marine_id[i]]="";obj_ini.hp[marine_co[i],marine_id[i]]=100;obj_ini.chaos[marine_co[i],marine_id[i]]=0;
-        obj_ini.experience[marine_co[i],marine_id[i]]=0;obj_ini.age[marine_co[i],marine_id[i]]=0;obj_ini.mobi[marine_co[i],marine_id[i]]="";
-        obj_ini.mobi[marine_co[i],marine_id[i]]="";obj_ini.spe[marine_co[i],marine_id[i]]="";
+        scr_kill_unit(marine_co[i],marine_id[i]);
     }
 
     // if (veh_type[i]="Predator") or (veh_type[i]="Land Raider") then show_message(string(veh_type[i])+" ("+string(veh_co[i])+"."+string(veh_id[i])+")#HP: "+string(veh_hp[i])+"#Dead: "+string(veh_dead[i])+"");

--- a/objects/obj_popup/Mouse_50.gml
+++ b/objects/obj_popup/Mouse_50.gml
@@ -1125,7 +1125,7 @@ if (mouse_x>=xx+408) and (mouse_y>=yy+393) and (mouse_x<xx+518) and (mouse_y<yy+
             if (target_comp>10) then target_comp=0;
 
             if (string_count("aemon",obj_ini.artifact_tags[obj_controller.menu_artifact])>0){
-                obj_ini.chaos[target_comp,obj_controller.ide[i]]+=choose(1,2,3,4,5,6)+choose(1,2,3,4,5,6);
+                obj_ini.TTRPG[target_comp][obj_controller.ide[i]].corruption+=choose(1,2,3,4,5,6)+choose(1,2,3,4,5,6);
                 if (string_count("dwarn|",obj_controller.useful_info)=0) and (obj_ini.role[target_comp,obj_controller.ide[i]]="Chapter Master"){
                     obj_controller.useful_info+="dwarn|";dwarn=true;
                 }

--- a/objects/obj_popup/Step_0.gml
+++ b/objects/obj_popup/Step_0.gml
@@ -232,10 +232,10 @@ if (title="Scheduled Event"){
                 repeat(700){ide+=1;
                     if (attend_corrupted[ide]=0) and (attend_id[ide]>0){
                         if (string_count("Chaos",obj_ini.artifact_tags[obj_controller.fest_display])>0){
-                            obj_ini.chaos[attend_co[ide],attend_id[ide]]+=choose(1,2,3,4);
+                            obj_ini.TTRPG[attend_co[ide],attend_id[ide]].corruption+=choose(1,2,3,4);
                         }
                         if (string_count("Daem",obj_ini.artifact_tags[obj_controller.fest_display])>0){
-                            obj_ini.chaos[attend_co[ide],attend_id[ide]]+=choose(6,7,8,9);
+                            obj_ini.TTRPG[attend_co[ide],attend_id[ide]].corruption+=choose(6,7,8,9);
                         }
                         attend_corrupted[ide]=1;
                     }
@@ -779,12 +779,7 @@ if (press=1) and (option1!="") or ((demand=1) and (mission!="") and (string_coun
         exit;    
     }
     if (title="He Built It"){
-        obj_ini.race[ma_co,ma_id]=0;obj_ini.loc[ma_co,ma_id]="";obj_ini.name[ma_co,ma_id]="";obj_ini.role[ma_co,ma_id]="";
-        obj_ini.wep1[ma_co,ma_id]="";obj_ini.lid[ma_co,ma_id]=0;obj_ini.wep2[ma_co,ma_id]="";obj_ini.armour[ma_co,ma_id]="";
-        obj_ini.gear[ma_co,ma_id]="";obj_ini.hp[ma_co,ma_id]=100;obj_ini.chaos[ma_co,ma_id]=0;obj_ini.experience[ma_co,ma_id]=0;
-        obj_ini.mobi[ma_co,ma_id]="";obj_ini.age[ma_co,ma_id]=0;
-        obj_ini.TTRPG[ma_co,ma_id]=new TTRPG_stats("chapter",ma_co,ma_id, "blank");
-;
+        scr_kill_unit(ma_co,ma_id);
         with(obj_ini){scr_company_order(0);}
     }
     

--- a/objects/obj_temp4/Alarm_2.gml
+++ b/objects/obj_temp4/Alarm_2.gml
@@ -25,7 +25,9 @@ i=0;
 if (string_count("Daemonic",obj_ini.artifact_tags[last_artifact-1])=1) then repeat(140){
     i+=1;
     if (man_sel[i]=1){
-        if (obj_controller.man[i]="man"){obj_ini.chaos[comp][i]+=choose(0,2,4,6,8);}
+        if (obj_controller.man[i]="man"){
+            obj_ini.TTRPG[comp][i].corruption+=choose(0,2,4,6,8);
+        }
         if (obj_controller.man[i]="vehicle"){obj_ini.veh_chaos[comp][i]+=choose(0,2,4,6,8);}
     }
 }

--- a/objects/obj_temp4/Alarm_3.gml
+++ b/objects/obj_temp4/Alarm_3.gml
@@ -25,7 +25,7 @@ i=0;
 if (string_count("Daemonic",obj_ini.artifact_tags[last_artifact-1])=1) then repeat(140){
     i+=1;
     if (man_sel[i]=1){
-        if (obj_controller.man[i]="man"){obj_ini.chaos[comp][i]+=choose(0,2,4,6,8);}
+        if (obj_controller.man[i]="man"){obj_ini.TTRPG[comp][i].corruption+=choose(0,2,4,6,8);}
         if (obj_controller.man[i]="vehicle"){obj_ini.veh_chaos[comp][i]+=choose(0,2,4,6,8);}
     }
 }

--- a/objects/obj_temp4/Alarm_4.gml
+++ b/objects/obj_temp4/Alarm_4.gml
@@ -93,7 +93,7 @@ i=0;
 if (string_count("Daemonic",obj_ini.artifact_tags[last_artifact-1])=1) then repeat(140){
     i+=1;
     if (man_sel[i]=1){
-        if (obj_controller.man[i]="man"){obj_ini.chaos[comp][i]+=choose(0,2,4,6,8);}
+        if (obj_controller.man[i]="man"){obj_ini.TTRPG[comp][i].corruption+=choose(0,2,4,6,8);}
         if (obj_controller.man[i]="vehicle"){obj_ini.veh_chaos[comp][i]+=choose(0,2,4,6,8);}
     }
 }

--- a/objects/obj_temp4/Alarm_5.gml
+++ b/objects/obj_temp4/Alarm_5.gml
@@ -103,16 +103,6 @@ with(obj_star_select){instance_destroy();}
 with(obj_fleet_select){instance_destroy();}
  delete_features(plan.p_feature[num], P_features.STC_Fragment);
 
-/*i=0;
-if (string_count("Daemonic",obj_ini.artifact_tags[last_artifact-1])=1) then repeat(140){
-    i+=1;
-    if (man_sel[i]=1){
-        if (obj_controller.man[i]="man"){obj_ini.chaos[comp][i]+=choose(0,2,4,6,8);}
-        if (obj_controller.man[i]="vehicle"){obj_ini.veh_chaos[comp][i]+=choose(0,2,4,6,8);}
-    }
-}*/
-
-
 scr_add_stc_fragment();// STC here
 
 

--- a/scripts/scr_add_corruption/scr_add_corruption.gml
+++ b/scripts/scr_add_corruption/scr_add_corruption.gml
@@ -1,7 +1,7 @@
-function scr_add_corruption(argument0, argument1) {
+function scr_add_corruption(is_fleet, modifier_type) {
 
-	// argument0: fleet (true) or planet (false)
-	// argument1: amount
+	// is_fleet: fleet (true) or planet (false)
+	// modifier_type: amount
 
 	// Corrupts marines at the target location
 
@@ -9,14 +9,14 @@ function scr_add_corruption(argument0, argument1) {
 	i=capital_number+escort_number+frigate_number;
 	c=0;shi=0;m=0;co=0;ide=0;
 
-	if (argument0=true){
+	if (is_fleet=true){
 	    repeat(capital_number){
 	        c+=1;shi=capital_num[c];co=0;ide=0;
 	        if (obj_ini.ship_carrying[shi]>0) then repeat(3500){
 	            if (co<10){ide+=1;
 	                if (ide>=300){co+=1;ide=1;}
 	                if (obj_ini.lid[co,ide]=shi){
-	                    if (argument1="1d3") then obj_ini.chaos[co,ide]+=choose(1,2,3);
+	                    if (modifier_type="1d3") then obj_ini.TTRPG[co][ide].corruption+=choose(1,2,3);
 	                }
 	            }
 	        }
@@ -27,7 +27,7 @@ function scr_add_corruption(argument0, argument1) {
 	            if (co<10){ide+=1;
 	                if (ide>=300){co+=1;ide=1;}
 	                if (obj_ini.lid[co,ide]=shi){
-	                    if (argument1="1d3") then obj_ini.chaos[co,ide]+=choose(1,2,3);
+	                    if (modifier_type="1d3") then obj_ini.TTRPG[co][ide].corruption+=choose(1,2,3);
 	                }
 	            }
 	        }
@@ -38,7 +38,7 @@ function scr_add_corruption(argument0, argument1) {
 	            if (co<10){ide+=1;
 	                if (ide>=300){co+=1;ide=1;}
 	                if (obj_ini.lid[co,ide]=shi){
-	                    if (argument1="1d3") then obj_ini.chaos[co,ide]+=choose(1,2,3);
+	                    if (modifier_type="1d3") then obj_ini.TTRPG[co][ide].corruption+=choose(1,2,3);
 	                }
 	            }
 	        }

--- a/scripts/scr_add_man/scr_add_man.gml
+++ b/scripts/scr_add_man/scr_add_man.gml
@@ -108,7 +108,6 @@ function scr_add_man(man_role, target_company, choice_armour, choice_weapons, ch
 	    obj_ini.wep1[target_company][good]="";
 	    obj_ini.wep2[target_company][good]="";
 	    obj_ini.armour[target_company][good]="";
-	    obj_ini.chaos[target_company][good]=corruption;
 	    obj_ini.experience[target_company][good]=spawn_exp;
 	    obj_ini.spe[target_company][good]="";
 	    obj_ini.god[target_company][good]=0;
@@ -269,6 +268,7 @@ function scr_add_man(man_role, target_company, choice_armour, choice_weapons, ch
     
     if (!array_contains(non_marine_roles,man_role)){
 		obj_ini.TTRPG[target_company, good] = new TTRPG_stats("chapter", target_company, good);
+		obj_ini.TTRPG[target_company, good].corruption=corruption
 		marines+=1;
 		}    
 	    with(obj_ini){scr_company_order(target_company);}

--- a/scripts/scr_civil_roster/scr_civil_roster.gml
+++ b/scripts/scr_civil_roster/scr_civil_roster.gml
@@ -88,22 +88,22 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
             
 	            // Chaos corruption check here
 	            if (new_combat.battle_special="cs_meeting_battle1"){
-	                if (deploying_unit.chaos[cooh,va]>=30) then new_combat.fighting[cooh,va]=1;
-	                if (deploying_unit.chaos[cooh,va]<30) then new_combat.fighting[cooh,va]=-5;
-	                if (deploying_unit.role[cooh,va]="Master of Sanctity") then new_combat.fighting[cooh,va]=-5;
+	                if (unit.corruption>=30) then new_combat.fighting[cooh,va]=1;
+	                if (unit.corruption<30) then new_combat.fighting[cooh,va]=-5;
+	                if (unit.role()="Master of Sanctity") then new_combat.fighting[cooh,va]=-5;
 	            }
 	            if (new_combat.battle_special="cs_meeting_battle2"){
-	                if (deploying_unit.chaos[cooh,va]>=3) then new_combat.fighting[cooh,va]=0;
-	                if (deploying_unit.chaos[cooh,va]<3) then new_combat.fighting[cooh,va]=-5;
-	                if (deploying_unit.role[cooh,va]="Master of Sanctity") then new_combat.fighting[cooh,va]=-5;
+	                if (unit.corruption>=3) then new_combat.fighting[cooh,va]=0;
+	                if (unit.corruption<3) then new_combat.fighting[cooh,va]=-5;
+	                if (unit.role()="Master of Sanctity") then new_combat.fighting[cooh,va]=-5;
 	            }
 	            if (new_combat.battle_special="cs_meeting_battle5") then new_combat.fighting[cooh,va]=1;
 	            if (new_combat.battle_special="cs_meeting_battle6") then new_combat.fighting[cooh,va]=1;
 	            if (new_combat.battle_special="cs_meeting_battle7"){
-	                if (deploying_unit.role[cooh,va]!="Chapter Master") then new_combat.fighting[cooh,va]=-5;
+	                if (unit.role()!="Chapter Master") then new_combat.fighting[cooh,va]=-5;
 	            }
             
-	            if (deploying_unit.role[cooh,va]="Chapter Master") then new_combat.fighting[cooh,va]=1;
+	            if (unit.role()="Chapter Master") then new_combat.fighting[cooh,va]=1;
 	            if (new_combat.fighting[cooh,va]=1) then he_good=1;
 	            if (new_combat.fighting[cooh,va]=-5) then he_good=-1;
             
@@ -114,23 +114,23 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
             
 	                var col,moov,targ;col=0;targ=0;moov=0;
                 
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][12]){col=22-obj_controller.bat_scout_column;new_combat.en_scouts+=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][8]){col=22-obj_controller.bat_tactical_column;new_combat.en_tacticals+=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][3]){col=22-obj_controller.bat_veteran_column;new_combat.en_veterans+=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][9]){col=22-obj_controller.bat_devastator_column;new_combat.en_devastators+=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][10]){col=22-obj_controller.bat_assault_column;new_combat.en_assaults+=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100,17]){col=22-obj_controller.bat_librarian_column;new_combat.en_librarians+=1;moov=1;}
-	                if (deploying_unit.role[cooh,va]=string(deploying_unit.role[100,17])+" Aspirant"){col=22-obj_controller.bat_librarian_column;new_combat.en_librarians+=1;moov=1;}
+	                if (unit.role()=deploying_unit.role[100][12]){col=22-obj_controller.bat_scout_column;new_combat.en_scouts+=1;}
+	                if (unit.role()=deploying_unit.role[100][8]){col=22-obj_controller.bat_tactical_column;new_combat.en_tacticals+=1;}
+	                if (unit.role()=deploying_unit.role[100][3]){col=22-obj_controller.bat_veteran_column;new_combat.en_veterans+=1;}
+	                if (unit.role()=deploying_unit.role[100][9]){col=22-obj_controller.bat_devastator_column;new_combat.en_devastators+=1;}
+	                if (unit.role()=deploying_unit.role[100][10]){col=22-obj_controller.bat_assault_column;new_combat.en_assaults+=1;}
+	                if (unit.role()=deploying_unit.role[100,17]){col=22-obj_controller.bat_librarian_column;new_combat.en_librarians+=1;moov=1;}
+	                if (unit.role()=string(deploying_unit.role[100,17])+" Aspirant"){col=22-obj_controller.bat_librarian_column;new_combat.en_librarians+=1;moov=1;}
                 
-	                if (deploying_unit.role[cooh,va]="Codiciery"){col=22-obj_controller.bat_librarian_column;new_combat.en_librarians+=1;moov=1;}
-	                if (deploying_unit.role[cooh,va]="Epistolary"){col=22-obj_controller.bat_librarian_column;new_combat.en_librarians+=1;moov=1;}
-	                if (deploying_unit.role[cooh,va]="Lexicanum"){col=22-obj_controller.bat_librarian_column;new_combat.en_librarians+=1;moov=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][16]){col=22-obj_controller.bat_techmarine_column;new_combat.en_techmarines+=1;moov=2;}
+	                if (unit.role()="Codiciery"){col=22-obj_controller.bat_librarian_column;new_combat.en_librarians+=1;moov=1;}
+	                if (unit.role()="Epistolary"){col=22-obj_controller.bat_librarian_column;new_combat.en_librarians+=1;moov=1;}
+	                if (unit.role()="Lexicanum"){col=22-obj_controller.bat_librarian_column;new_combat.en_librarians+=1;moov=1;}
+	                if (unit.role()=deploying_unit.role[100][16]){col=22-obj_controller.bat_techmarine_column;new_combat.en_techmarines+=1;moov=2;}
                 
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][2]){col=22-obj_controller.bat_honor_column;new_combat.en_honors+=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][6]){col=22-obj_controller.bat_dreadnought_column;new_combat.en_dreadnoughts+=1;}
-	                if (deploying_unit.role[cooh,va]="Venerable "+string(deploying_unit.role[100][6])){col=22-obj_controller.bat_dreadnought_column;new_combat.en_dreadnoughts+=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][4]){col=22-obj_controller.bat_terminator_column;new_combat.en_terminators+=1;}
+	                if (unit.role()=deploying_unit.role[100][2]){col=22-obj_controller.bat_honor_column;new_combat.en_honors+=1;}
+	                if (unit.role()=deploying_unit.role[100][6]){col=22-obj_controller.bat_dreadnought_column;new_combat.en_dreadnoughts+=1;}
+	                if (unit.role()="Venerable "+string(deploying_unit.role[100][6])){col=22-obj_controller.bat_dreadnought_column;new_combat.en_dreadnoughts+=1;}
+	                if (unit.role()=deploying_unit.role[100][4]){col=22-obj_controller.bat_terminator_column;new_combat.en_terminators+=1;}
                 
 	                if (moov>0){
 	                    if ((moov=1) and (obj_controller.command_set[8]=1)) or ((moov=2) and (obj_controller.command_set[9]=1)){
@@ -140,31 +140,31 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
 	                    }
 	                }
                 
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][15]) or (deploying_unit.role[cooh,va]=deploying_unit.role[100][14]) or (string_count("Aspirant",deploying_unit.role[cooh,va])>0){
-	                    if (deploying_unit.role[cooh,va]=string(deploying_unit.role[100][15])+" Aspirant"){col=22-obj_controller.bat_tactical_column;new_combat.en_tacticals+=1;}
-	                    if (deploying_unit.role[cooh,va]=string(deploying_unit.role[100][14])+" Aspirant"){col=22-obj_controller.bat_tactical_column;new_combat.en_tacticals+=1;}
+	                if (unit.role()=deploying_unit.role[100][15]) or (unit.role()=deploying_unit.role[100][14]) or (string_count("Aspirant",unit.role())>0){
+	                    if (unit.role()=string(deploying_unit.role[100][15])+" Aspirant"){col=22-obj_controller.bat_tactical_column;new_combat.en_tacticals+=1;}
+	                    if (unit.role()=string(deploying_unit.role[100][14])+" Aspirant"){col=22-obj_controller.bat_tactical_column;new_combat.en_tacticals+=1;}
                 
-	                    if (deploying_unit.role[cooh,va]=deploying_unit.role[100][15]) then new_combat.en_apothecaries+=1;
-	                    if (deploying_unit.role[cooh,va]=deploying_unit.role[100][14]){new_combat.en_chaplains+=1;if (new_combat.en_big_mofo>5) then new_combat.en_big_mofo=5;}
+	                    if (unit.role()=deploying_unit.role[100][15]) then new_combat.en_apothecaries+=1;
+	                    if (unit.role()=deploying_unit.role[100][14]){new_combat.en_chaplains+=1;if (new_combat.en_big_mofo>5) then new_combat.en_big_mofo=5;}
                     
 	                    col=22-obj_controller.bat_tactical_column;
 
-	                    if (obj_ini.armour[cooh,va]="Terminator Armour") then col=22-obj_controller.bat_terminator_column;
-	                    if (obj_ini.armour[cooh,va]="Tartaros Armour") then col=22-obj_controller.bat_terminator_column;
+	                    if (unit.armour()="Terminator Armour") then col=22-obj_controller.bat_terminator_column;
+	                    if (unit.armour()="Tartaros Armour") then col=22-obj_controller.bat_terminator_column;
 
 	                    if (co=10) then col=22-obj_controller.bat_scout_column;
 	                }
                 
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][5]) or (deploying_unit.role[cooh,va]="Standard Bearer") or (deploying_unit.role[cooh,va]=deploying_unit.role[100][7]){
-	                    if (deploying_unit.role[cooh,va]=deploying_unit.role[100][5]){new_combat.en_captains+=1;if (new_combat.en_big_mofo>5) then new_combat.en_big_mofo=5;}
-	                    if (deploying_unit.role[cooh,va]="Standard Bearer") then new_combat.en_standard_bearers+=1;
-						if (deploying_unit.role[cooh,va]=deploying_unit.role[100][7]) then new_combat.champions+=1;
+	                if (unit.role()=deploying_unit.role[100][5]) or (unit.role()="Standard Bearer") or (unit.role()=deploying_unit.role[100][7]){
+	                    if (unit.role()=deploying_unit.role[100][5]){new_combat.en_captains+=1;if (new_combat.en_big_mofo>5) then new_combat.en_big_mofo=5;}
+	                    if (unit.role()="Standard Bearer") then new_combat.en_standard_bearers+=1;
+						if (unit.role()=deploying_unit.role[100][7]) then new_combat.champions+=1;
                     
 	                    if (co=1){
 	                        col=22-obj_controller.bat_veteran_column;
 
-	                        if (obj_ini.armour[cooh,va]="Terminator Armour") then col=22-obj_controller.bat_terminator_column;
-	                        if (obj_ini.armour[cooh,va]="Tartaros Armour") then col=22-obj_controller.bat_terminator_column;
+	                        if (unit.armour()="Terminator Armour") then col=22-obj_controller.bat_terminator_column;
+	                        if (unit.armour()="Tartaros Armour") then col=22-obj_controller.bat_terminator_column;
 
 	                    }
 	                    if (co>=2) then col=22-obj_controller.bat_tactical_column;
@@ -172,10 +172,12 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
 	                    if (deploying_unit.mobi[cooh,va]="Jump Pack") then col=22-obj_controller.bat_assault_column;
 	                }
                 
-	                if (deploying_unit.role[cooh,va]="Forge Master"){col=22-obj_controller.bat_command_column;new_combat.en_important_dudes+=1;}
-	                if (deploying_unit.role[cooh,va]="Master of Sanctity"){col=22-obj_controller.bat_command_column;new_combat.en_important_dudes+=1;if (new_combat.en_big_mofo>2) then new_combat.en_big_mofo=2;}
-	                if (deploying_unit.role[cooh,va]="Master of the Apothecarion"){col=22-obj_controller.bat_command_column;new_combat.en_important_dudes+=1;}
-	                if (deploying_unit.role[cooh,va]="Chief "+string(deploying_unit.role[100,17])){col=22-obj_controller.bat_command_column;new_combat.en_important_dudes+=1;if (new_combat.en_big_mofo>3) then new_combat.en_big_mofo=3;}
+	                if (unit.role()="Forge Master"){col=22-obj_controller.bat_command_column;new_combat.en_important_dudes+=1;}
+	                if (unit.role()="Master of Sanctity"){col=22-obj_controller.bat_command_column;new_combat.en_important_dudes+=1;
+	                if (new_combat.en_big_mofo>2) then new_combat.en_big_mofo=2;}
+	                if (unit.role()="Master of the Apothecarion"){col=22-obj_controller.bat_command_column;new_combat.en_important_dudes+=1;}
+	                if (unit.role()="Chief "+string(deploying_unit.role[100,17])){col=22-obj_controller.bat_command_column;new_combat.en_important_dudes+=1;
+	                if (new_combat.en_big_mofo>3) then new_combat.en_big_mofo=3;}
                 
 	                if (col=0) then col=22-obj_controller.bat_hire_column;
                 
@@ -195,7 +197,7 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
 	                targ.men+=1;
 	                targ.dude_co[targ.men]=cooh;
 	                targ.dude_id[targ.men]=va;
-	                targ.dudes[targ.men]=deploying_unit.role[cooh,va];
+	                targ.dudes[targ.men]=unit.role();
 	                targ.dudes_num[targ.men]=1;
 	                targ.dudes_hp[targ.men]=deploying_unit.hp[cooh,va];
 	                targ.dudes_exp[targ.men]=deploying_unit.experience[cooh,va];
@@ -216,7 +218,7 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
 	                if (dr<0.25) then dr=0.25;
 	                targ.dudes_dr[targ.men]=dr;
                 
-	                if (deploying_unit.role[cooh,va]="Death Company"){// Ahahahahah
+	                if (unit.role()="Death Company"){// Ahahahahah
 	                    var really;really=false;
 
 	                    if (string_count("Dreadnought",obj_ini.armour[co][v])>0) then really=true;
@@ -256,7 +258,7 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
 	                    if (obj_controller.stc_bonus[2]=3){if (targ.dudes_ac[targ.men]>=40) then targ.dudes_ac[targ.men]+=2;if (targ.dudes_ac[targ.men]<40) then targ.dudes_ac[targ.men]+=1;}
 	                }
                 
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][6]) or (deploying_unit.role[cooh,va]="Venerable "+string(deploying_unit.role[100][6])){
+	                if (unit.role()=deploying_unit.role[100][6]) or (unit.role()="Venerable "+string(deploying_unit.role[100][6])){
 	                    targ.dudes_hp[targ.men]=targ.dudes_hp[targ.men]*2;targ.dreads+=1;
 	                }
 	                if (deploying_unit.mobi[cooh,va]="Bike") then targ.dudes_hp[targ.men]+=25;
@@ -275,23 +277,23 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
                 
 	                if (new_combat.battle_special="space_hulk") then new_combat.player_starting_dudes+=1;
                 
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][12]){col=obj_controller.bat_scout_column;new_combat.scouts+=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][8]){col=obj_controller.bat_tactical_column;new_combat.tacticals+=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][3]){col=obj_controller.bat_veteran_column;new_combat.veterans+=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][9]){col=obj_controller.bat_devastator_column;new_combat.devastators+=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][10]){col=obj_controller.bat_assault_column;new_combat.assaults+=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100,17]){col=obj_controller.bat_librarian_column;new_combat.librarians+=1;moov=1;}
-	                if (deploying_unit.role[cooh,va]=string(deploying_unit.role[100,17])+" Aspirant"){col=obj_controller.bat_librarian_column;new_combat.librarians+=1;moov=1;}
+	                if (unit.role()=deploying_unit.role[100][12]){col=obj_controller.bat_scout_column;new_combat.scouts+=1;}
+	                if (unit.role()=deploying_unit.role[100][8]){col=obj_controller.bat_tactical_column;new_combat.tacticals+=1;}
+	                if (unit.role()=deploying_unit.role[100][3]){col=obj_controller.bat_veteran_column;new_combat.veterans+=1;}
+	                if (unit.role()=deploying_unit.role[100][9]){col=obj_controller.bat_devastator_column;new_combat.devastators+=1;}
+	                if (unit.role()=deploying_unit.role[100][10]){col=obj_controller.bat_assault_column;new_combat.assaults+=1;}
+	                if (unit.role()=deploying_unit.role[100,17]){col=obj_controller.bat_librarian_column;new_combat.librarians+=1;moov=1;}
+	                if (unit.role()=string(deploying_unit.role[100,17])+" Aspirant"){col=obj_controller.bat_librarian_column;new_combat.librarians+=1;moov=1;}
                 
-	                if (deploying_unit.role[cooh,va]="Codiciery"){col=obj_controller.bat_librarian_column;new_combat.librarians+=1;moov=1;}
-	                if (deploying_unit.role[cooh,va]="Epistolary"){col=obj_controller.bat_librarian_column;new_combat.librarians+=1;moov=1;}
-	                if (deploying_unit.role[cooh,va]="Lexicanum"){col=obj_controller.bat_librarian_column;new_combat.librarians+=1;moov=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][16]){col=obj_controller.bat_techmarine_column;new_combat.techmarines+=1;moov=2;}
+	                if (unit.role()="Codiciery"){col=obj_controller.bat_librarian_column;new_combat.librarians+=1;moov=1;}
+	                if (unit.role()="Epistolary"){col=obj_controller.bat_librarian_column;new_combat.librarians+=1;moov=1;}
+	                if (unit.role()="Lexicanum"){col=obj_controller.bat_librarian_column;new_combat.librarians+=1;moov=1;}
+	                if (unit.role()=deploying_unit.role[100][16]){col=obj_controller.bat_techmarine_column;new_combat.techmarines+=1;moov=2;}
                 
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][2]){col=obj_controller.bat_honor_column;new_combat.honors+=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][6]){col=obj_controller.bat_dreadnought_column;new_combat.dreadnoughts+=1;}
-	                if (deploying_unit.role[cooh,va]="Venerable "+string(deploying_unit.role[100][6])){col=obj_controller.bat_dreadnought_column;new_combat.dreadnoughts+=1;}
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][4]){col=obj_controller.bat_terminator_column;new_combat.terminators+=1;}
+	                if (unit.role()=deploying_unit.role[100][2]){col=obj_controller.bat_honor_column;new_combat.honors+=1;}
+	                if (unit.role()=deploying_unit.role[100][6]){col=obj_controller.bat_dreadnought_column;new_combat.dreadnoughts+=1;}
+	                if (unit.role()="Venerable "+string(deploying_unit.role[100][6])){col=obj_controller.bat_dreadnought_column;new_combat.dreadnoughts+=1;}
+	                if (unit.role()=deploying_unit.role[100][4]){col=obj_controller.bat_terminator_column;new_combat.terminators+=1;}
                 
 	                if (moov>0){
 	                    if ((moov=1) and (obj_controller.command_set[8]=1)) or ((moov=2) and (obj_controller.command_set[9]=1)){
@@ -301,31 +303,31 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
 	                    }
 	                }
                 
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][15]) or (deploying_unit.role[cooh,va]=deploying_unit.role[100][14]) or (string_count("Aspirant",deploying_unit.role[cooh,va])>0){
-	                    if (deploying_unit.role[cooh,va]=string(deploying_unit.role[100][15])+" Aspirant"){col=obj_controller.bat_tactical_column;new_combat.tacticals+=1;}
-	                    if (deploying_unit.role[cooh,va]=string(deploying_unit.role[100][14])+" Aspirant"){col=obj_controller.bat_tactical_column;new_combat.tacticals+=1;}
+	                if (unit.role()=deploying_unit.role[100][15]) or (unit.role()=deploying_unit.role[100][14]) or (string_count("Aspirant",unit.role())>0){
+	                    if (unit.role()=string(deploying_unit.role[100][15])+" Aspirant"){col=obj_controller.bat_tactical_column;new_combat.tacticals+=1;}
+	                    if (unit.role()=string(deploying_unit.role[100][14])+" Aspirant"){col=obj_controller.bat_tactical_column;new_combat.tacticals+=1;}
                 
-	                    if (deploying_unit.role[cooh,va]=deploying_unit.role[100][15]) then new_combat.apothecaries+=1;
-	                    if (deploying_unit.role[cooh,va]=deploying_unit.role[100][14]){new_combat.chaplains+=1;if (new_combat.big_mofo>5) then new_combat.big_mofo=5;}
+	                    if (unit.role()=deploying_unit.role[100][15]) then new_combat.apothecaries+=1;
+	                    if (unit.role()=deploying_unit.role[100][14]){new_combat.chaplains+=1;if (new_combat.big_mofo>5) then new_combat.big_mofo=5;}
                     
 	                    col=obj_controller.bat_tactical_column;
 
-	                    if (obj_ini.armour[cooh,va]="Terminator Armour") then col=obj_controller.bat_terminator_column;
-	                    if (obj_ini.armour[cooh,va]="Tartaros Armour") then col=obj_controller.bat_terminator_column;
+	                    if (unit.armour()="Terminator Armour") then col=obj_controller.bat_terminator_column;
+	                    if (unit.armour()="Tartaros Armour") then col=obj_controller.bat_terminator_column;
 
 	                    if (co=10) then col=obj_controller.bat_scout_column;
 	                }
                 
-	                if (deploying_unit.role[cooh,va]=deploying_unit.role[100][5]) or (deploying_unit.role[cooh,va]="Standard Bearer") or (deploying_unit.role[cooh,va]=deploying_unit.role[100][7]){
-	                    if (deploying_unit.role[cooh,va]=deploying_unit.role[100][5]){new_combat.captains+=1;if (new_combat.big_mofo>5) then new_combat.big_mofo=5;}
-	                    if (deploying_unit.role[cooh,va]="Standard Bearer") then new_combat.standard_bearers+=1;
-						if (deploying_unit.role[cooh,va]=deploying_unit.role[100][7]) then new_combat.champions+=1;
+	                if (unit.role()=deploying_unit.role[100][5]) or (unit.role()="Standard Bearer") or (unit.role()=deploying_unit.role[100][7]){
+	                    if (unit.role()=deploying_unit.role[100][5]){new_combat.captains+=1;if (new_combat.big_mofo>5) then new_combat.big_mofo=5;}
+	                    if (unit.role()="Standard Bearer") then new_combat.standard_bearers+=1;
+						if (unit.role()=deploying_unit.role[100][7]) then new_combat.champions+=1;
                     
 	                    if (co=1){
 	                        col=obj_controller.bat_veteran_column;
 
-	                        if (obj_ini.armour[cooh,va]="Terminator Armour") then col=obj_controller.bat_terminator_column;
-	                        if (obj_ini.armour[cooh,va]="Tartaros Armour") then col=obj_controller.bat_terminator_column;
+	                        if (unit.armour()="Terminator Armour") then col=obj_controller.bat_terminator_column;
+	                        if (unit.armour()="Tartaros Armour") then col=obj_controller.bat_terminator_column;
 
 	                    }
 	                    if (co>=2) then col=obj_controller.bat_tactical_column;
@@ -333,15 +335,15 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
 	                    if (deploying_unit.mobi[cooh,va]="Jump Pack") then col=obj_controller.bat_assault_column;
 	                }
                 
-	                if (deploying_unit.role[cooh,va]="Chapter Master"){
+	                if (unit.role()="Chapter Master"){
 	                    col=obj_controller.bat_command_column;new_combat.important_dudes+=1;new_combat.big_mofo=1;
 	                    if (string_count("0",deploying_unit.spe[cooh,va])>0) then new_combat.chapter_master_psyker=1;
 	                    else{new_combat.chapter_master_psyker=0;}
 	                }
-	                if (deploying_unit.role[cooh,va]="Forge Master"){col=obj_controller.bat_command_column;new_combat.important_dudes+=1;}
-	                if (deploying_unit.role[cooh,va]="Master of Sanctity"){col=obj_controller.bat_command_column;new_combat.important_dudes+=1;if (new_combat.big_mofo>2) then new_combat.big_mofo=2;}
-	                if (deploying_unit.role[cooh,va]="Master of the Apothecarion"){col=obj_controller.bat_command_column;new_combat.important_dudes+=1;}
-	                if (deploying_unit.role[cooh,va]="Chief "+string(deploying_unit.role[100,17])){col=obj_controller.bat_command_column;new_combat.important_dudes+=1;if (new_combat.big_mofo>3) then new_combat.big_mofo=3;}
+	                if (unit.role()="Forge Master"){col=obj_controller.bat_command_column;new_combat.important_dudes+=1;}
+	                if (unit.role()="Master of Sanctity"){col=obj_controller.bat_command_column;new_combat.important_dudes+=1;if (new_combat.big_mofo>2) then new_combat.big_mofo=2;}
+	                if (unit.role()="Master of the Apothecarion"){col=obj_controller.bat_command_column;new_combat.important_dudes+=1;}
+	                if (unit.role()="Chief "+string(deploying_unit.role[100,17])){col=obj_controller.bat_command_column;new_combat.important_dudes+=1;if (new_combat.big_mofo>3) then new_combat.big_mofo=3;}
                 
 	                if (col=0) then col=obj_controller.bat_hire_column;
                 

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -95,7 +95,6 @@ function scr_company_order(company) {
 	        temp_armour[co][v]=armour[co][unit_num];
 	        temp_gear[co][v]=gear[co][unit_num];
 	        temp_hp[co][v]=hp[co][unit_num];
-	        temp_chaos[co][v]=chaos[co][unit_num];
 	        temp_experience[co][v]=experience[co][unit_num];
 	        temp_age[co][v]=age[co][unit_num];
 	        temp_mobi[co][v]=mobi[co][unit_num];
@@ -286,7 +285,6 @@ function scr_company_order(company) {
 	        gear[co][i]=temp_gear[co][i];
 	        mobi[co][i]=temp_mobi[co][i];
 	        hp[co][i]=temp_hp[co][i];
-	        chaos[co][i]=temp_chaos[co][i];
 	        experience[co][i]=temp_experience[co][i];
 	        age[co][i]=temp_age[co][i];
 	        spe[co][i]=temp_spe[co][i];

--- a/scripts/scr_dead_marines/scr_dead_marines.gml
+++ b/scripts/scr_dead_marines/scr_dead_marines.gml
@@ -51,7 +51,6 @@ function scr_dead_marines(run) {
 		            obj_ini.armour[company,i]="";
 		            obj_ini.gear[company,i]="";
 		            obj_ini.hp[company,i]=100;
-		            obj_ini.chaos[company,i]=0;
 		            obj_ini.experience[company,i]=0;
 		            obj_ini.mobi[company,i]="";
 		            obj_ini.age[company,i]=0;

--- a/scripts/scr_dialogue/scr_dialogue.gml
+++ b/scripts/scr_dialogue/scr_dialogue.gml
@@ -472,7 +472,7 @@ function scr_dialogue(diplo_keyphrase) {
 				diplo_text="Sooo many good souls how sweet on my tounge. Enjoy your gift";
 			break;
 			case "Slaanesh_arti":
-				diplo_text="Fetch this for her and you shll have their favour";
+				diplo_text="Fetch this for her and you shall have their favour";
 			break;
 			case "Nurgle_gift":
 				diplo_text="The father is a loving figure. Farewell may your men rot gently.";

--- a/scripts/scr_dialogue/scr_dialogue.gml
+++ b/scripts/scr_dialogue/scr_dialogue.gml
@@ -138,7 +138,7 @@ function scr_dialogue(diplo_keyphrase) {
 	    var born=false;
 		for(var ii=1; i<=200; i++){if (obj_ini.role[0,ii]="Chapter Master") and (string_count("$",obj_ini.spe[0,ii])>0) then born=true;}
     
-	    if (obj_ini.chaos[0,3]>=50) and (born=true){
+	    if (obj_ini.TTRPG[0][3].corruption>=50) and (born=true){
 	        diplo_option[4]="Right now I need my Master of Sanctity at my side, trusting that his Chapter Master is doing what is best, what is necessary for the Chapter, during this dangerous moment. All will be made clear in time, I promise you brother. This is the right path.";
 	        diplo_goto[4]="cs_meeting_m3";
 	    }
@@ -313,7 +313,9 @@ function scr_dialogue(diplo_keyphrase) {
 	    }
     
 	    var born=false;
-		for(var ii=1; ii<200; ii++){if (obj_ini.role[0,ii]=="Chapter Master") then obj_ini.chaos[0,ii]+=floor(random_range(30,50));}
+		for(var ii=1; ii<200; ii++){
+			if (obj_ini.role[0,ii]=="Chapter Master") then obj_ini.TTRPG[0][ii].corruption+=floor(random_range(30,50));
+		}
 	    obj_controller.chaos_rating+=1;
     
 	    // Casket, Chalice, Tome
@@ -412,11 +414,12 @@ function scr_dialogue(diplo_keyphrase) {
 	}
 	// ** Chaos Gods **
 	if (diplomacy == 10.1){
+		diplo_option=["","","","",""];
 		switch (diplo_keyphrase){
 			case "intro":
 				diplo_text = "[[The Emmissary to Chaos is writhing snake like creature, a vile creature even by the standards of it's foul bretheren it has no specific master instead preffering to work undividely. It's savage toungue flicks from between it's teeth with glazed aged ayes staring into your soul]]";
 				diplo_text += "###";
-				diplo_text += "Greetings Chapter Master, The gods have been watching you oh so very closely, they see you struggles, they hear your pain, they breathe your despair. The warp is the key too all things all you need do is ask and they will provide......For a cost of course even in the warp nothing comes withou cost";
+				diplo_text += "Greetings Chapter Master, The gods have been watching you oh so very closely, they see you struggles, they hear your pain, they breathe your despair. The warp is the key too all things all you need do is ask and they will provide......For a cost of course even in the warp nothing comes without cost";
 				diplo_option[1] = "I seek a favour from the Gods"; 
 				diplo_option[2]="Begone Filth i serve the true god FOR THE EMPROR"; 
 				diplo_option[3]="The gods may have respect when they earn it i'll be back cretin";
@@ -430,9 +433,9 @@ function scr_dialogue(diplo_keyphrase) {
 				break;
 			case "Khorne_path":
 				diplo_text ="AAAAH the path of the warrior perhaps it was a little hopefull of me to expect anymore, from the right angle i suppose you could almost pass form one of those stunted little red bretheren of mine. The lord of skulls is always eager to help in an endevour that might spill even a moreseful more, but pray what will you offer to the lord of skulls for such favour; he loathes those who emply sorcery but then, but he's known to value the martial mans skull most, i suppose it dosen't matter too much from where the blood flows so long as it flows."
-				diplo_option[1] ="Sacrifice Librarian"; 
+				diplo_option[1] = "Sacrifice Librarian"; 
 				diplo_option[2] = "Sacrifice Champion"; 
-				diplo_option[3] = "Sacfrice squad"; 
+				diplo_option[3] = "Sacrifice squad"; 
 				diplo_option[4] = "FLEE"
 			break;
 				case "daemon_scorn":
@@ -463,13 +466,13 @@ function scr_dialogue(diplo_keyphrase) {
 				diplo_text="one less spell caster how pleasing for the lord. Enjoy your gift.";
 			break;	
 			case "sacrifice_champ":
-				diplo_text="How much of a champion can a dead man really be>Enjoy your gift.";
+				diplo_text="How much of a champion can a dead man really be. Enjoy your gift.";
 			break;	
 			case "sacrifice_squad":
 				diplo_text="Sooo many good souls how sweet on my tounge. Enjoy your gift";
 			break;
 			case "Slaanesh_arti":
-				diplo_text="Fetch this for her and you dahll have her favour";
+				diplo_text="Fetch this for her and you shll have their favour";
 			break;
 			case "Nurgle_gift":
 				diplo_text="The father is a loving figure. Farewell may your men rot gently.";

--- a/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
+++ b/scripts/scr_enemy_ai_d/scr_enemy_ai_d.gml
@@ -370,7 +370,7 @@ function scr_enemy_ai_d() {
 	                var co,me;co=-1;me=0;
 	                repeat(obj_ini.companies+1){co+=1;me=0;
 	                    repeat(500){me+=1;
-	                        if (obj_ini.race[co,me]=1) and (obj_ini.role[co,me]!="") then obj_ini.chaos[co,me]+=choose(1,2,3,4,5,6)+choose(1,2,3,4,5,6)+choose(1,2,3,4,5,6);
+	                        if (obj_ini.race[co,me]=1) and (obj_ini.role[co,me]!="") then obj_ini.TTRPG[co][me].corruption+=choose(1,2,3,4,5,6)+choose(1,2,3,4,5,6)+choose(1,2,3,4,5,6);
 	                    }
 	                }
 	                tixt="Any Fallen that may have been on "+string(name)+" ";

--- a/scripts/scr_event_dudes/scr_event_dudes.gml
+++ b/scripts/scr_event_dudes/scr_event_dudes.gml
@@ -1,13 +1,13 @@
-function scr_event_dudes(argument0, argument1, argument2, argument3) {
+function scr_event_dudes(do_action, is_planet, system_name, location_id) {
 
 	/*
-	argument0: perform action?          0: nope,    1: pass dudes over to the obj_event object
-	argument1: planet?
-	argument2: star name
-	argument3: ship or planet ID
+	do_action: perform action?          0: nope,    1: pass dudes over to the obj_event object
+	is_planet: planet?
+	system_name: star name
+	location_id: ship or planet ID
 	*/
 
-	if (argument0=1){
+	if (do_action=1){
 	    if (obj_ini.progenitor=0){
 	        if (obj_controller.fest_feasts<2) then obj_controller.fest_feasts=2;
 	    }
@@ -21,7 +21,7 @@ function scr_event_dudes(argument0, argument1, argument2, argument3) {
 	}
 
 
-	var coh,ide,oc,ocn,ty,g,good,blur;;
+	var coh,ide,oc,ocn,ty,g,good,blur,unit;;
 	coh=-1;ide=0;ide=-1;ty=0;g=0;good=0;blur="";
 	repeat(200){ide+=1;oc[ide]="";ocn[ide]=0;}
 
@@ -29,11 +29,13 @@ function scr_event_dudes(argument0, argument1, argument2, argument3) {
 	repeat(11){coh+=1;ide=0;
 	    repeat(300){ide+=1;
 	        var adding;adding=false;
+	        if (obj_ini.name[coh][ide] == "") then continue;
+	        unit=obj_ini.TTRPG[coh][ide];
         
-	        if (argument1=0) and (obj_ini.lid[coh,ide]=argument3){
+	        if (is_planet=0) and (obj_ini.lid[coh,ide]=location_id){
 	            if (obj_ini.race[coh,ide]=1) or (obj_ini.race[coh,ide]=5) then adding=true;
 	        }
-	        if (argument1=1) and (obj_ini.loc[coh,ide]=argument2) and (obj_ini.wid[coh,ide]=argument3){
+	        if (is_planet=1) and (obj_ini.loc[coh,ide]=system_name) and (obj_ini.wid[coh,ide]=location_id){
 	            if (obj_ini.race[coh,ide]=1) or (obj_ini.race[coh,ide]=5) then adding=true;
 	        }
         
@@ -42,7 +44,7 @@ function scr_event_dudes(argument0, argument1, argument2, argument3) {
 	        if (string_count("Dread",obj_ini.armour[coh,ide])>0) then adding=false;
         
 	        // Just compile a list
-	        if (adding=true) and (argument0=0){
+	        if (adding=true) and (do_action=0){
 	            good=0;g=0;
 	            repeat(100){g+=1;
 	                if (good=0){
@@ -55,14 +57,9 @@ function scr_event_dudes(argument0, argument1, argument2, argument3) {
 	        }
         
 	        // Don't compile a list and create an array in obj_event instead
-	        if (adding=true) and (argument0=1){
-	            var speshul;speshul=false;
-            
-	                if (obj_ini.role[coh,ide]="Chapter Master") then speshul=true;
-	                if (obj_ini.role[coh,ide]="Master of the Apothecarion") then speshul=true;
-	                if (obj_ini.role[coh,ide]="Master of Sanctity") then speshul=true;
-	                if (obj_ini.role[coh,ide]="Forge Master") then speshul=true;
-	                if (obj_ini.role[coh,ide]="Chief "+string(obj_ini.role[100,17])) then speshul=true;
+	        if (adding=true) and (do_action=1){
+	            var speshul=false;
+            		if (unit.IsSpecialist("heads")) then speshul=true;
                 
 	                if (speshul=true){
 	                    obj_event.avatars+=1;
@@ -81,7 +78,7 @@ function scr_event_dudes(argument0, argument1, argument2, argument3) {
 	                obj_event.attendants+=1;
 	                obj_event.attend_co[obj_event.attendants]=coh;
 	                obj_event.attend_id[obj_event.attendants]=ide;
-	                obj_event.attend_corruption[obj_event.attendants]=obj_ini.chaos[coh,ide];
+	                obj_event.attend_corruption[obj_event.attendants]=unit.corruption;
 	                obj_event.attend_race[obj_event.attendants]=obj_ini.race[coh,ide];
                 
 	                // Determine attend confused here
@@ -93,9 +90,9 @@ function scr_event_dudes(argument0, argument1, argument2, argument3) {
 	                    base_confusion=choose(1,2,2,3);
 	                    base_confusion-=obj_controller.fest_feasts;
 	                    if (obj_controller.fest_feature2=1) then base_confusion+=1;
-	                    if (obj_controller.fest_feature3=1) and (obj_ini.chaos[coh,ide]<50) then base_confusion+=1;
-	                    if (obj_ini.chaos[coh,ide]>20) then base_confusion-=1;
-	                    if (obj_ini.chaos[coh,ide]>50) then base_confusion-=2;
+	                    if (obj_controller.fest_feature3=1) and (unit.corruption<50) then base_confusion+=1;
+	                    if (unit.corruption>20) then base_confusion-=1;
+	                    if (unit.corruption>50) then base_confusion-=2;
 	                }
                 
 	                obj_event.attend_confused[obj_event.attendants]=base_confusion;
@@ -109,7 +106,7 @@ function scr_event_dudes(argument0, argument1, argument2, argument3) {
 
 
 	// Return that list
-	if (argument0=0){
+	if (do_action=0){
 	    i=0;good=1;
 	    repeat(100){i+=1;
 	        if (good=1){
@@ -124,7 +121,7 @@ function scr_event_dudes(argument0, argument1, argument2, argument3) {
 	}
 
 	// Yar har har
-	if (argument0=1){
+	if (do_action=1){
 	    debugl("Event: Present marines passed to obj_event array");
 	    obj_event.time_max=obj_event.attendants*10;
     

--- a/scripts/scr_event_gossip/scr_event_gossip.gml
+++ b/scripts/scr_event_gossip/scr_event_gossip.gml
@@ -4,7 +4,7 @@ function scr_event_gossip(argument0) {
 
 	var possible_gossips,gossip,that,that_type,p,words,him_chaos;
 	possible_gossips=0;that=0;that_type="";words="";
-	him_chaos=obj_ini.chaos[attend_co[argument0],attend_id[argument0]];
+	him_chaos=obj_ini.TTRPG[attend_co[argument0],attend_id[argument0]].corruption;
 
 	p=-1;
 	repeat(101){p+=1;

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -666,7 +666,7 @@ function scr_initialize_custom() {
 	    armour[100,i]="";
 	    gear[100,i]="";
 	    mobi[100,i]="";
-	    chaos[100,i]=0;experience[100,i]=0;
+	    experience[100,i]=0;
 	    hp[100,i]=0;
 	    age[100,i]=((millenium*1000)+year)-10;
 	    god[100,i]=0;
@@ -687,7 +687,6 @@ function scr_initialize_custom() {
 	    armour[0,i]="";
 	    gear[0,i]="";
 	    mobi[0,i]="";
-	    chaos[0,i]=0;
 	    experience[0,i]=0;
 	    hp[0,i]=0;
 	    age[0,i]=((millenium*1000)+year)-10;
@@ -1458,7 +1457,6 @@ function scr_initialize_custom() {
 	    armour[company,5]="";
 	    gear[company,5]="";
 	    hp[company,5]=0;
-	    chaos[company,5]=0;
 	    experience[company,5]=0;
 	    man_size-=1;
 	    commands-=1;
@@ -1479,7 +1477,7 @@ function scr_initialize_custom() {
 	    wep2[company][k]=wep2[101,16];
 	    armour[company][k]="Power Armour";
 	    gear[company][k]=gear[101,16];
-	    chaos[company][k]=0;
+	    
 	    experience[company][k]=100;
 		spawn_unit = TTRPG[company][k];
 		spawn_unit.spawn_old_guard();
@@ -1498,7 +1496,7 @@ function scr_initialize_custom() {
 	    wep2[company][k]=wep2[101,17];
 	    armour[company][k]="MK7 Aquila";
 	    gear[company][k]=gear[101,17];
-	    chaos[company][k]=0;
+	    
 	    experience[company][k]=125;
 	    if (psyky=1) then experience[company][k]+=10;
 
@@ -1527,7 +1525,7 @@ function scr_initialize_custom() {
 	    name[company][k]=scr_marine_name();
 	    wep2[company][k]="Bolt Pistol";
 	    gear[company][k]="Psychic Hood";
-	    chaos[company][k]=0;
+	    
 	    experience[company][k]=80;
 	    if (psyky=1) then experience[company][k]+=10;
 
@@ -1555,7 +1553,7 @@ function scr_initialize_custom() {
 	    wep1[company][k]="Bolter";
 	    name[company][k]=scr_marine_name();
 	    wep2[company][k]="Chainsword";
-	    chaos[company][k]=0;
+	    
 	    experience[company][k]=40;
 	    if (psyky=1) then experience[company][k]+=10;
 
@@ -1584,7 +1582,7 @@ function scr_initialize_custom() {
 	    wep2[company][k]=wep2[101,15];
 	    armour[company][k]="MK7 Aquila";
 	    gear[company][k]=gear[101,15];
-	    chaos[company][k]=0;
+	    
 	    experience[company][k]=100;
 		spawn_unit.spawn_old_guard();
 		spawn_unit.spawn_exp();
@@ -1617,7 +1615,7 @@ function scr_initialize_custom() {
 	    wep2[company][k]=wep2[101,2];
 	    armour[company][k]="MK4 Maximus";
 
-	    chaos[company][k]=0;
+	    
 	    unit.add_exp(210+irandom(30));
 	    unit.spawn_old_guard();
 	    unit.add_trait(choose("guardian", "champion","observant","perfectionist"));
@@ -1665,7 +1663,7 @@ function scr_initialize_custom() {
 	    wep1[company][k]=wep1[101,5];
 	    name[company][k]=scr_marine_name();
 	    wep2[company][k]=wep2[101,5];
-	    chaos[company][k]=0;
+	    
 	    gear[company][k]=gear[101,5];
 	    spawn_unit = TTRPG[company][k]
 		spawn_unit.spawn_old_guard();
@@ -1703,7 +1701,7 @@ function scr_initialize_custom() {
 				spawn_unit.spawn_old_guard();
 				spawn_unit.spawn_exp();
 	            armour[company][k]="Terminator Armour";
-	            gear[company][k]=gear[101,14]chaos[company][k]=0;
+	            gear[company][k]=gear[101,14]
 	            if (string_count("Crafter",strin)>0) then armour[company][k]="Tartaros";
 	            if (terminator<=0) then armour[company][k]="MK6 Corvus";
 	            if (mobi[101,14]!="") then mobi[company][k]=mobi[101,14];
@@ -1725,7 +1723,7 @@ function scr_initialize_custom() {
 		spawn_unit.spawn_exp();
 	    armour[company][k]="Terminator Armour";
 	    gear[company][k]=gear[101,15];
-	    chaos[company][k]=0;
+	    
 	    if (string_count("Crafter",strin)>0) then armour[company][k]="Tartaros";
 	    if (terminator<=0) then armour[company][k]="MK6 Corvus";
 	    if (mobi[101,15]!="") then mobi[company][k]=mobi[101,15];
@@ -1744,7 +1742,7 @@ function scr_initialize_custom() {
 	        wep2[company][k]=wep2[101,15];
 	        armour[company][k]="Terminator Armour";
 	        gear[company][k]=gear[101,15];
-	        chaos[company][k]=0;
+	        
 	        spawn_unit = TTRPG[company][k]
 			spawn_unit.spawn_old_guard();
 			spawn_unit.spawn_exp();
@@ -1767,7 +1765,7 @@ function scr_initialize_custom() {
 	        spawn_unit = TTRPG[company][k]
 			spawn_unit.spawn_old_guard();
 			spawn_unit.spawn_exp();
-	        chaos[company][k]=0;
+	        
 	        if (mobi[101,16]!="") then mobi[company][k]=mobi[101,16];
 	        if (armour[company][k]="Terminator") or (armour[company][k]="Tartaros") then man_size+=1;
 	    }
@@ -1784,7 +1782,7 @@ function scr_initialize_custom() {
 	    spawn_unit = TTRPG[company][k]
 		spawn_unit.spawn_old_guard();
 		spawn_unit.spawn_exp();
-	    chaos[company][k]=0;
+	    
 	    if (string_count("Crafter",strin)>0) then armour[company][k]="Tartaros";
 	    if (terminator<=0) then armour[company][k]="MK6 Corvus";
 	    if (armour[company][k]="Terminator") or (armour[company][k]="Tartaros") then man_size+=1;
@@ -1802,7 +1800,7 @@ function scr_initialize_custom() {
 		spawn_unit.spawn_old_guard();
 		spawn_unit.spawn_exp();
 	    armour[company][k]="Terminator Armour";
-	    chaos[company][k]=0;
+	    
 	    if (string_count("Crafter",strin)>0) then armour[company][k]="Tartaros";
 	    if (terminator<=0) then armour[company][k]="MK6 Corvus";
 	    if (armour[company][k]="Terminator") or (armour[company][k]="Tartaros") then man_size+=1;
@@ -1825,7 +1823,7 @@ function scr_initialize_custom() {
 		spawn_unit.spawn_old_guard();
 		spawn_unit.spawn_exp();
 	    armour[company][k]="Terminator Armour";
-	    chaos[company][k]=0;
+	    
 	    if (string_count("Crafter",strin)>0) and (k<=20) then armour[company][k]="Tartaros";
 	}
 	repeat(veteran){
@@ -1839,7 +1837,7 @@ function scr_initialize_custom() {
 	    name[company][k]=scr_marine_name();
 	    wep2[company][k]=wep2[101,3];
 	    armour[company][k]="MK6 Corvus";
-	    chaos[company][k]=0;
+	    
 	    mobi[company][k]=mobi[101,3];
 	    spawn_unit = TTRPG[company][k]
 		spawn_unit.spawn_old_guard();
@@ -1856,7 +1854,7 @@ function scr_initialize_custom() {
 		wep1[company][k]=wep1[101,6];man_size+=8;
 		wep2[company][k]=wep2[101,6];
 		armour[company][k]="Dreadnought";
-		chaos[company][k]=0;
+		
 		experience[company][k]=400;
 		name[company][k]=scr_marine_name();
 	}
@@ -2070,7 +2068,7 @@ function scr_initialize_custom() {
 			// used to randomly make a marine an old guard of their company, giving a bit more xp (TODO) and fancier armor they've hanged onto all these years	
 			spawn_unit.spawn_exp();
 	        spawn_unit.spawn_old_guard();
-	        chaos[company][k]=0;
+	        
 
 	        if (company=8) then mobi[company][k]="Jump Pack";
 	        if (mobi[101,5]!="") then mobi[company][k]=mobi[101,5];
@@ -2093,7 +2091,7 @@ function scr_initialize_custom() {
 	                armour[company][k]="MK7 Aquila";
 	                if (company<=2) then armour[company][k]=choose("MK8 Errant","MK6 Corvus");
 	                gear[company][k]=gear[101,14];
-	                chaos[company][k]=0;
+	                
 	                if (company=8) then mobi[company][k]="Jump Pack";
 	                if (mobi[101,14]!="") then mobi[company][k]=mobi[101,14];
 					spawn_unit = TTRPG[company][k]
@@ -2114,7 +2112,7 @@ function scr_initialize_custom() {
 			spawn_unit.spawn_exp();
 	        spawn_unit.spawn_old_guard();
 	        gear[company][k]=gear[101,15];
-	        chaos[company][k]=0;
+	        
 	        if (company=8) then mobi[company][k]="Jump Pack";
 	        if (mobi[101,15]!="") then mobi[company][k]=mobi[101,15];
 
@@ -2130,7 +2128,7 @@ function scr_initialize_custom() {
 	            armour[company][k]="MK7 Aquila";
 	            if (company<=2) then armour[company][k]=choose("MK8 Errant","MK6 Corvus");
 	            gear[company][k]=gear[101,15];
-	            chaos[company][k]=0;
+	            
 	            if (company=8) then mobi[company][k]="Jump Pack";
 	            if (mobi[101,15]!="") then mobi[company][k]=mobi[101,15];
 				spawn_unit = TTRPG[company][k]
@@ -2149,7 +2147,7 @@ function scr_initialize_custom() {
 	            wep2[company][k]=wep2[101,16];
 	            armour[company][k]="Power Armour";
 	            gear[company][k]=gear[101,16];
-	            chaos[company][k]=0;
+	            
 	            if (mobi[101,16]!="") then mobi[company][k]=mobi[101,16];
 				spawn_unit = TTRPG[company][k]
 				spawn_unit.spawn_exp();
@@ -2165,7 +2163,7 @@ function scr_initialize_custom() {
 	  		name[company][k]=scr_marine_name();
 	        wep2[company][k]="Company Standard";
 	        armour[company][k]="MK5 Heresy";
-	        chaos[company][k]=0;
+	        
 	        if (company=8) then mobi[company][k]="Jump Pack";
 	        spawn_unit = TTRPG[company][k];
 			spawn_unit.spawn_exp();
@@ -2180,7 +2178,7 @@ function scr_initialize_custom() {
 	  		name[company][k]=scr_marine_name();
 	        wep2[company][k]=wep2[100,7];
 	        armour[company][k]="MK4 Maximus";
-	        chaos[company][k]=0;
+	        
 			spawn_unit = TTRPG[company][k];
 			spawn_unit.add_trait("champion");
 			spawn_unit.spawn_exp();
@@ -2202,7 +2200,7 @@ function scr_initialize_custom() {
 		                wep1[company][k]=wep1[101,8];
 		                wep2[company][k]=wep2[101,8];
 		          name[company][k]=scr_marine_name();
-		                chaos[company][k]=0;
+		                
 
 				        spawn_unit = TTRPG[company][k];
 						spawn_unit.spawn_exp();
@@ -2220,7 +2218,7 @@ function scr_initialize_custom() {
 		                wep1[company][k]=wep1[101,10];
 		                name[company][k]=scr_marine_name();
 						mobi[company][k]="Jump Pack";
-						chaos[company][k]=0;
+						
 						wep2[company][k]=wep2[101,10]; 
 							
 				        spawn_unit = TTRPG[company][k];
@@ -2238,7 +2236,7 @@ function scr_initialize_custom() {
 		                wep2[company][k]=wep2[101][9];
 		                mobi[company][k]=mobi[100][9];
 		                name[company][k]=scr_marine_name();
-		                chaos[company][k]=0;
+		                
 		                TTRPG[company][k]=new TTRPG_stats("chapter", company,k);
 
 	                    if (wep1[101,9]=="Heavy Ranged") then wep1[company][k]=choose("Lascannon","Missile Launcher","Heavy Bolter");
@@ -2262,7 +2260,7 @@ function scr_initialize_custom() {
 	              		name[company][k]=scr_marine_name();
 	                    wep2[company][k]=wep2[101,12];
 	                    armour[company][k]="Scout Armour";
-	                    chaos[company][k]=0;
+	                    
 	                    experience[company][k] = 10+irandom(15);
 	                }
 	            }
@@ -2280,7 +2278,7 @@ function scr_initialize_custom() {
 	                wep1[company][k]=wep1[101,8];
 	                wep2[company][k]=wep2[101,8];
 	          		name[company][k]=scr_marine_name();
-	                chaos[company][k]=0;
+	                
 
 					
 			        spawn_unit = TTRPG[company][k];
@@ -2298,7 +2296,7 @@ function scr_initialize_custom() {
 	            	wep1[company][k]=wep1[101,10];
 	            	wep2[company][k]=wep2[101,10];
 	              	name[company][k]=scr_marine_name();
-	            	chaos[company][k]=0;
+	            	
 	            	mobi[company][k]="Jump Pack";
 
 					
@@ -2315,7 +2313,7 @@ function scr_initialize_custom() {
 	                role[company][k]=role[100][9];
 	          		name[company][k]=scr_marine_name();
 	                wep2[company][k]=wep2[101,9];
-	                chaos[company][k]=0;
+	                
 					mobi[company][k]=mobi[100][9];
 
 	                if (wep1[101,9]="Heavy Ranged") then wep1[company][k]=choose("Lascannon","Missile Launcher","Heavy Bolter");
@@ -2337,7 +2335,7 @@ function scr_initialize_custom() {
 	            	name[company][k]=scr_marine_name();
 	                wep2[company][k]=wep2[101,12];
 	                armour[company][k]="Scout Armour";
-	                chaos[company][k]=0;
+	                
 	                experience[company][k] = 10+irandom(15);
 
 	            } 
@@ -2351,7 +2349,7 @@ function scr_initialize_custom() {
 	                wep2[company][k]=wep2[101,10];
 	            	name[company][k]=scr_marine_name();
 	                mobi[company][k]=mobi[101,10];
-	                chaos[company][k]=0;
+	                
 			        spawn_unit = TTRPG[company][k]
 					spawn_unit.spawn_exp();
 					spawn_unit.spawn_old_guard();	
@@ -2364,7 +2362,7 @@ function scr_initialize_custom() {
 	                role[company][k]=role[100][9];
 	          		name[company][k]=scr_marine_name();
 	                wep2[company][k]=wep2[101,9];
-					chaos[company][k]=0;
+					
 					mobi[company][k]=mobi[100][9];
 
 					
@@ -2393,7 +2391,7 @@ function scr_initialize_custom() {
 	            	name[company][k]=scr_marine_name();
 	                wep2[company][k]=wep2[101,6];
 	                armour[company][k]="Dreadnought";
-	                chaos[company][k]=0;
+	                
 	                experience[company][k]=300;
 	                if (company=9) then wep1[company][k]="Missile Launcher";
 	            }
@@ -2476,7 +2474,7 @@ function scr_initialize_custom() {
 	        wep2[company][k]=wep2[101,14];
 	        armour[company][k]="MK7 Aquila";// if (company<=2) then armour[company][k]=choose("MK8 Errant","MK6 Corvus");
 	        gear[company][k]=gear[101,14];
-	        chaos[company][k]=0;
+	        
 	        experience[company][k]=100;
 	        bio[company][k]=0;
 	        // if (company=8) then mobi[company][k]="Jump Pack";
@@ -2597,7 +2595,8 @@ function scr_initialize_custom() {
 		    penitent_end=obj_creation.strength*5;
 
 		    if (obj_creation.chapter="Lamenters"){
-		        penitent_max=600;penitent_end=600;
+		        penitent_max=600;
+		        penitent_end=600;
 		        // obj_controller.loyalty=50;obj_controller.loyalty_hidden=50;
 		    }
 		}

--- a/scripts/scr_kill_unit/scr_kill_unit.gml
+++ b/scripts/scr_kill_unit/scr_kill_unit.gml
@@ -13,7 +13,6 @@ function scr_kill_unit(company, unit_slot){
 	obj_ini.armour[company,unit_slot]="";
 	obj_ini.gear[company,unit_slot]="";
 	obj_ini.hp[company,unit_slot]=0;
-	obj_ini.chaos[company,unit_slot]=0;
 	obj_ini.god[company,unit_slot]=0;
 	obj_ini.experience[company,unit_slot]=0;
 	obj_ini.age[company,unit_slot]=0;

--- a/scripts/scr_load/scr_load.gml
+++ b/scripts/scr_load/scr_load.gml
@@ -777,7 +777,6 @@ function scr_load(argument0, argument1) {
                         }
                     }
                     obj_ini.hp[coh,mah]=ini_read_real("Mar","hp"+string(coh)+"."+string(mah),0);
-                    obj_ini.chaos[coh,mah]=ini_read_real("Mar","cha"+string(coh)+"."+string(mah),0);
                     obj_ini.experience[coh,mah]=ini_read_real("Mar","exp"+string(coh)+"."+string(mah),0);
                     obj_ini.age[coh,mah]=ini_read_real("Mar","ag"+string(coh)+"."+string(mah),0);
                     obj_ini.spe[coh,mah]=ini_read_string("Mar","spe"+string(coh)+"."+string(mah),"");

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1358,13 +1358,6 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
     	return "complete";
 	};
 
-
-		static corruption = function(){ 
-			return obj_ini.chaos[company][marine_number];
-		};	   
-       static update_corruption = function(new_corruption){
-            obj_ini.chaos[company][marine_number] = new_corruption;
-	   };	
 		static specials = function(){ 
 			return obj_ini.spe[company][marine_number];
 		};	   

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -43,6 +43,7 @@ global.trait_list = {
 		ballistic_skill:[10,5, "max"],
 		display_name : "Champion",
 		flavour_text : "Through either natural talent, or obsessive training {0} is a master of arms",
+		effect:"increase melee carry"
 	},
 	"lightning_warriors":{
 		constitution: -6,
@@ -1522,6 +1523,10 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 			if (weapon_skill>=50){
 				melee_hands_limit+=0.25;
 				carry_string+="skill:+0.25#";
+			}
+			if (has_trait("champion")){
+				melee_hands_limit+=0.25;
+				carry_string+="Champion:+0.25#";
 			}
 			var armour_carry = get_armour_data("melee_hands")
 			if (armour_carry!=0){

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -577,6 +577,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine") constructor{
 	constitution=0; strength=0;luck=0;dexterity=0;wisdom=0;piety=0;charisma=0;technology=0;intelligence=0;weapon_skill=0;ballistic_skill=0;size = 0;
 	religion="none";
 	psionic=0;
+	corruption=0;
 	religion_sub_cult = "none";
 	base_group = "none";
 	role_history = [];

--- a/scripts/scr_max_marine/scr_max_marine.gml
+++ b/scripts/scr_max_marine/scr_max_marine.gml
@@ -1,10 +1,10 @@
-function scr_max_marine(argument0) {
+function scr_max_marine(max_type) {
 
-	// argument0 : "chaos" or "age" or "exp"
+	// max_type : "chaos" or "age" or "exp"
 
 	// Returns the marine with the highest value
 
-	var man_c, man_i, c, i, value;
+	var man_c, man_i, c, i, value, unit;
 	man_c=0;man_i=0;c=0;i=0;value=0;
 
 	i=-1;c=-1;
@@ -14,9 +14,23 @@ function scr_max_marine(argument0) {
 	        i+=1;// man_c[i]=0;man_i[i]=0;
         
 	        if (obj_ini.name[c,i]!=""){
-	            if (argument0="chaos"){if (obj_ini.chaos[c,i]>value){value=obj_ini.chaos[c,i];man_c=c;man_i=i;}}
-	            if (argument0="age"){if (obj_ini.age[c,i]<value){value=obj_ini.age[c,i];man_c=c;man_i=i;}}
-	            if (argument0="exp"){if (obj_ini.experience[c,i]>value){value=obj_ini.experience[c,i];man_c=c;man_i=i;}}
+	        	unit=obj_ini.TTRPG[c][i];
+	            if (max_type="chaos"){
+	            	if (unit.corruption>value){
+	            		value=unit.corruption;
+	            		man_c=c;man_i=i;
+	            	}
+	            }else if (max_type="age"){
+	            	if (obj_ini.age[c,i]<value){
+	            		value=obj_ini.age[c,i];
+	            		man_c=c;
+	            		man_i=i;
+	            	}
+	            }else if (max_type="exp"){
+	            	if (obj_ini.experience[c,i]>value){
+	            		value=obj_ini.experience[c,i];man_c=c;man_i=i;
+	            	}
+	            }
 	        }
 	    }
 	}

--- a/scripts/scr_move_unit_info/scr_move_unit_info.gml
+++ b/scripts/scr_move_unit_info/scr_move_unit_info.gml
@@ -33,7 +33,6 @@ function scr_move_unit_info(start_company,end_company, start_slot, end_slot, eva
 		obj_ini.gear[end_company][end_slot]=obj_ini.gear[start_company][start_slot];
 		obj_ini.armour[end_company][end_slot]=obj_ini.armour[start_company][start_slot];
 		obj_ini.hp[end_company][end_slot]=obj_ini.hp[start_company][start_slot];
-		obj_ini.chaos[end_company][end_slot]=obj_ini.chaos[start_company][start_slot];
 		obj_ini.god[end_company][end_slot]=obj_ini.god[start_company][start_slot];
 		obj_ini.experience[end_company][end_slot]=obj_ini.experience[start_company][start_slot];
 		obj_ini.age[end_company][end_slot]=obj_ini.age[start_company][start_slot];
@@ -61,7 +60,6 @@ function scr_move_unit_info(start_company,end_company, start_slot, end_slot, eva
 		obj_ini.armour[start_company][start_slot]="";
 		obj_ini.gear[start_company][start_slot]="";
 		obj_ini.hp[start_company][start_slot]=0;
-		obj_ini.chaos[start_company][start_slot]=0;
 		obj_ini.god[start_company][start_slot]=0;
 		obj_ini.experience[start_company][start_slot]=0;
 		obj_ini.age[start_company][start_slot]=0;

--- a/scripts/scr_powers/scr_powers.gml
+++ b/scripts/scr_powers/scr_powers.gml
@@ -432,8 +432,8 @@ function scr_powers(argument0, argument1, argument2, argument3) {
     
 	    if (tome_bad>0){
 	        var tome_roll;tome_roll=floor(random(100))+1;
-	        if (tome_roll<=10) and (tome_bad=1) then obj_ini.chaos[marine_co[argument3],marine_id[argument3]]+=choose(1,2);
-	        if (tome_roll<=20) and (tome_bad>1) then obj_ini.chaos[marine_co[argument3],marine_id[argument3]]+=choose(3,4,5);
+	        if (tome_roll<=10) and (tome_bad=1) then obj_ini.TTRPG[marine_co[argument3],marine_id[argument3]].corruption+=choose(1,2);
+	        if (tome_roll<=20) and (tome_bad>1) then obj_ini.TTRPG[marine_co[argument3],marine_id[argument3]].corruption+=choose(3,4,5);
 	    }
     
 	}
@@ -480,10 +480,10 @@ function scr_powers(argument0, argument1, argument2, argument3) {
 	    if (string_count("daemon",book_powers)>0) then peril1+=25;
 	    m1=string(marine_type[argument3])+" "+string(obj_ini.name[marine_co[argument3],marine_id[argument3]])+" suffers Perils of the Warp!  ";
     
-	    if (peril3>0) and (peril3<=15){marine_hp[argument3]-=choose(8,12,16,20);m2="He begins to gibber as psychic backlash overtakes him.";obj_ini.chaos[marine_co[argument3],marine_id[argument3]]+=choose(2,4,6,8);}
+	    if (peril3>0) and (peril3<=15){marine_hp[argument3]-=choose(8,12,16,20);m2="He begins to gibber as psychic backlash overtakes him.";obj_ini.TTRPG[marine_co[argument3],marine_id[argument3]].corruption+=choose(2,4,6,8);}
 	    if (peril3>15) and (peril3<=23){marine_hp[argument3]-=choose(30,35,40,45);m2="His mind is burned fiercly by the warp.";}
 	    if (peril3>23) and (peril3<=31){marine_hp[argument3]-=5000;m2="Psychic backlash knocks him out entirely, incapacitating the marine.";}
-	    if (peril3>31) and (peril3<=39){marine_casting[argument3]-=999;m2="His mind is seared by the warp, now unable to cast more powers this battle.";obj_ini.chaos[marine_co[argument3],marine_id[argument3]]+=choose(7,10,13,15);}
+	    if (peril3>31) and (peril3<=39){marine_casting[argument3]-=999;m2="His mind is seared by the warp, now unable to cast more powers this battle.";obj_ini.TTRPG[marine_co[argument3],marine_id[argument3]].corruption+=choose(7,10,13,15);}
 	    if (peril3>39) and (peril3<=47){marine_hp[argument3]-=choose(30,35,40,45);
 	        m2="The psychic blast he had prepared runs loose, striking himself!";
 	        if (school="biomancy"){m2="The psychic blast he had prepared runs loose, boiling his own blood!";}
@@ -492,10 +492,10 @@ function scr_powers(argument0, argument1, argument2, argument3) {
 	    }
 	    if (peril3>47) and (peril3<=55){
 	        m2="Capricious voices eminate from the surrounding area, whispering poisonous lies and horrible truths.";
-	        obj_ini.chaos[marine_co[argument3],marine_id[argument3]]+=choose(10,15,20);
+	        obj_ini.TTRPG[marine_co[argument3],marine_id[argument3]].corruption+=choose(10,15,20);
 	        repeat(6){
 	            var t;t=floor(random(men))+1;
-	            if (marine_type[t]!="") then obj_ini.chaos[marine_co[t],marine_id[t]]+=choose(6,9,12,15);
+	            if (marine_type[t]!="") then obj_ini.TTRPG[marine_co[t],marine_id[t]].corruption+=choose(6,9,12,15);
 	        }
 	    }
 	    if (peril3>55) and (peril3<=63){
@@ -509,10 +509,17 @@ function scr_powers(argument0, argument1, argument2, argument3) {
 	        if (exist=0){
 	            repeat(30){if (d3=0){d2+=1;if (d1.dudes[d2]=""){d3=d2;}}}
 	            d2=choose(3,4,5,6);
-	            d1.dudes[d3]=dem;d1.dudes_special[d3]="";d1.dudes_num[d3]=d2;
-	            d1.dudes_ac[d3]=15;d1.dudes_hp[d3]=150;d1.dudes_dr[d3]=0.7;
-	            d1.dudes_vehicle[d3]=0;d1.dudes_damage[d3]=0;d1.men+=d2;
-	            obj_ncombat.enemy_forces+=d2;obj_ncombat.enemy_max+=d2;
+	            d1.dudes[d3]=dem;
+	            d1.dudes_special[d3]="";
+	            d1.dudes_num[d3]=d2;
+	            d1.dudes_ac[d3]=15;
+	            d1.dudes_hp[d3]=150;
+	            d1.dudes_dr[d3]=0.7;
+	            d1.dudes_vehicle[d3]=0;
+	            d1.dudes_damage[d3]=0;
+	            d1.men+=d2;
+	            obj_ncombat.enemy_forces+=d2;
+	            obj_ncombat.enemy_max+=d2;
 	        }
 	    }
 	    if (peril3>63) and (peril3<=71){

--- a/scripts/scr_save/scr_save.gml
+++ b/scripts/scr_save/scr_save.gml
@@ -856,7 +856,6 @@ function scr_save(save_slot,save_id) {
 	                ini_write_string("Mar","mb"+string(coh)+"."+string(mah),obj_ini.mobi[coh,mah]);
 
 	                ini_write_real("Mar","hp"+string(coh)+"."+string(mah),obj_ini.TTRPG[coh,mah].hp());
-	                ini_write_real("Mar","cha"+string(coh)+"."+string(mah),obj_ini.chaos[coh,mah]);
 	                ini_write_real("Mar","exp"+string(coh)+"."+string(mah),obj_ini.experience[coh,mah]);
 	                ini_write_real("Mar","ag"+string(coh)+"."+string(mah),obj_ini.age[coh,mah]);
 	                ini_write_string("Mar","spe"+string(coh)+"."+string(mah),obj_ini.spe[coh,mah]);

--- a/scripts/scr_ui_advisors/scr_ui_advisors.gml
+++ b/scripts/scr_ui_advisors/scr_ui_advisors.gml
@@ -422,14 +422,15 @@ function scr_ui_advisors() {
                 draw_set_halign(fa_left);
 
                 var behav = 0,
-                    r_eta = 0;
+                    r_eta = 0,unit;
 
                 for (var qp = 1; qp <= min(36, penitorium); qp++) {
-                    if (obj_ini.chaos[penit_co[qp], penit_id[qp]] > 0) then r_eta = round((obj_ini.chaos[penit_co[qp], penit_id[qp]] * obj_ini.chaos[penit_co[qp], penit_id[qp]]) / 50);
-                    if (obj_ini.chaos[penit_co[qp], penit_id[qp]] >= 90) then r_eta = "Never";
-                    if (obj_ini.chaos[penit_co[qp], penit_id[qp]] <= 0) then r_eta = "0";
+                    unit = obj_ini.TTRPG[penit_co[qp]][penit_id[qp]];
+                    if (unit.corruption > 0) then r_eta = round((unit.corruption * unit.corruption) / 50);
+                    if (unit.corruption >= 90) then r_eta = "Never";
+                    if (unit.corruption <= 0) then r_eta = "0";
                     draw_rectangle(xx + 947, yy + 100 + ((qp - 1) * 20), xx + 1577, yy + 100 + (qp * 20), 1);
-                    draw_text(xx + 950, yy + 100 + ((qp - 1) * 20), string_hash_to_newline(string(obj_ini.role[penit_co[qp], penit_id[qp]]) + " " + string(obj_ini.name[penit_co[qp], penit_id[qp]])));
+                    draw_text(xx + 950, yy + 100 + ((qp - 1) * 20), string_hash_to_newline(unit.name_role()));
                     draw_text(xx + 1200, yy + 100 + ((qp - 1) * 20), string_hash_to_newline("ETA: " + string(r_eta)));
                     draw_text(xx + 1432, yy + 100 + ((qp - 1) * 20), string_hash_to_newline("[Execute]  [Release]"));
                 }


### PR DESCRIPTION
- Stops the CTD from the chaos emissary
- deprecates the use of obj_ini.chaos[company][unit] for unit.corruption
- this is ultimately laying the way to implementing corruption properly in the near future
- finishes all of the khorne options in the emissary allowing the you to make a sacrifice and in return receive khornes favour/attention (currently a trait called blood_for_blood) 