### PR TITLE
Vehicle equipment rework

### DIFF
--- a/objects/obj_shop/Create_0.gml
+++ b/objects/obj_shop/Create_0.gml
@@ -755,6 +755,15 @@ if (shop = "vehicles") {
     }
     i += 1;
     x_mod[i] = 9;
+    item[i] = "Quad Linked Heavy Bolter Sponsons";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 60;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
     item[i] = "Twin Linked Assault Cannon Mount";
     item_stocked[i] = scr_item_count(item[i]);
     item_cost[i] = 60;
@@ -810,15 +819,15 @@ if (shop = "vehicles") {
     item[i] = "Land Speeder";
     item_stocked[i] = scr_vehicle_count(item[i], "");
     nobuy[i] = 1;
+	if (obj_controller.stc_vehicles >= 6) {
+    nobuy[i] = 0;
+    item_cost[i] = 120;
+    }
     i += 1;
     x_mod[i] = 9;
     item[i] = "Twin Linked Bolters";
     item_stocked[i] = scr_item_count(item[i]);
     item_cost[i] = 8;
-    if (obj_controller.stc_vehicles >= 6) {
-        nobuy[i] = 0;
-        item_cost[i] = 200;
-    } // if (rene=1){nobuy[i]=1;item_cost[i]=0;}
     i += 1;
     item[i] = "Bike";
     item_stocked[i] = scr_item_count(item[i]);
@@ -904,7 +913,7 @@ if (shop = "vehicles") {
     }
     i += 1;
     x_mod[i] = 9;
-    item[i] = "Flamestorm Cannon";
+    item[i] = "Dreadnought Lightning Claw";
     item_stocked[i] = scr_item_count(item[i]);
     item_cost[i] = 135;
     if (rene = 1) {
@@ -922,7 +931,7 @@ if (shop = "vehicles") {
     }
     i += 1;
     x_mod[i] = 9;
-    item[i] = "Twin-Linked Assault Cannon";
+    item[i] = "Dreadnought Power Claw";
     item_stocked[i] = scr_item_count(item[i]);
     item_cost[i] = 150;
     if (rene = 1) {
@@ -931,7 +940,7 @@ if (shop = "vehicles") {
     }
     i += 1;
     x_mod[i] = 9;
-    item[i] = "Whirlwind Missile Launcher";
+    item[i] = "Whirlwind Missiles";
     item_stocked[i] = scr_item_count(item[i]);
     item_cost[i] = 90;
     if (rene = 1) {
@@ -951,7 +960,79 @@ if (shop = "vehicles") {
     x_mod[i] = 9;
     item[i] = "Void Shield";
     item_stocked[i] = scr_item_count(item[i]);
-    item_cost[i] = 250;
+    nobuy[i] = 1;
+    if (obj_controller.stc_vehicles >= 6) {
+        nobuy[i] = 0;
+        item_cost[i] = 500;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Lucifer Pattern Engine";
+    item_stocked[i] = scr_item_count(item[i]);
+    nobuy[i] = 1;
+    if (obj_controller.stc_vehicles >= 6) {
+        nobuy[i] = 0;
+        item_cost[i] = 90;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Artificer Hull";
+    item_stocked[i] = scr_item_count(item[i]);
+    nobuy[i] = 1;
+    if (obj_controller.stc_vehicles >= 3) {
+        nobuy[i] = 0;
+        item_cost[i] = 200;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Armoured Ceramite";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 120;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Heavy Armour";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 50;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Smoke Launchers";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 10;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Dozer Blades";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 10;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Searchlight";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 15;
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+    i += 1;
+    x_mod[i] = 9;
+    item[i] = "Frag Assault Launchers";
+    item_stocked[i] = scr_item_count(item[i]);
+    item_cost[i] = 30;
     if (rene = 1) {
         nobuy[i] = 1;
         item_cost[i] = 0;

--- a/scripts/scr_flavor/scr_flavor.gml
+++ b/scripts/scr_flavor/scr_flavor.gml
@@ -399,6 +399,12 @@ function scr_flavor(number_of_attacking_weapons, target, target_type, number_of_
 	    if (number_of_shots>1) and (casulties=0) then p1=$"{number_of_shots} {weapon_name} crackle and swing into the {target_name} ranks (X{casulties} casulties).";
 	    if (number_of_shots>1) and (casulties>0) then p1=$"{number_of_shots} {weapon_name} crackle and swing into the {target_name} ranks (X{casulties} casulties).  "+string(casulties)+" are smashed.";
 	}
+	if (weapon_name="Dozer Blades") and (solod=false){flavored=1;
+	    if (number_of_shots=1) and (casulties=0) then p1=$"A {target_name} is rammed but survives.";
+	    if (number_of_shots=1) and (casulties=1) then p1=$"A {target_name} is splattered by {weapon_name}.";
+	    if (number_of_shots>1) and (casulties=0) then p1=$"{weapon_name} ploughs {target_name} ranks (X{casulties} casulties).";
+	    if (number_of_shots>1) and (casulties>0) then p1=$"{weapon_name} hits {target_name} ranks (X{casulties} casulties).  "+string(casulties)+" are smashed.";
+	}
 	if (weapon_name="Inactive Force Staff") and (solod=false){flavored=1;
 	    if (number_of_shots=1) and (casulties=0) then p1=$"A {target_name} is struck by a {weapon_name} but survives.";
 	    if (number_of_shots=1) and (casulties=1) then p1=$"A {target_name} is smashed by a {weapon_name}.";

--- a/scripts/scr_vehicle_weapon/scr_vehicle_weapon.gml
+++ b/scripts/scr_vehicle_weapon/scr_vehicle_weapon.gml
@@ -22,6 +22,7 @@ function scr_vehicle_weapon(argument0, argument1) {
 	if (weep="Thunder Hammer")then melee=1;if (weep="Power Sword")then melee=1;
 	if (weep="Power Weapon")then melee=1;if (weep="Power Axe")then melee=1;
 	if (weep="Power Fist")then melee=1;if (weep="Power Fists")then melee=1;
+	if (weep="Dozer Blades") then melee=1;
 	if (melee=1) then wep_range[argument1]=max(target[argument1].sprite_width-8,target[argument1].sprite_height-8,sprite_height-8);
 
 
@@ -78,6 +79,7 @@ function scr_vehicle_weapon(argument0, argument1) {
 	if (weep="Combat Knife"){with(bull){instance_destroy();}target[argument1].hp-=dym;}
 	if (weep="Force Staff"){with(bull){instance_destroy();}target[argument1].hp-=dym;}
 	if (weep="Thunder Hammer"){with(bull){instance_destroy();}target[argument1].hp-=dym;}
+	if (weep="Dozer Blades"){with(bull){instance_destroy();}target[argument1].hp-=dym;}
 
 	if (weep="Power Sword"){with(bull){instance_destroy();}target[argument1].hp-=dym;}
 	if (weep="Power Weapon"){with(bull){instance_destroy();}target[argument1].hp-=dym;}

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -460,7 +460,7 @@ global.weapons={
         "range": 1,
         "spli": 10,
         "arp": 0,
-        "tags":["power", "vehicle","dual","fist"],
+        "tags":["power", "vehicle", "dual", "dreadnought", "fist"],
     },
     "Thunder Hammer": {
       "abbreviation": "ThndHmr",                
@@ -693,7 +693,7 @@ global.weapons={
         "range": 1,
         "spli": 10,
         "arp": 1,
-        "tags":["dreadnought"]  
+        "tags":["power", "vehicle", "dual", "dreadnought", "fist"]  
     },
     "Close Combat Weapon":{
         "abbreviation": "CCW",               
@@ -728,9 +728,9 @@ global.weapons={
     "Meltagun": {
         "abbreviation": "Mltgn",
         "attack": {
-            "standard": 250,
-            "master_crafted": 275,
-            "artifact": 300
+            "standard": 450,
+            "master_crafted": 475,
+            "artifact": 500
         },
         "description": "A loud weapon that roars with fury, this gun vaporizes flesh and armor alike. Due to heat dissipation, it has only a short range.",
         "melee_hands": 1,
@@ -744,9 +744,9 @@ global.weapons={
     "Multi-Melta": {
          "abbreviation": "MltMelt",
         "attack": {
-            "standard": 500,
-            "master_crafted": 550,
-            "artifact": 600
+            "standard": 800,
+            "master_crafted": 850,
+            "artifact": 900
         },
         "description": "Though bearing longer range than the Meltagun, this weapon's great size usually restricts it to vehicles though those with Power Armor can carry this cumbersome weapon into battle.",
         "melee_hands": 1,
@@ -844,21 +844,21 @@ global.weapons={
             "master_crafted": 264,
             "artifact": 288
         },
-        "description": "A heavy rotary autocannon with a devastating fire rate that can be counted in the hundreds per minute. It is incredibly effective against infantry and lightly armored targets.",
+        "description": "A heavy rotary autocannon with a devastating fire rate that can be counted in the hundreds per minute. It is incredibly effective against infantry and light armored targets.",
         "melee_hands": 2.1,
         "ranged_hands": 2.25,
         "ammo": 5,
         "range": 12,
         "spli": 20,
-        "arp": 0,
+        "arp": 1,
         "tags":["heavy_ranged","dreadnought"]
     },
     "Autocannon": {
         "abbreviation": "Autocnn",       
         "attack": {
-            "standard": 180,
-            "master_crafted": 198,
-            "artifact": 216
+            "standard": 380,
+            "master_crafted": 400,
+            "artifact": 430
         },
         "description": "A rapid-firing weapon able to use a wide variety of ammunition, from mass-reactive explosive to solid shells. It has been found to be incredibly effective against large groups of targets and even Traitor Astartes to an extent.",
         "melee_hands": 0,
@@ -866,7 +866,7 @@ global.weapons={
         "ammo": 25,
         "range": 18,
         "spli": 15,
-        "arp": 0,
+        "arp": 1,
         "tags":["heavy_ranged","dreadnought"]
     },
     "Missile Launcher": {
@@ -972,31 +972,31 @@ global.weapons={
     "Twin Linked Heavy Bolter": {
         "abbreviation": "TwnHvyBltr", 
         "attack": {
-            "standard": 240,
-            "master_crafted": 264,
-            "artifact": 288
+            "standard": 320,
+            "master_crafted": 352,
+            "artifact": 384
         },
         "description": "Twin-linked Heavy Bolters are an upgraded version of the standard Heavy Bolter weapon, which is known for its high rate of fire and effectiveness against infantry and light vehicles.",
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 20,
         "range": 16,
-        "spli": 8,
+        "spli": 9,
         "arp": 1,
         "tags":["heavy_ranged","vehicle","dreadnought"]
     },
     "Twin Linked Lascannon": {
         "abbreviation": "TwnLascnn", 
         "attack": {
-            "standard": 250,
-            "master_crafted": 275,
-            "artifact": 300
+            "standard": 600,
+            "master_crafted": 700,
+            "artifact": 900
         },
         "description": "The Twin-Linked Lascannons is a powerful anti-armour weapons that fire highly focused and devastating duel energy beams capable of penetrating even the toughest armor.",
         "melee_hands": 0,
         "ranged_hands": 0,
-        "ammo": 10,
-        "range": 20,
+        "ammo": 8,
+        "range": 24,
         "spli": 2,
         "arp": 1,
         "tags":["heavy_ranged","vehicle","dreadnought"]
@@ -1050,7 +1050,7 @@ global.weapons={
     },
     "HK Missile": {
         "abbreviation": "HKMssl", 
-        "description": "",
+        "description": "A single shot hunter killer	missile that serves as a powerful anti armour/aircraft deterent.",
     },  
     "Twin Linked Heavy Bolter Mount": {
         "attack": {
@@ -1084,25 +1084,25 @@ global.weapons={
     },
     "Twin Linked Assault Cannon Mount": {
         "attack": {
-            "standard": 360,
-            "master_crafted": 396,
-            "artifact": 432
+            "standard": 240,
+            "master_crafted": 264,
+            "artifact": 288
         },
         "description": "A twin mount of rotary autocannons, boasting an incredible rate of fire numbering in the hundreds of shots fired per second.",
         "abbreviation": "TwnAssCnn", 
         "melee_hands": 0,
         "ranged_hands": 0,
-        "ammo": 5,
+        "ammo": 6,
         "range": 12,
-        "spli": 3,
-        "arp": 0,
-        "tags":["vehicle","pintle"]
+        "spli": 30,
+        "arp": 1,
+        "tags":["vehicle","pintle","dreadnought"]
     },
     "Reaper Autocannon Mount": {
         "attack": {
-            "standard": 250,
-            "master_crafted": 275,
-            "artifact": 300
+            "standard": 500,
+            "master_crafted": 550,
+            "artifact": 600
         },
         "description": "An archaic twin-linked autocannon design dating back to the Great Crusade. The Reaper Autocannon is effective against infantry and armored targets. This version is mounted onto vehicles.",
         "abbreviation": "RprAtcnn", 
@@ -1110,31 +1110,31 @@ global.weapons={
         "ranged_hands": 0,
         "ammo": 25,
         "range": 15,
-        "spli": 3,
-        "arp": 0,
+        "spli": 6,
+        "arp": 1,
         "tags":["vehicle","pintle"]
     },
     "Quad Linked Heavy Bolter Sponsons": {
         "attack": {
-            "standard": 480,
-            "master_crafted": 528,
-            "artifact": 576
+            "standard": 320,
+            "master_crafted": 352,
+            "artifact": 384
         },
         "description": "Quad-linked Heavy Bolters are a significantly upgraded version of the standard Heavy Bolter mount; already punishing in a single mount, this quad mount is devastating against a variety of targets.",
         "abbreviation": "QdHvyBltrs", 
         "melee_hands": 0,
         "ranged_hands": 0,
-        "ammo": 10,
+        "ammo": 15,
         "range": 16,
-        "spli": 3,
+        "spli": 5,
         "arp": 1,
         "tags":["bolt", "vehicle","sponson"]
     },
     "Twin Linked Lascannon Sponsons": {
         "attack": {
-            "standard": 375,
-            "master_crafted": 412.5,
-            "artifact": 450
+            "standard": 600,
+            "master_crafted": 700,
+            "artifact": 900
         },
         "description": "The Twin-Linked Lascannons are powerful anti-armour weapons that fire highly focused and devastating energy beams capable of penetrating even the toughest armour. This version is mounted onto the sides of vehicles.",
         "abbreviation": "TwnLascnns", 
@@ -1142,39 +1142,39 @@ global.weapons={
         "ranged_hands": 0,
         "ammo": 5,
         "range": 20,
-        "spli": 4,
+        "spli": 3,
         "arp": 1,
         "tags":["las", "vehicle","sponson", "twin_linked"]
     },
     "Lascannon Sponsons": {
         "attack": {
-            "standard": 250,
-            "master_crafted": 300,
-            "artifact": 350
+            "standard": 500,
+            "master_crafted": 600,
+            "artifact": 750
         },
         "description": "Lascannons are powerful anti-armour weapons that fire highly focused and devastating energy beams capable of penetrating even the toughest armour. This version is mounted onto the sides of vehicles.",
         "abbreviation": "Lscnns", 
         "melee_hands": 0,
         "ranged_hands": 0,
-        "ammo": 5,
+        "ammo": 8,
         "range": 20,
-        "spli": 2,
+        "spli": 1,
         "arp": 1,
         "tags":["las", "vehicle","sponson"]
     },    
     "Hurricane Bolter Sponsons": {
         "attack": {
-            "standard": 405,
-            "master_crafted": 445.5,
-            "artifact": 486
+            "standard": 50,
+            "master_crafted": 55,
+            "artifact": 60
         },
         "description": "Hurricane Bolters are large hex-mount bolter arrays that are able to deliver a withering hail of anti-infantry fire at short ranges. This version is mounted onto the sides of vehicles.",
         "abbreviation": "HrcBltrs", 
         "melee_hands": 0,
         "ranged_hands": 0,
-        "ammo": 20,
-        "range": 12,
-        "spli": 3,
+        "ammo": 10,
+        "range": 10,
+        "spli": 60,
         "arp": 0,
         "tags":["bolt", "vehicle","sponson"]
     },
@@ -1189,24 +1189,24 @@ global.weapons={
         "melee_hands": 0,
         "ranged_hands": 0,
         "ammo": 6,
-        "range": 3,
+        "range": 2,
         "spli": 3,
         "arp": 1,
         "tags":["flame", "vehicle","sponson"]
     },
     "Twin Linked Heavy Flamer Sponsons": {
         "attack": {
-            "standard": 550,
-            "master_crafted": 605,
-            "artifact": 660
+            "standard": 500,
+            "master_crafted": 550,
+            "artifact": 600
         },
         "description": "A twin-linked significantly heavier flamer attached to the sponsons on a vehicle.",
         "abbreviation": "TwnHvyFlmrs", 
         "melee_hands": 0,
         "ranged_hands": 0,
-        "ammo": 12,
+        "ammo": 8,
         "range": 2.1,
-        "spli": 3,
+        "spli": 8,
         "arp": -1,
         "tags":["flame", "vehicle","sponson"]
     },
@@ -1227,21 +1227,70 @@ global.weapons={
     "Twin Linked Multi-Melta Sponsons": {
         "abbreviation": "TwnMltMelts", 
         "attack": {
-            "standard": 450,
-            "master_crafted": 495,
-            "artifact": 540
+            "standard": 800,
+            "master_crafted": 850,
+            "artifact": 900
         },
         "description": "Though bearing longer range than the Meltagun, this weapon's great size usually restricts it to vehicles. In this case it is mounted to the sponsons on a vehicle.",
         "melee_hands": 0,
         "ranged_hands": 0,
-        "ammo": 6,
+        "ammo": 8,
         "range": 4.1,
-        "spli": 3,
+        "spli": 2,
         "arp": 1,
         "tags":["vehicle", "Sponson", "melta"]
     },
     "Twin Linked Volkite Culverin Sponsons": {
         "abbreviation": "TwnVlkCulvs", 
+        "attack": {
+            "standard": 480,
+            "master_crafted": 510,
+            "artifact": 540
+        },
+        "description": "An advanced thermal weapon from a bygone era, Volkite Culverins are able to ignite entire formations of enemy forces. In this case it is mounted to the sponsons on a vehicle.",
+        "melee_hands": 0,
+        "ranged_hands": 0,
+        "ammo": 25,
+        "range": 18,
+        "spli": 9,
+        "arp": 0,
+        "tags":["vehicle", "Sponson", "volkite"]
+    },
+    "Heavy Bolter Sponsons": {
+        "abbreviation": "HvyBltrs", 
+        "attack": {
+            "standard": 240,
+            "master_crafted": 264,
+            "artifact": 288
+        },
+        "description": "Heavy Bolters are mounted in sponsons. They are known for high rates of fire and effectiveness against infantry and light vehicles.",
+        "melee_hands": 0,
+        "ranged_hands": 0,
+        "ammo": 20,
+        "range": 16,
+        "spli": 4,
+        "arp": 1,
+        "tags":["heavy_ranged","vehicle","sponson"]
+    },  
+    "Heavy Flamer Sponsons": {
+        "abbreviation": "HvyFlmrs", 
+        "attack": {
+            "standard": 500,
+            "master_crafted": 550,
+            "artifact": 600
+        },
+        "description": "A significantly heavier flamer attached to the sponsons on a vehicle.",
+        "abbreviation": "SpnHvyFlmrs", 
+        "melee_hands": 0,
+        "ranged_hands": 0,
+        "ammo": 8,
+        "range": 2.1,
+        "spli": 4,
+        "arp": -1,
+        "tags":["flame", "vehicle","sponson"]
+    },  
+    "Volkite Culverin Sponsons": {
+        "abbreviation": "VlkClvs", 
         "attack": {
             "standard": 480,
             "master_crafted": 528,
@@ -1252,35 +1301,23 @@ global.weapons={
         "ranged_hands": 0,
         "ammo": 25,
         "range": 18,
-        "spli": 3,
-        "arp": 0,
+        "spli": 5,
+        "arp": 1,
         "tags":["vehicle", "Sponson", "volkite"]
-    },
-    "Heavy Bolter Sponsons": {
-        "abbreviation": "HvyBltrs", 
-        "description": "",
-    },  
-    "Heavy Flamer Sponsons": {
-        "abbreviation": "HvyFlmrs", 
-        "description": "",
-    },  
-    "Volkite Culverin Sponsons": {
-        "abbreviation": "VlkClvs", 
-        "description": "",
     },  
     "Autocannon Turret": {
         "abbreviation": "Autocnn", 
         "attack": {
-            "standard": 130,
+            "standard": 380,
             "master_crafted": 528,
             "artifact": 576
         },
         "description": "A Predator-compatible turret mounting a reliable all-purpose autocannon capable of doing effective damage to infantry and lightly armored targets.",
         "melee_hands": 0,
         "ranged_hands": 0,
-        "ammo": 50,
+        "ammo": 25,
         "range": 18,
-        "spli": 3,
+        "spli": 15,
         "arp": 0,
         "tags":["vehicle", "turrent"]
     },     
@@ -1437,47 +1474,129 @@ global.weapons={
 	},
      "Twin Linked Lascannon Turret": {
         "attack": {
-            "standard": 250,
-            "master_crafted": 300,
-            "artifact": 350
+            "standard": 600,
+            "master_crafted": 700,
+            "artifact": 900
         },
         "abbreviation": "TwnLscnn", 
         "description": "A Predator-compatible turret mounting a twin-linked lascannon.",
-        "range": 1,
-        "spli": 0,
         "arp": 1,
-        "range":20,
-        "ammo":10,
+        "range":24,
+        "ammo":5,
         "spli": 2,
         "tags":["las", "twin_linked", "vehicle","turret"]
     },
     "Twin Linked Assault Cannon Turret": {
         "abbreviation": "TwnAssCnn", 
-        "description": "",
+        "attack": {
+            "standard": 240,
+            "master_crafted": 264,
+            "artifact": 288
+        },
+        "description": "A heavy rotary autocannon with a devastating fire rate that can be counted in the hundreds per minute, in a twin mount. It is incredibly effective against infantry and lightly armored targets.",
+        "melee_hands": 2.1,
+        "ranged_hands": 2.25,
+        "ammo": 5,
+        "range": 12,
+        "spli": 30,
+        "arp": 1,
+        "tags":["heavy_ranged","twin_linked", "vehicle","turret"]
     },  
     "Flamestorm Cannon Turret": {
         "abbreviation": "FlmstCnn", 
-        "description": "",
+        "attack": {
+            "standard": 600,
+            "master_crafted": 660,
+            "artifact": 720
+        },
+        "description": "A huge vehicle-mounted flamethrower cannon, the heat produced by this terrifying weapon can melt armoured ceramite.",
+        "melee_hands": 0,
+        "ranged_hands": 0,
+        "ammo": 12,
+        "range": 2,
+        "spli": 3,
+        "arp": 1,
+        "tags":["flame", "vehicle","turret"]
     },  
     "Magna-Melta Turret": {
         "abbreviation": "MgnMlt", 
-        "description": "",
+        "attack": {
+            "standard": 800,
+            "master_crafted": 900,
+            "artifact": 1000
+        },
+        "description": "Though bearing longer range than the Meltagun, this weapon's great size usually restricts it to vehicles. In this case it is mounted to the turret on a vehicle.",
+        "melee_hands": 0,
+        "ranged_hands": 0,
+        "ammo": 6,
+        "range": 5.1,
+        "spli": 2,
+        "arp": 1,
+        "tags":["vehicle", "turret", "melta"]
     },  
     "Plasma Destroyer Turret": {
         "abbreviation": "PlsmDestr", 
-        "description": "",
+        "attack": {
+            "standard": 500,
+            "master_crafted": 600,
+            "artifact": 750
+        },
+        "description": "A heavy variant of the plasma gun, its power output is significantly higher and its damage capability shows. However, it is mounted in a tank turret.",
+        "melee_hands": 1,
+        "ranged_hands": 3,
+        "ammo": 16,
+        "range": 14,
+        "spli": 3,
+        "arp": 1,
+        "tags":["plasma", "vehicle", "turret"]
     },  
-    "Heavy Conversion Beamer Turret": {
+    "Heavy Conversion Beam Projector": {
         "abbreviation": "HvyCnvBmr", 
-        "description": "",
+        "attack": {
+            "standard": 800,
+            "master_crafted": 900,
+            "artifact": 1000
+        },
+        "description": "The Conversion Beam Projector is a heavy energy weapon that harnesses advanced technology to project a concentrated beam of destructive energy. Armor detonates as the matter that comproises it is transformed into pure energy. This is the heavy version for mounting in vehicles.",
+        "melee_hands": 0,
+        "ranged_hands": 0,
+        "ammo": 6,
+        "range": 20,
+        "spli": 1,
+        "arp": 1,
+        "tags":["vehicle", "dreadnought", "turret"]
     },  
     "Neutron Blaster Turret": {
         "abbreviation": "NtrnBlstr", 
-        "description": "",
+        "attack": {
+            "standard": 800,
+            "master_crafted": 900,
+            "artifact": 1000
+        },
+        "description": "This is a Neutron blaster, typically found in Sabre Strike Tanks, this one has been mounted for use in a space marine tank.",
+        "melee_hands": 0,
+        "ranged_hands": 1,
+        "ammo": 6,
+        "range": 20,
+        "spli": 2,
+        "arp": 1,
+	"tags":[ "vehicle", "turret"]
     },  
     "Volkite Saker Turret": {
         "abbreviation": "VlkSkr", 
-        "description": "",
+        "attack": {
+            "standard": 300,
+            "master_crafted": 333,
+            "artifact": 375
+        },
+        "description": "An advanced thermal weapon from a bygone era, Volkite sakers are optimized for spreading damage across swaths of enemy troops.",
+        "melee_hands": 0,
+        "ranged_hands": 0,
+        "ammo": 25,
+        "range": 18,
+        "spli": 30,
+        "arp": 0,
+        "tags":["vehicle", "turret", "volkite"]
     },
 				
 }
@@ -1830,6 +1949,36 @@ global.gear = {
         }, 
         "tags":["vehicle","armour"],              
     },
+    "Void Shield":{
+        "abbreviation": "V Shld",
+        "description": "An advanced shield capable of providing extreme protection to heavy vehicles.",
+         "armour_value": {
+            "standard": 40,
+            "master_crafted": 52, 
+            "artifact": 64 
+        },
+		"damage_resistance_mod": {
+        "standard": 30,
+        "master_crafted": 35,
+        "artifact": 40
+      },
+        "tags":["vehicle","armour"],              
+    },
+    "Lucifer Pattern Engine":{
+        "abbreviation": "Luc Eng",
+        "description": "An advanced engine that increases tactical flexibility by enabling more options for movement and faster repositioning.",
+		"damage_resistance_mod": {
+        "standard": 10,
+        "master_crafted": 15,
+        "artifact": 20
+      },
+      "ranged_mod": {
+        "standard": 10,
+        "master_crafted": 15,
+        "artifact": 20
+      },
+        "tags":["vehicle","armour"],              
+    },
     "Artificer Hull":{
         "abbreviation": "ArtHll",
         "description": "Replacing numerous structural components and armour plates with thrice-blessed replacements, the vehicle’s hull is upgraded to be a rare work of mechanical art by master artificers.",
@@ -1838,6 +1987,11 @@ global.gear = {
             "master_crafted": 12, 
             "artifact": 14 
         }, 
+      "damage_resistance_mod": {
+        "standard": 15,
+        "master_crafted": 20,
+        "artifact": 25
+      },
         "tags":["vehicle","Upgrade"],              
     }                
 } , 
@@ -1922,21 +2076,45 @@ global.gear = {
     "Smoke Launchers": {
       "description": "Useful for providing concealment in open terrain, these launchers project wide-spectrum concealing smoke to prevent accurate targeting of the vehicle.",
       "abbreviation": "SmkLnchrs",
+      "damage_resistance_mod": {
+        "standard": 5,
+        "master_crafted": 10,
+        "artifact": 15
+      },
       "tags":["smoke","conceal", "vehicle"]
     },
     "Dozer Blades": {
       "description": "An attachment for the front of vehicles, useful for clearing difficult terrain and can be used as an improvised weapon. ",
       "abbreviation": "DzrBlds",
+        "attack": {
+            "standard": 30,
+            "master_crafted": 35,
+            "artifact": 50
+        },
+        "ammo": 0,
+        "range": 1,
+        "spli": 1,
+        "arp": 0,
        "tags":["vehicle"],              
     },
     "Searchlight": {
       "description": "A simple solution for fighting in dark environments, searchlights serve to illuminate enemies for ease of targeting.",
       "abbreviation": "SrchLght",
+      "ranged_mod": {
+        "standard": 5,
+        "master_crafted": 10,
+        "artifact": 15
+      },
        "tags":["vehicle"],              
     },
     "Frag Assault Launchers": {
         "abbreviation": "FrgAssLnchrs", 
-        "description": "",
+        "description": "These launchers enable a vehicle to clear an area for its loaded troops, or prevent boarding by an enemy at close range.",
+      "damage_resistance_mod": {
+        "standard": 10,
+        "master_crafted": 15,
+        "artifact": 20
+      },
          "tags":["vehicle"],              
     },             
   },

--- a/scripts/scr_weapons_equip/scr_weapons_equip.gml
+++ b/scripts/scr_weapons_equip/scr_weapons_equip.gml
@@ -149,9 +149,9 @@ function scr_weapons_equip() {
 				}
 			} else {
 				i+=1;
-				item_name[i]="Inferno Cannon";
-				i+=1;
 				item_name[i]="Multi-Melta";
+				i+=1;
+				item_name[i]="Twin Linked Heavy Flamer Sponsons";
 				i+=1;
 				item_name[i]="Plasma Cannon";
 				i+=1;
@@ -162,6 +162,8 @@ function scr_weapons_equip() {
 				item_name[i]="Missile Launcher";
 				i+=1;
 				item_name[i]="Twin Linked Lascannon";
+				i+=1;
+				item_name[i]="Twin Linked Assault Cannon Mount";
 				i+=1;
 				item_name[i]="Twin Linked Heavy Bolter";																								
 			}
@@ -191,6 +193,8 @@ function scr_weapons_equip() {
 			i+=1;
 			item_name[i]="Close Combat Weapon";
 			i+=1;
+			item_name[i]="Dreadnought Power Claw";
+			i+=1;
 			item_name[i]="Dreadnought Lightning Claw";
 		}
 	}
@@ -207,7 +211,7 @@ function scr_weapons_equip() {
 			i=0; // Land Raider Relic Front Weapon
 			i+=1;item_name[i]="(None)";
 			//i+=1;item_name[i]="Thunderfire Cannon Mount";
-			i+=1;item_name[i]="Twin Linked Lascannon Mount";
+			i+=1;item_name[i]="Neutron Blaster Turret";
 			i+=1;item_name[i]="Reaper Autocannon Mount";
 			//i+=1;item_name[i]="Twin Linked Helfrost Cannon Mount";
 			//i+=1;item_name[i]="Graviton Cannon Mount";
@@ -305,13 +309,15 @@ function scr_weapons_equip() {
 	    i+=1;item_name[i]="Armoured Ceramite";
 	    i+=1;item_name[i]="Artificer Hull";
 	    i+=1;item_name[i]="Heavy Armour";
-			if dude!=50{i+=1;item_name[i]="Lucifer Pattern Engine";} //not available for Land Raiders
+			if dude=50{i+=1;item_name[i]="Void Shield";} //only for Land Raiders
 	}
-	if (tc=5) and (tb=1) and ((dude=50) or (dude=51) or (dude=52) or (dude=54)){var i;i=0; // Tank Accessory
+	if (tc=5) and (tb=1) and ((dude=50) or (dude=51) or (dude=52) or (dude=54) or (dude=6)){var i;i=0; // Tank Accessory
 			i+=1;item_name[i]="(None)";
-	    i+=1;item_name[i]="Dozer Blades";
+	    if dude!=6 {i+=1;item_name[i]="Dozer Blades"};
 	    i+=1;item_name[i]="Searchlight";
 	    i+=1;item_name[i]="Smoke Launchers";
+		i+=1;item_name[i]="Frag Assault Launchers";
+		if dude!=50 and dude!=6{i+=1;item_name[i]="Lucifer Pattern Engine"}; //not available for Land Raiders
 	}
 
 	if (tc=3) and (dude=1){ // dude=1 for normal infantry gear

--- a/scripts/scr_wep_abbreviate/scr_wep_abbreviate.gml
+++ b/scripts/scr_wep_abbreviate/scr_wep_abbreviate.gml
@@ -90,6 +90,7 @@ function scr_wep_abbreviate(argument0) {
 	if (we="Armoured Ceramite") then we2="Cera";
 	if (we="Artificer Hull") then we2="Art Hull";
 	if (we="Heavy Armour") then we2="Hvy Arm";
+	if (we="Void Shield") then we2="V Shld";
 	if (we="Lucifer Pattern Engine") then we2="Luc Eng";
 
 	if (we="Dozer Blades") then we2="Doz Blad";


### PR DESCRIPTION
enables a bunch of equipment, gives em stats, allows stuff in stores, and balances equipment in a temporary fashion and partially enabled dozer blade for vehicle melee although most of the changes except whats expected to be useful for future vehicle rework have been revoked due to potential issues and the fact the code will be rendered obsolete.

todo for either when vehicle rework comes out:
fully implement dozer blade
adjust stats of weapons
enable last few weapons that havent been implemented and likely rename or duplicate some equipment (ie dreadnought uses what is called twin linked flamer sponsons since the stats would be the same for both.)
enable mobility equipment on dreads, and see about using the 4th slot for either secondary weapons for claws (as per lore).
change the vehicle new equipment stc bonus to something else

todo for any time but i am not planning it for this update or in the immediate future:
implement forge integration for vehicle equipment/forge research projects to match it.


this pr has been play tested to a moderate level by rolling for a start on nid infested worlds and testing vehicle equipment against them. A handful of weapons are not shop purchasable as they are likely meant for special drops. If its in the scr_weapons_equip on dreadnought, or vehicle slots then its an item you can use for a reward item.